### PR TITLE
Add support for Multiple OpenSearch cluster Connectivity

### DIFF
--- a/src/mcp_server_opensearch/__init__.py
+++ b/src/mcp_server_opensearch/__init__.py
@@ -5,9 +5,14 @@ from .stdio_server import serve as serve_stdio
 from .sse_server import serve as serve_sse
 
 def main() -> None:
+    """
+    Main entry point for the OpenSearch MCP Server.
+    Handles command line arguments and starts the appropriate server based on transport type.
+    """
     import argparse
     import asyncio
 
+    # Set up command line argument parser
     parser = argparse.ArgumentParser(description='OpenSearch MCP Server')
     parser.add_argument(
         '--transport', 
@@ -26,16 +31,24 @@ def main() -> None:
         default=9900, 
         help='Port to listen on (SSE only)'
     )
+    parser.add_argument(
+        '--mode',
+        choices=['single', 'multi'],
+        default='single',
+        help='Server mode: single (default) uses environment variables for OpenSearch connection, multi requires explicit connection parameters'
+    )
 
     args = parser.parse_args()
 
+    # Start the appropriate server based on transport type
     if args.transport == 'stdio':
-        asyncio.run(serve_stdio())
+        asyncio.run(serve_stdio(mode=args.mode))
     else:
         asyncio.run(
             serve_sse(
                 host=args.host,
-                port=args.port
+                port=args.port,
+                mode=args.mode
             )
         )
 

--- a/src/mcp_server_opensearch/sse_server.py
+++ b/src/mcp_server_opensearch/sse_server.py
@@ -11,19 +11,14 @@ from starlette.responses import Response
 from mcp.server.sse import SseServerTransport
 from mcp.server import Server
 from mcp.types import TextContent, Tool
-from tools.common import get_enabled_tools
-from opensearch.helper import get_opensearch_version
+from tools.common import get_tools
 
-import os
 import logging
 
 
-def create_mcp_server() -> Server:
+def create_mcp_server(mode: str = "single") -> Server:
     server = Server("opensearch-mcp-server")
-    opensearch_url = os.getenv("OPENSEARCH_URL", "https://localhost:9200")
-    version = get_opensearch_version(opensearch_url)
-    enabled_tools = get_enabled_tools(version)
-    logging.info(f"Connected OpenSearch version: {version}")
+    enabled_tools = get_tools(mode)
     logging.info(f"Enabled tools: {list(enabled_tools.keys())}")
 
     @server.list_tools()
@@ -83,8 +78,8 @@ class MCPStarletteApp:
         )
 
 
-async def serve(host: str = "0.0.0.0", port: int = 9900) -> None:
-    mcp_server = create_mcp_server()
+async def serve(host: str = "0.0.0.0", port: int = 9900, mode: str = "single") -> None:
+    mcp_server = create_mcp_server(mode)
     app_handler = MCPStarletteApp(mcp_server)
     app = app_handler.create_app()
 

--- a/src/mcp_server_opensearch/stdio_server.py
+++ b/src/mcp_server_opensearch/stdio_server.py
@@ -4,19 +4,14 @@
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
-from tools.common import get_enabled_tools
-from opensearch.helper import get_opensearch_version
-import os
+from tools.common import get_tools
 import logging
 
 
 # --- Server setup ---
-async def serve() -> None:
+async def serve(mode: str = "single") -> None:
     server = Server("opensearch-mcp-server")
-    opensearch_url = os.getenv("OPENSEARCH_URL", "https://localhost:9200")
-    version = get_opensearch_version(opensearch_url)
-    enabled_tools = get_enabled_tools(version)
-    logging.info(f"Connected OpenSearch version: {version}")
+    enabled_tools = get_tools(mode)
     logging.info(f"Enabled tools: {list(enabled_tools.keys())}")
 
     @server.list_tools()

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -3,46 +3,44 @@
 
 from .client import initialize_client
 import json
-from typing import Any
 from semver import Version
+from .tool_params import *
 
 
 # List all the helper functions, these functions perform a single rest call to opensearch
 # these functions will be used in tools folder to eventually write more complex tools
-def list_indices(opensearch_url: str) -> json:
-    client = initialize_client(opensearch_url)
+def list_indices(args: ListIndicesArgs) -> json:
+    client = initialize_client(args)
     response = client.cat.indices(format="json")
     return response
 
 
