### PR TITLE
Use refreshable credentials for OpenSearch client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix OpenSearch client to use refreshable credentials ([13](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/13))
 
 ### Security

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -58,14 +58,14 @@ def initialize_client() -> OpenSearch:
 
     # 2. Try to get credentials (boto3 session)
     try:
-        credentials = boto3.Session().get_credentials()
+        credentials=boto3.Session().get_credentials()
         if credentials:
-            aws_auth = AWS4Auth(
-                refreshable_credentials = credentials,
-                service = OPENSEARCH_SERVICE,
-                region = aws_region,
+            aws_auth=AWS4Auth(
+                refreshable_credentials=credentials,
+                service=OPENSEARCH_SERVICE,
+                region=aws_region,
             )
-            client_kwargs['http_auth'] = aws_auth
+            client_kwargs['http_auth']=aws_auth
             return OpenSearch(**client_kwargs)
     except (boto3.exceptions.Boto3Error, Exception) as e:
         logger.error(f"Failed to get AWS credentials: {str(e)}")

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -61,11 +61,9 @@ def initialize_client() -> OpenSearch:
         credentials = boto3.Session().get_credentials()
         if credentials:
             aws_auth = AWS4Auth(
-                credentials.access_key,
-                credentials.secret_key,
-                aws_region,
-                OPENSEARCH_SERVICE,
-                session_token=credentials.token
+                refreshable_credentials = credentials,
+                service = OPENSEARCH_SERVICE,
+                region = aws_region,
             )
             client_kwargs['http_auth'] = aws_auth
             return OpenSearch(**client_kwargs)

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -58,14 +58,14 @@ def initialize_client() -> OpenSearch:
 
     # 2. Try to get credentials (boto3 session)
     try:
-        credentials=boto3.Session().get_credentials()
+        credentials = boto3.Session().get_credentials()
         if credentials:
-            aws_auth=AWS4Auth(
+            aws_auth = AWS4Auth(
                 refreshable_credentials=credentials,
                 service=OPENSEARCH_SERVICE,
                 region=aws_region,
             )
-            client_kwargs['http_auth']=aws_auth
+            client_kwargs['http_auth'] = aws_auth
             return OpenSearch(**client_kwargs)
     except (boto3.exceptions.Boto3Error, Exception) as e:
         logger.error(f"Failed to get AWS credentials: {str(e)}")


### PR DESCRIPTION
### Description
Using refreshable credentials to create the client. This ensures that temporary credentials (from EC2 instance profiles or other IAM roles) automatically refresh without requiring the application to reinitialize the client.

### Issues Resolved
https://github.com/opensearch-project/opensearch-mcp-server-py/issues/3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).