### PR TITLE
Add no-auth fallback support for OpenSearch clusters without authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Extend list indices tool ([#68](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/68))
+- Add `OPENSEARCH_NO_AUTH` environment variable for connecting to clusters without authentication
 
 ### Removed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -71,6 +71,22 @@ Configure `claude_desktop_config.json` from Settings > Developer. See [here](htt
   }
 }
 ```
+
+**For clusters without authentication:**
+```json
+{
+  "mcpServers": {
+    "opensearch-mcp-server": {
+      "command": "uvx",
+      "args": ["opensearch-mcp-server-py"],
+      "env": {
+        "OPENSEARCH_URL": "<your_opensearch_domain_url>",
+        "OPENSEARCH_NO_AUTH": "true"
+      }
+    }
+  }
+}
+```
 See [Environment Variables](#environment-variables) for supported environment variables. 
 See [Authentication](#authentication) section for detailed authentication setup.
 
@@ -190,6 +206,7 @@ The server supports multiple authentication methods with the following priority 
 1. **IAM Role Authentication**
 2. **Basic Authentication**
 3. **AWS Credentials Authentication**
+4. **No Authentication** (only if `OPENSEARCH_NO_AUTH=true` environment variable is set)
 
 ### Single Mode Authentication
 
@@ -225,6 +242,12 @@ export AWS_REGION="<your_aws_region>"
 export AWS_PROFILE="<your_aws_profile>"
 ```
 
+#### No Authentication (for clusters without authentication)
+```bash
+export OPENSEARCH_URL="<your_opensearch_domain_url>"
+export OPENSEARCH_NO_AUTH="true"
+```
+
 ### Multi Mode Authentication
 
 Multi mode uses a YAML configuration file to define authentication for each cluster:
@@ -258,6 +281,11 @@ clusters:
     aws_region: "us-east-1"
     profile: "your-aws-profile"
     is_serverless: true
+
+  # No Authentication (for clusters without authentication)
+  no-auth-cluster:
+    opensearch_url: "http://localhost:9200"
+    opensearch_no_auth: true
 ```
 
 #### Authentication Methods in Multi Mode:
@@ -272,6 +300,10 @@ clusters:
 3. **AWS Credentials Authentication:**
    - Requires: `opensearch_url`, `profile` (optional)
    - Uses AWS credentials from the specified profile or default credentials
+
+4. **No Authentication:**
+   - Requires: `opensearch_url`, `opensearch_no_auth: true`
+   - For OpenSearch clusters that allow anonymous access without authentication
 
 ### AWS Profile Support
 
@@ -353,6 +385,7 @@ python -m mcp_server_opensearch --mode multi
 | `AWS_SESSION_TOKEN` | No | `''` | AWS session token |
 | `AWS_PROFILE` | No | `''` | AWS profile name |
 | `AWS_OPENSEARCH_SERVERLESS` | No | `''` | Set to `"true"` for OpenSearch Serverless |
+| `OPENSEARCH_NO_AUTH` | No | `''` | Set to `"true"` to connect without authentication |
 
 ### SSL & Security Variables
 
@@ -385,6 +418,7 @@ When using multi-mode, each cluster in your YAML configuration file accepts the 
 | `aws_region` | string | No* | AWS region for the OpenSearch cluster |
 | `profile` | string | No | AWS profile name |
 | `is_serverless` | boolean | No | Set to `true` for OpenSearch Serverless |
+| `opensearch_no_auth` | boolean | No | Set to `true` to connect without authentication |
 
 *Required for respective authentication method (basic auth, IAM role, or AWS credentials)
 
@@ -396,6 +430,7 @@ When using multi-mode, each cluster in your YAML configuration file accepts the 
 | **IAM Role Authentication** | `opensearch_url`, `iam_arn`, `aws_region` | `profile` |
 | **AWS Credentials Authentication** | `opensearch_url` | `aws_region`, `profile` |
 | **OpenSearch Serverless** | `opensearch_url`, `aws_region` | `profile`, `is_serverless: true` |
+| **No Authentication** | `opensearch_url` | `opensearch_no_auth: true` |
 
 ## Tool Filter
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -203,18 +203,17 @@ The LLM should choose the appropriate cluster based on the operation context (e.
 ### Authentication Methods
 
 The server supports multiple authentication methods with the following priority order:
-1. **IAM Role Authentication**
-2. **Basic Authentication**
-3. **AWS Credentials Authentication**
-4. **No Authentication** (only if `OPENSEARCH_NO_AUTH=true` environment variable is set)
+1. **No Authentication** (only if `OPENSEARCH_NO_AUTH=true` environment variable is set)
+2. **IAM Role Authentication**
+3. **Basic Authentication**
+4. **AWS Credentials Authentication**
 
 ### Single Mode Authentication
 
-#### Basic Authentication
+#### No Authentication (for clusters without authentication)
 ```bash
 export OPENSEARCH_URL="<your_opensearch_domain_url>"