-def get_index_mapping(opensearch_url: str, index: str) -> json:
-    client = initialize_client(opensearch_url)
-    response = client.indices.get_mapping(index=index)
+def get_index_mapping(args: GetIndexMappingArgs) -> json:
+    client = initialize_client(args)
+    response = client.indices.get_mapping(index=args.index)
     return response
 
 
-def search_index(opensearch_url: str, index: str, query: Any) -> json:
-    client = initialize_client(opensearch_url)
-    response = client.search(index=index, body=query)
+def search_index(args: SearchIndexArgs) -> json:
+    client = initialize_client(args)
+    response = client.search(index=args.index, body=args.query)
     return response
 
 
-def get_shards(opensearch_url: str, index: str) -> json:
-    client = initialize_client(opensearch_url)
-    response = client.cat.shards(index=index, format="json")
+def get_shards(args: GetShardsArgs) -> json:
+    client = initialize_client(args)
+    response = client.cat.shards(index=args.index, format="json")
     return response
 
 
-def get_opensearch_version(opensearch_url: str) -> Version:
+def get_opensearch_version() -> Version:
     """
     Get the version of OpenSearch cluster.
-
-    Args:
-        opensearch_url (str): The URL of the OpenSearch cluster
 
     Returns:
         Version: The version of OpenSearch cluster (SemVer style)
     """
-    client = initialize_client(opensearch_url)
+    args = baseToolArgs()
+    client = initialize_client(args)
     response = client.info()
     return Version.parse(response["version"]["number"])

--- a/src/opensearch/tool_params.py
+++ b/src/opensearch/tool_params.py
@@ -1,0 +1,51 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from pydantic import BaseModel, Field
+from typing import Any
+
+class baseToolArgs(BaseModel):
+    """
+    Base class for all tool arguments that contains common OpenSearch connection parameters.
+    """
+    opensearch_url: str = Field(
+        default="",
+        description="The URL of the OpenSearch cluster endpoint (e.g., https://search-domain.region.es.amazonaws.com)"
+    )
+    iam_arn: str = Field(
+        default="",
+        description="The ARN of the IAM role to assume for authentication. If not provided, will try basic auth or default AWS credentials"
+    )
+    aws_region: str = Field(
+        default="",
+        description="The AWS region where the OpenSearch domain is located (e.g., us-west-2)"
+    )
+    opensearch_username: str = Field(
+        default="",
+        description="Username for basic authentication. If not provided, will try IAM authentication"
+    )
+    opensearch_password: str = Field(
+        default="",
+        description="Password for basic authentication. If not provided, will try IAM authentication"
+    )
+
+class ListIndicesArgs(baseToolArgs):
+    pass
+
+class GetIndexMappingArgs(baseToolArgs):
+    index: str = Field(
+        description="The name of the index to get mapping information for"
+    )
+
+class SearchIndexArgs(baseToolArgs):
+    index: str = Field(
+        description="The name of the index to search in"
+    )
+    query: Any = Field(
+        description="The search query in OpenSearch query DSL format"
+    )
+
+class GetShardsArgs(baseToolArgs):
+    index: str = Field(
+        description="The name of the index to get shard information for"
+    ) 

--- a/src/tools/common.py
+++ b/src/tools/common.py
@@ -1,9 +1,9 @@
 from .tools import TOOL_REGISTRY
 from semver import Version
-
+from opensearch.helper import get_opensearch_version
+import logging
 
 def is_tool_compatible(current_version: Version, tool_info: dict = {}):
-    # use opensearch_url if provided, otherwise use the environment variable
     min_tool_version = Version.parse(
         tool_info.get("min_version", "0.0.0"), optional_minor_and_patch=True
     )
@@ -13,9 +13,27 @@ def is_tool_compatible(current_version: Version, tool_info: dict = {}):
     return min_tool_version <= current_version <= max_tool_version
 
 
-def get_enabled_tools(version: str) -> dict:
+def get_tools(mode: str = "single") -> dict:
     enabled = {}
     for name, info in TOOL_REGISTRY.items():
-        if is_tool_compatible(version, info):
-            enabled[name] = info
+        # Create a copy of the tool info
+        tool_info = info.copy()
+        
+        if mode == "single":
+            version = get_opensearch_version()
+            logging.info(f"Connected OpenSearch version: {version}")
+            # In single mode, we do version filtering and remove baseToolArgs
+            if not is_tool_compatible(version, info):
+                continue
+                
+            # Remove baseToolArgs from schema
+            schema = tool_info["input_schema"].copy()
+            if "properties" in schema:
+                # Remove baseToolArgs fields
+                for field in ["opensearch_url", "iam_arn", "aws_region", 
+                            "opensearch_username", "opensearch_password"]:
+                    schema["properties"].pop(field, None)
+            tool_info["input_schema"] = schema
+        
+        enabled[name] = tool_info
     return enabled

