### PR TITLE
Fix endpoint selection bug in ClusterHealthTool and CountTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix endpoint selection bug in ClusterHealthTool and CountTool ([#59](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/59))
 
 ### Security
 

--- a/tests/tools/test_tool_generator.py
+++ b/tests/tools/test_tool_generator.py
@@ -155,14 +155,19 @@ class TestToolGenerator:
         # Setup test endpoints
         endpoints = [
             {
-                'path': '/_cluster/health/{index}',
+                'path': '/_cluster/health',
                 'method': 'get',
                 'details': {'description': 'Returns cluster health for index'},
             },
             {
-                'path': '/_cluster/health',
+                'path': '/_cluster/health/{index}',
                 'method': 'get',
                 'details': {'description': 'Returns cluster health'},
+            },
+            {
+                'path': '/_cluster/health/{index}/{shard}',
+                'method': 'get',
+                'details': {'description': 'Returns cluster health for specific shard'},
             },
         ]
 
@@ -173,6 +178,22 @@ class TestToolGenerator:
 
         # Test case 2: Without index parameter - should select the simpler endpoint
         params = {}
+        selected = self.select_endpoint(endpoints, params)
+        assert selected['path'] == '/_cluster/health'
+
+        # Test case 3: With both index and shard parameters - should select the most specific endpoint
+        params = {'index': 'test-index', 'shard': '0'}
+        selected = self.select_endpoint(endpoints, params)
+        assert selected['path'] == '/_cluster/health/{index}/{shard}'
+
+        # Test case 4: With index and extra parameters - should still select the index endpoint
+        params = {'index': 'test-index', 'other_param': 'value'}
+        selected = self.select_endpoint(endpoints, params)
+        assert selected['path'] == '/_cluster/health/{index}'
+
+        # Test case 5: With shard but no index - should select the base endpoint
+        # since the shard endpoint requires index parameter
+        params = {'shard': '0'}
         selected = self.select_endpoint(endpoints, params)
         assert selected['path'] == '/_cluster/health'
 

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "opensearch-mcp-server-py"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
### Description
Fix endpoint selection bug in ClusterHealthTool and CountTool. When users provide an `index` parameter, the server incorrectly selects the base endpoint (e.g., `GET _cluster/health/`) instead of the more specific endpoint that uses the index (e.g., `GET _cluster/health/{index}`). This occurs because the `select_endpoint` function prioritizes endpoints with fewer required parameters rather than endpoints that utilize more of the provided parameters.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-mcp-server-py/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).