### PR TITLE
fix aws auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
-- Add OpenSearch URl as an optional parameter for tool calls ([20](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/20))
-- Add CI to run unit tests ([22](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/22))
+- Add OpenSearch URl as an optional parameter for tool calls ([#20](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/20))
+- Add CI to run unit tests ([#22](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/22))
 ### Removed
 
 ### Fixed
-- Fix OpenSearch client to use refreshable credentials ([13](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/13))
+- Fix AWS auth requiring `AWS_REGION` environment variable to be set, will now support using region set via `~/.aws/config` ([#28](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/28))
+- Fix OpenSearch client to use refreshable credentials ([#13](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/13))
 
 ### Security

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -40,7 +40,6 @@ def initialize_client(opensearch_url: str) -> OpenSearch:
 
     opensearch_username = os.getenv("OPENSEARCH_USERNAME", "")
     opensearch_password = os.getenv("OPENSEARCH_PASSWORD", "")
-    aws_region = os.getenv("AWS_REGION", "")
 
     # Parse the OpenSearch domain URL
     parsed_url = urlparse(opensearch_url)
@@ -60,7 +59,11 @@ def initialize_client(opensearch_url: str) -> OpenSearch:
 
     # 2. Try to get credentials (boto3 session)
     try:
-        credentials = boto3.Session().get_credentials()
+        session = boto3.Session()
+        credentials = session.get_credentials()
+        aws_region = session.region_name or os.getenv("AWS_REGION")
+        if not aws_region:
+            raise RuntimeError("AWS region not found, please specify region using `aws configure`")
         if credentials:
             aws_auth = AWS4Auth(
                 refreshable_credentials=credentials,


### PR DESCRIPTION
### Description
AWS auth from credentials provider chain does not work at the moment unless `AWS_REGION` variable exists, this fixes the issue

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-mcp-server-py/issues/27

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).