--- a/tests/mcp_server_opensearch/test_sse_server.py
+++ b/tests/mcp_server_opensearch/test_sse_server.py
@@ -8,9 +8,14 @@ from mcp.types import Tool, TextContent
 
 @pytest.fixture(autouse=True)
 def patch_opensearch_version():
+    """Mock OpenSearch client and version check"""
+    mock_client = Mock()
+    mock_client.info.return_value = {"version": {"number": "3.0.0"}}
+    
     with (
-        patch("opensearch.helper.get_opensearch_version", return_value="2.9.0"),
-        patch("opensearch.client.initialize_client", return_value=Mock()),
+        patch("opensearch.helper.get_opensearch_version", return_value="3.0.0"),
+        patch("opensearch.client.initialize_client", return_value=mock_client),
+        patch("tools.common.get_opensearch_version", return_value="3.0.0")
     ):
         yield
 
@@ -30,7 +35,7 @@ class TestMCPServer:
             }
         }
 
-    @patch("mcp_server_opensearch.sse_server.get_enabled_tools")
+    @patch("tools.common.get_tools")
     def test_create_mcp_server(self, mock_registry, mock_tool_registry):
         """Test MCP server creation"""
         # Setup mock registry
@@ -44,7 +49,7 @@ class TestMCPServer:
         assert server.name == "opensearch-mcp-server"
 
     @pytest.mark.asyncio
-    @patch("mcp_server_opensearch.sse_server.get_enabled_tools")
+    @patch("tools.common.get_tools")
     async def test_list_tools(self, mock_registry, mock_tool_registry):
         """Test listing available tools"""
         # Setup mock registry
@@ -72,7 +77,7 @@ class TestMCPServer:
         assert tools[0].inputSchema == {"type": "object"}
 
     @pytest.mark.asyncio
-    @patch("mcp_server_opensearch.sse_server.get_enabled_tools")
+    @patch("tools.common.get_tools")
     async def test_call_tool(self, mock_registry, mock_tool_registry):
         """ "Test calling the tool"""
         # Setup mock registry

--- a/tests/mcp_server_opensearch/test_stdio_server.py
+++ b/tests/mcp_server_opensearch/test_stdio_server.py
@@ -29,9 +29,14 @@ MOCK_TOOL_REGISTRY = {
 
 @pytest.fixture(autouse=True)
 def patch_opensearch_version():
+    """Mock OpenSearch client and version check"""
+    mock_client = Mock()
+    mock_client.info.return_value = {"version": {"number": "3.0.0"}}
+    
     with (
-        patch("opensearch.helper.get_opensearch_version", return_value="2.9.0"),
-        patch("opensearch.client.initialize_client", return_value=Mock()),
+        patch("opensearch.helper.get_opensearch_version", return_value="3.0.0"),
+        patch("opensearch.client.initialize_client", return_value=mock_client),
+        patch("tools.common.get_opensearch_version", return_value="3.0.0")
     ):
         yield
 
@@ -85,7 +90,7 @@ def mock_tool_registry():
     }
 
     with patch(
-        "mcp_server_opensearch.stdio_server.get_enabled_tools",
+        "tools.common.get_tools",
         return_value=MOCK_TOOL_REGISTRY,
     ):
         yield MOCK_TOOL_REGISTRY

--- a/tests/opensearch/test_client.py
+++ b/tests/opensearch/test_client.py
@@ -9,13 +9,14 @@ from requests_aws4auth import AWS4Auth
 import boto3
 
 from opensearch.client import initialize_client
+from opensearch.tool_params import baseToolArgs
 
 class TestOpenSearchClient:
     def setup_method(self):
         """Setup that runs before each test method"""
         # Clear any existing environment variables
         self.original_env = {}
-        for key in ['OPENSEARCH_USERNAME', 'OPENSEARCH_PASSWORD', 'AWS_REGION']:
+        for key in ['OPENSEARCH_USERNAME', 'OPENSEARCH_PASSWORD', 'AWS_REGION', 'OPENSEARCH_URL']:
             if key in os.environ:
                 self.original_env[key] = os.environ[key]
                 del os.environ[key]
