### PR TITLE
Added URL as an optional parameter for all the tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
-
+- Add OpenSearch URl as an optional parameter for tool calls ([20](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/20))
 ### Removed
 
 ### Fixed

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -66,7 +66,7 @@ uv sync
                 "mcp_server_opensearch"
             ],
             "env": {
-                // Required
+                // Optional
                 "OPENSEARCH_URL": "<your_opensearch_domain_url>",
 
                 // For Basic Authentication

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -24,7 +24,7 @@ For Claude Desktop, configure `claude_desktop_config.json` from Settings > Devel
         "opensearch-mcp-server-py"
       ],
       "env": {
-        // Required
+        // Optional
         "OPENSEARCH_URL": "<your_opensearch_domain_url>",
 
         // For Basic Authentication
@@ -43,6 +43,7 @@ For Claude Desktop, configure `claude_desktop_config.json` from Settings > Devel
 ```
 
 That's it! You are now ready to use your AI agent with OpenSearch tools.
+Please note that if the `OPENSEARCH_URL` is not set via the environment variables, it must be provided as an argument during tool invocation.
 
 ## Installation
 
@@ -64,7 +65,7 @@ pip install opensearch-mcp-server-py
                 "mcp_server_opensearch"
             ],
             "env": {
-                // Required
+                // Optional
                 "OPENSEARCH_URL": "<your_opensearch_domain_url>",
 
                 // For Basic Authentication

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -17,28 +17,30 @@ logger = logging.getLogger(__name__)
 OPENSEARCH_SERVICE = "es"
 
 # This file should expose the OpenSearch py client
-def initialize_client() -> OpenSearch:
+def initialize_client(opensearch_url: str) -> OpenSearch:
     """
     Initialize and return an OpenSearch client with appropriate authentication.
     
     The function attempts to authenticate in the following order:
     1. Basic authentication using OPENSEARCH_USERNAME and OPENSEARCH_PASSWORD
     2. AWS IAM authentication using boto3 credentials
+
+    Args:
+        opensearch_url (str): The URL of the OpenSearch cluster. Must be a non-empty string.
     
     Returns:
-        OpenSearch: Configured OpenSearch client
-        
+        OpenSearch: An initialized OpenSearch client instance.
+    
     Raises:
-        ValueError: If OPENSEARCH_URL is not set
+        ValueError: If opensearch_url is empty or invalid
         RuntimeError: If no valid authentication method is available
     """
-    opensearch_url = os.getenv("OPENSEARCH_URL", "")
+    if not opensearch_url:
+        raise ValueError("OpenSearch URL cannot be empty")
+
     opensearch_username = os.getenv("OPENSEARCH_USERNAME", "")
     opensearch_password = os.getenv("OPENSEARCH_PASSWORD", "")
     aws_region = os.getenv("AWS_REGION", "")
-
-    if not opensearch_url:
-        raise ValueError("OPENSEARCH_URL environment variable is not set")
 
     # Parse the OpenSearch domain URL
     parsed_url = urlparse(opensearch_url)
@@ -71,6 +73,3 @@ def initialize_client() -> OpenSearch:
         logger.error(f"Failed to get AWS credentials: {str(e)}")
 
     raise RuntimeError("No valid AWS or basic authentication provided for OpenSearch")
-
-
-client = initialize_client()

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -1,24 +1,28 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from .client import client
+from .client import initialize_client
 import json
 from typing import Any
 
 # List all the helper functions, these functions perform a single rest call to opensearch
 # these functions will be used in tools folder to eventually write more complex tools
-def list_indices() -> json:
+def list_indices(opensearch_url: str) -> json:
+    client = initialize_client(opensearch_url)
     response = client.cat.indices(format="json")
     return response
 
-def get_index_mapping(index: str) -> json:
+def get_index_mapping(opensearch_url: str, index: str) -> json:
+    client = initialize_client(opensearch_url)
     response = client.indices.get_mapping(index=index)
     return response
 
-def search_index(index: str, query: Any) -> json:
+def search_index(opensearch_url: str, index: str, query: Any) -> json:
+    client = initialize_client(opensearch_url)
     response = client.search(index=index, body=query)
     return response
 
-def get_shards(index: str) -> json:
+def get_shards(opensearch_url: str, index: str) -> json:
+    client = initialize_client(opensearch_url)
     response = client.cat.shards(index=index, format="json")
     return response

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -5,23 +5,27 @@ from pydantic import BaseModel
 from opensearch.helper import list_indices, get_index_mapping, search_index, get_shards
 from typing import Any
 import json
+import os
 
 class ListIndicesArgs(BaseModel):
-    pass  # no args needed
+    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
 
 class GetIndexMappingArgs(BaseModel):
     index: str
+    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
 
 class SearchIndexArgs(BaseModel):
     index: str
     query: Any
+    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
 
 class GetShardsArgs(BaseModel):
     index: str
+    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
 
 async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
     try:
-        indices = list_indices()
+        indices = list_indices(args.opensearch_url)
         indices_text = "\n".join(index['index'] for index in indices)
         
         # Return in MCP expected format
@@ -37,7 +41,7 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
 
 async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
     try:
-        mapping = get_index_mapping(args.index)
+        mapping = get_index_mapping(args.opensearch_url, args.index)
         formatted_mapping = json.dumps(mapping, indent=2)
         
         return [{
@@ -52,7 +56,7 @@ async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
 
 async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
     try:
-        result = search_index(args.index, args.query)
+        result = search_index(args.opensearch_url, args.index, args.query)
         formatted_result = json.dumps(result, indent=2)
         
         return [{
@@ -67,7 +71,7 @@ async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
 
 async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
     try:
-        result = get_shards(args.index)
+        result = get_shards(args.opensearch_url, args.index)
         
         if isinstance(result, dict) and "error" in result:
             return [{


### PR DESCRIPTION
### Description
- OpenSearch URL can not be accepted as an parameter for every tool. 
- If the URL is not provided by the MCP client, we fall back to the URL set via environment variable. 
- If the URL is not set via env variable and not passed in the tool call, we throw an error.

### Issues Resolved
Closes #15 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).