### PR TITLE
Add empty response in handle_sse as suggested in official mcp SDK

### DIFF
--- a/src/mcp_server_opensearch/sse_server.py
+++ b/src/mcp_server_opensearch/sse_server.py
@@ -54,6 +54,9 @@ class MCPStarletteApp:
                 self.mcp_server.create_initialization_options(),
             )
 
+        # Done to prevent 'NoneType' errors. For more details: https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/sse.py#L33-L37
+        return Response()
+
     async def handle_health(self, request: Request) -> Response:
         return Response("OK", status_code=200)
 


### PR DESCRIPTION
In the official MCP sse source code, it is mentioned that an empty response should be returned in `handle_sse` to prevent `NoneType` errors: https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/sse.py#L33-L37