@@ -29,8 +30,8 @@ class TestOpenSearchClient:
     def test_initialize_client_empty_url(self):
         """Test that initialize_client raises ValueError when opensearch_url is empty"""
         with pytest.raises(ValueError) as exc_info:
-            initialize_client("")
-        assert str(exc_info.value) == "OpenSearch URL cannot be empty"
+            initialize_client(baseToolArgs(opensearch_url=""))
+        assert str(exc_info.value) == "OpenSearch URL must be provided either via command line argument or OPENSEARCH_URL environment variable"
 
     @patch('opensearch.client.OpenSearch')
     def test_initialize_client_basic_auth(self, mock_opensearch):
@@ -44,7 +45,7 @@ class TestOpenSearchClient:
         mock_opensearch.return_value = mock_client
 
         # Execute
-        client = initialize_client('https://test-opensearch-domain.com')
+        client = initialize_client(baseToolArgs(opensearch_url='https://test-opensearch-domain.com'))
 
         # Assert
         assert client == mock_client
@@ -78,7 +79,7 @@ class TestOpenSearchClient:
         mock_opensearch.return_value = mock_client
 
         # Execute
-        client = initialize_client('https://test-opensearch-domain.com')
+        client = initialize_client(baseToolArgs(opensearch_url='https://test-opensearch-domain.com'))
 
         # Assert
         assert client == mock_client
@@ -104,7 +105,7 @@ class TestOpenSearchClient:
 
         # Execute and assert
         with pytest.raises(RuntimeError) as exc_info:
-            initialize_client('https://test-opensearch-domain.com')
+            initialize_client(baseToolArgs(opensearch_url='https://test-opensearch-domain.com'))
         assert str(exc_info.value) == "No valid AWS or basic authentication provided for OpenSearch"
 
     @patch('opensearch.client.OpenSearch')
@@ -118,5 +119,5 @@ class TestOpenSearchClient:
 
         # Execute and assert
         with pytest.raises(RuntimeError) as exc_info:
-            initialize_client('https://test-opensearch-domain.com')
+            initialize_client(baseToolArgs(opensearch_url='https://test-opensearch-domain.com'))
         assert str(exc_info.value) == "No valid AWS or basic authentication provided for OpenSearch"

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -88,7 +88,7 @@ class TestTools():
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'index1\nindex2' in result[0]['text']
-        self.mock_list_indices.assert_called_once_with(self.test_url)
+        self.mock_list_indices.assert_called_once_with(self.ListIndicesArgs(opensearch_url=self.test_url))
 
     @pytest.mark.asyncio
     async def test_list_indices_tool_error(self):
@@ -103,7 +103,7 @@ class TestTools():
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Error listing indices: Test error' in result[0]['text']
-        self.mock_list_indices.assert_called_once_with(self.test_url)
+        self.mock_list_indices.assert_called_once_with(self.ListIndicesArgs(opensearch_url=self.test_url))
 
     @pytest.mark.asyncio
     async def test_get_index_mapping_tool(self):
@@ -119,17 +119,18 @@ class TestTools():
         self.mock_get_mapping.return_value = mock_mapping
 
         # Execute
-        result = await self._get_index_mapping_tool(self.GetIndexMappingArgs(
+        args = self.GetIndexMappingArgs(
             opensearch_url=self.test_url,
             index="test-index"
-        ))
+        )
+        result = await self._get_index_mapping_tool(args)
 
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Mapping for test-index' in result[0]['text']
         assert json.loads(result[0]['text'].split('\n', 1)[1]) == mock_mapping
-        self.mock_get_mapping.assert_called_once_with(self.test_url, "test-index")
+        self.mock_get_mapping.assert_called_once_with(args)
     
     @pytest.mark.asyncio
     async def test_get_index_mapping_tool_error(self):
@@ -138,16 +139,17 @@ class TestTools():
         self.mock_get_mapping.side_effect = Exception("Test error")
 
         # Execute
-        result = await self._get_index_mapping_tool(self.GetIndexMappingArgs(
+        args = self.GetIndexMappingArgs(
             opensearch_url=self.test_url,
             index="test-index"
-        ))
+        )
+        result = await self._get_index_mapping_tool(args)
 
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Error getting mapping: Test error' in result[0]['text']
-        self.mock_get_mapping.assert_called_once_with(self.test_url, "test-index")
+        self.mock_get_mapping.assert_called_once_with(args)
 
     @pytest.mark.asyncio
     async def test_search_index_tool(self):
