### PR TITLE
Feat: Add logic using AWS Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add OpenSearch URl as an optional parameter for tool calls ([#20](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/20))
 - Add CI to run unit tests ([#22](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/22))
+- Add support for AWS Profile ([#30](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/30))
 ### Removed
 
 ### Fixed

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -59,7 +59,8 @@ def initialize_client(opensearch_url: str) -> OpenSearch:
 
     # 2. Try to get credentials (boto3 session)
     try:
-        session = boto3.Session()
+        aws_profile = os.getenv("AWS_PROFILE")
+        session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
         credentials = session.get_credentials()
         aws_region = session.region_name or os.getenv("AWS_REGION")
         if not aws_region:


### PR DESCRIPTION
### Description
Added fature to use AWS Profile as a variable.

### Issues Resolved
https://github.com/opensearch-project/opensearch-mcp-server-py/issues/29

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).