-export OPENSEARCH_USERNAME="<your_opensearch_domain_username>"
-export OPENSEARCH_PASSWORD="<your_opensearch_domain_password>"
+export OPENSEARCH_NO_AUTH="true"
 ```
 
 #### IAM Role Authentication
@@ -222,6 +221,13 @@ export OPENSEARCH_PASSWORD="<your_opensearch_domain_password>"
 export OPENSEARCH_URL="<your_opensearch_domain_url>"
 export AWS_IAM_ARN="arn:aws:iam::123456789012:role/YourOpenSearchRole"
 export AWS_REGION="<your_aws_region>"
+```
+
+#### Basic Authentication
+```bash
+export OPENSEARCH_URL="<your_opensearch_domain_url>"
+export OPENSEARCH_USERNAME="<your_opensearch_domain_username>"
+export OPENSEARCH_PASSWORD="<your_opensearch_domain_password>"
 ```
 
 #### AWS Credentials Authentication
@@ -242,12 +248,6 @@ export AWS_REGION="<your_aws_region>"
 export AWS_PROFILE="<your_aws_profile>"
 ```
 
-#### No Authentication (for clusters without authentication)
-```bash
-export OPENSEARCH_URL="<your_opensearch_domain_url>"
-export OPENSEARCH_NO_AUTH="true"
-```
-
 ### Multi Mode Authentication
 
 Multi mode uses a YAML configuration file to define authentication for each cluster:
@@ -257,6 +257,11 @@ version: "1.0"
 description: "OpenSearch cluster configurations"
 
 clusters:
+  # No Authentication (for clusters without authentication)
+  no-auth-cluster:
+    opensearch_url: "http://localhost:9200"
+    opensearch_no_auth: true
+
   # Basic Authentication
   local-cluster:
     opensearch_url: "http://localhost:9200"
@@ -281,29 +286,24 @@ clusters:
     aws_region: "us-east-1"
     profile: "your-aws-profile"
     is_serverless: true
-
-  # No Authentication (for clusters without authentication)
-  no-auth-cluster:
-    opensearch_url: "http://localhost:9200"
-    opensearch_no_auth: true
 ```
 
 #### Authentication Methods in Multi Mode:
 
-1. **IAM Role Authentication:**
+1. **No Authentication:**
+   - Requires: `opensearch_url`, `opensearch_no_auth: true`
+   - For OpenSearch clusters that allow anonymous access without authentication
+
+2. **IAM Role Authentication:**
    - Requires: `opensearch_url`, `iam_arn`, `aws_region`, `profile` (optional)
    - **Process**: The server assumes the specified IAM role using AWS STS and then connects to the cluster using those temporary credentials
 
-2. **Basic Authentication:**
+3. **Basic Authentication:**
    - Requires: `opensearch_url`, `opensearch_username`, `opensearch_password`
 
-3. **AWS Credentials Authentication:**
+4. **AWS Credentials Authentication:**
    - Requires: `opensearch_url`, `profile` (optional)
    - Uses AWS credentials from the specified profile or default credentials
-
-4. **No Authentication:**
-   - Requires: `opensearch_url`, `opensearch_no_auth: true`
-   - For OpenSearch clusters that allow anonymous access without authentication
 
 ### AWS Profile Support
 
@@ -426,11 +426,11 @@ When using multi-mode, each cluster in your YAML configuration file accepts the 
 
 | Authentication Method | Required Parameters | Optional Parameters |
 |----------------------|-------------------|-------------------|
+| **No Authentication** | `opensearch_url` | `opensearch_no_auth: true` |
 | **Basic Authentication** | `opensearch_url`, `opensearch_username`, `opensearch_password` | `profile` |
 | **IAM Role Authentication** | `opensearch_url`, `iam_arn`, `aws_region` | `profile` |
 | **AWS Credentials Authentication** | `opensearch_url` | `aws_region`, `profile` |
 | **OpenSearch Serverless** | `opensearch_url`, `aws_region` | `profile`, `is_serverless: true` |
-| **No Authentication** | `opensearch_url` | `opensearch_no_auth: true` |
 
 ## Tool Filter
 

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -64,7 +64,7 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
     2. AWS IAM authentication using boto3 credentials
        - Uses 'aoss' service name if OPENSEARCH_SERVERLESS=true
        - Uses 'es' service name otherwise
-    3. No authentication as fallback for clusters that don't require authentication
+    3. No authentication (only if OPENSEARCH_NO_AUTH=true environment variable is set)
 
     Args:
         cluster_info (ClusterInfo): Cluster information object containing authentication and connection details
@@ -167,12 +167,13 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
     except (boto3.exceptions.Boto3Error, Exception) as e:
         logger.error(f'[AWS CREDS] Failed to get AWS credentials: {str(e)}')
 