@@ -162,18 +164,19 @@ class TestTools():
         self.mock_search.return_value = mock_results
 
         # Execute
-        result = await self._search_index_tool(self.SearchIndexArgs(
+        args = self.SearchIndexArgs(
             opensearch_url=self.test_url,
             index="test-index",
             query={"match_all": {}}
-        ))
+        )
+        result = await self._search_index_tool(args)
 
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Search results from test-index' in result[0]['text']
         assert json.loads(result[0]['text'].split('\n', 1)[1]) == mock_results
-        self.mock_search.assert_called_once_with(self.test_url, "test-index", {"match_all": {}})
+        self.mock_search.assert_called_once_with(args)
     
     @pytest.mark.asyncio
     async def test_search_index_tool_error(self):
@@ -182,17 +185,18 @@ class TestTools():
         self.mock_search.side_effect = Exception("Test error")
 
         # Execute
-        result = await self._search_index_tool(self.SearchIndexArgs(
+        args = self.SearchIndexArgs(
             opensearch_url=self.test_url,
             index="test-index",
             query={"match_all": {}}
-        ))
+        )
+        result = await self._search_index_tool(args)
 
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Error searching index: Test error' in result[0]['text']
-        self.mock_search.assert_called_once_with(self.test_url, "test-index", {"match_all": {}})
+        self.mock_search.assert_called_once_with(args)
 
     @pytest.mark.asyncio
     async def test_get_shards_tool(self):
@@ -211,17 +215,18 @@ class TestTools():
         self.mock_shards.return_value = mock_shards
 
         # Execute
-        result = await self._get_shards_tool(self.GetShardsArgs(
+        args = self.GetShardsArgs(
             opensearch_url=self.test_url,
             index="test-index"
-        ))
+        )
+        result = await self._get_shards_tool(args)
 
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'index | shard | prirep | state | docs | store | ip | node' in result[0]['text']
         assert 'test-index | 0 | p | STARTED | 1000 | 1mb | 127.0.0.1 | node1' in result[0]['text']
-        self.mock_shards.assert_called_once_with(self.test_url, "test-index")
+        self.mock_shards.assert_called_once_with(args)
 
     @pytest.mark.asyncio
     async def test_get_shards_tool_error(self):
@@ -230,16 +235,17 @@ class TestTools():
         self.mock_shards.side_effect = Exception("Test error")
 
         # Execute
-        result = await self._get_shards_tool(self.GetShardsArgs(
+        args = self.GetShardsArgs(
             opensearch_url=self.test_url,
             index="test-index"
-        ))
+        )
+        result = await self._get_shards_tool(args)
 
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Error getting shards information: Test error' in result[0]['text']
-        self.mock_shards.assert_called_once_with(self.test_url, "test-index")
+        self.mock_shards.assert_called_once_with(args)
 
     def test_tool_registry(self):
         """Test TOOL_REGISTRY structure"""


### PR DESCRIPTION
### Description
With these changes, the MCP server can not be instantiated in 2 modes with --mode flag.

**Single Mode**: Same behavior as the current MCP server, i.e pick up credentials from environment variables
**Multi Mode**: The MCP Server accepts extra variables for connecting to different clients

Muti mode allows `opensearch_url`, `iam_arn`, `aws_region`, `opensearch_username`, and `opensearch_password` as optional parameters.

### Design:
![Multi-mcp](https://github.com/user-attachments/assets/0ceb3c14-d1e0-46df-b9ec-e29624cb6a2c)


### Setup expected from customers:

**Start  the server in Multi mode:**

* Start the server with --mode as multi

**IAM Roles setup (if needed):**

* Create an IAM role for each cluster.
* For all these IAM roles add Trust relationship to be assumed by a user or role

Example:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Statement1",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::419213735998:root" // I used a root user in this example
            },
            "Action": "sts:AssumeRole"
        }
    ]
}
```
**Env setup:**
* The MCP server tries to assume the IAM role provided by the LLM during tool call.
* We need to add the credentials of the role/user which has permissions to assume all the IAM roles in environment variables (or via aws configure or if running on EC2 instance, instance profile role)
* These credentials will be used by the MCP server to assume IAM roles.
* If only basic auth is used, we do not need to do this setup.

**Provide Context to the LLM:**

The LLM to successfully make calls to different clusters, the users need to provide context about the connection information. This can be done my manually putting the information in the prompt.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).