-    # Try no authentication as last resort
-    logger.info('[NO AUTH] Attempting connection without authentication')
-    try:
-        return OpenSearch(**client_kwargs)
-    except Exception as e:
-        logger.error(f'[NO AUTH] Failed to connect without authentication: {str(e)}')
+    # 4. Try no authentication if explicitly enabled
+    if os.getenv('OPENSEARCH_NO_AUTH', '').lower() == 'true':
+        logger.info('[NO AUTH] Attempting connection without authentication (OPENSEARCH_NO_AUTH=true)')
+        try:
+            return OpenSearch(**client_kwargs)
+        except Exception as e:
+            logger.error(f'[NO AUTH] Failed to connect without authentication: {str(e)}')
         
     raise RuntimeError('No valid AWS or basic authentication provided for OpenSearch')
 

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -64,6 +64,7 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
     2. AWS IAM authentication using boto3 credentials
        - Uses 'aoss' service name if OPENSEARCH_SERVERLESS=true
        - Uses 'es' service name otherwise
+    3. No authentication as fallback for clusters that don't require authentication
 
     Args:
         cluster_info (ClusterInfo): Cluster information object containing authentication and connection details
@@ -166,6 +167,13 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
     except (boto3.exceptions.Boto3Error, Exception) as e:
         logger.error(f'[AWS CREDS] Failed to get AWS credentials: {str(e)}')
 
+    # Try no authentication as last resort
+    logger.info('[NO AUTH] Attempting connection without authentication')
+    try:
+        return OpenSearch(**client_kwargs)
+    except Exception as e:
+        logger.error(f'[NO AUTH] Failed to connect without authentication: {str(e)}')
+        
     raise RuntimeError('No valid AWS or basic authentication provided for OpenSearch')
 
 

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -60,11 +60,11 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
     """Initialize and return an OpenSearch client with appropriate authentication.
 
     The function attempts to authenticate in the following order:
-    1. Basic authentication using OPENSEARCH_USERNAME and OPENSEARCH_PASSWORD
-    2. AWS IAM authentication using boto3 credentials
+    1. No authentication (only if OPENSEARCH_NO_AUTH=true environment variable is set)
+    2. Basic authentication using OPENSEARCH_USERNAME and OPENSEARCH_PASSWORD
+    3. AWS IAM authentication using boto3 credentials
        - Uses 'aoss' service name if OPENSEARCH_SERVERLESS=true
        - Uses 'es' service name otherwise
-    3. No authentication (only if OPENSEARCH_NO_AUTH=true environment variable is set)
 
     Args:
         cluster_info (ClusterInfo): Cluster information object containing authentication and connection details
@@ -117,7 +117,15 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
     if not aws_region:
         aws_region = session.region_name or os.getenv('AWS_REGION', '')
 
-    # 1. Try IAM auth
+    # 1. Try no authentication if explicitly enabled
+    if os.getenv('OPENSEARCH_NO_AUTH', '').lower() == 'true':
+        logger.info('[NO AUTH] Attempting connection without authentication (OPENSEARCH_NO_AUTH=true)')
+        try:
+            return OpenSearch(**client_kwargs)
+        except Exception as e:
+            logger.error(f'[NO AUTH] Failed to connect without authentication: {str(e)}')
+
+    # 2. Try IAM auth
     if iam_arn:
         logger.info(f'[IAM AUTH] Using IAM role authentication: {iam_arn}')
         try:
@@ -144,13 +152,13 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
         except Exception as e:
             logger.error(f'[IAM AUTH] Failed to assume IAM role {iam_arn}: {str(e)}')
 
-    # 2. Try basic auth
+    # 3. Try basic auth
     if opensearch_username and opensearch_password:
         logger.info(f'[BASIC AUTH] Using basic authentication: {opensearch_username}')
         client_kwargs['http_auth'] = (opensearch_username, opensearch_password)
         return OpenSearch(**client_kwargs)
 
-    # 3. Try to get credentials from boto3 session
+    # 4. Try to get credentials from boto3 session
     try:
         logger.info(f'[AWS CREDS] Using AWS credentials authentication')
         credentials = session.get_credentials()
@@ -166,14 +174,6 @@ def initialize_client_with_cluster(cluster_info: ClusterInfo = None) -> OpenSear
             return OpenSearch(**client_kwargs)
     except (boto3.exceptions.Boto3Error, Exception) as e:
         logger.error(f'[AWS CREDS] Failed to get AWS credentials: {str(e)}')
-
-    # 4. Try no authentication if explicitly enabled
-    if os.getenv('OPENSEARCH_NO_AUTH', '').lower() == 'true':
-        logger.info('[NO AUTH] Attempting connection without authentication (OPENSEARCH_NO_AUTH=true)')
-        try:
-            return OpenSearch(**client_kwargs)
-        except Exception as e:
-            logger.error(f'[NO AUTH] Failed to connect without authentication: {str(e)}')
         
     raise RuntimeError('No valid AWS or basic authentication provided for OpenSearch')
 


### PR DESCRIPTION

### Description
Currently, the client requires either basic auth (username/password) or AWS credentials. However, some OpenSearch clusters (especially internal/development clusters) don't require any authentication.

### Issues Resolved
- Adds fallback support for OpenSearch clusters that  don't require authentication

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).