### PR TITLE
Handle Tool Filtering failure gracefully and define priority to the AWS Region definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-- Handle Tool Filtering failure gracefully and define priority to the AWS Region definitions ([#74](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/74))
 
 ### Added
 - Extend list indices tool ([#68](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/68))
@@ -12,10 +11,14 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-- Fix endpoint selection bug in ClusterHealthTool and CountTool ([#59](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/59))
-- Fix Serverless issues ([#61](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/61))
+- Handle Tool Filtering failure gracefully and define priority to the AWS Region definitions ([#74](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/74))
 
 ### Security
+
+## [Released 0.2]
+### Fixed
+- Fix endpoint selection bug in ClusterHealthTool and CountTool ([#59](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/59))
+- Fix Serverless issues ([#61](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/61))
 
 ## [Released 0.2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Security
 
-## [Released 0.2]
+## [Released 0.2.2]
 ### Fixed
 - Fix endpoint selection bug in ClusterHealthTool and CountTool ([#59](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/59))
 - Fix Serverless issues ([#61](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/61))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+- Handle Tool Filtering failure gracefully and define priority to the AWS Region definitions ([#74](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/74))
 
 ### Added
 - Extend list indices tool ([#68](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/68))

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 from semver import Version
 from tools.tool_params import *
+
+# Configure logging
+logger = logging.getLogger(__name__)
 
 
 # List all the helper functions, these functions perform a single rest call to opensearch
@@ -62,12 +66,12 @@ def get_opensearch_version(args: baseToolArgs) -> Version:
     Returns:
         Version: The version of OpenSearch cluster (SemVer style)
     """
-    from .client import initialize_client, is_serverless
+    from .client import initialize_client
 
-    if is_serverless(args):
-        # TODO: The version is placeholder with no impact on logic, we need to add serverless compatibility check for all tools
-        return Version.parse('2.11.0')
-
-    client = initialize_client(args)
-    response = client.info()
-    return Version.parse(response['version']['number'])
+    try:
+        client = initialize_client(args)
+        response = client.info()
+        return Version.parse(response['version']['number'])
+    except Exception as e:
+        logger.error(f'Error getting OpenSearch version: {e}')
+        return None

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -190,24 +190,18 @@ def get_tools(mode: str = 'single', config: str = '') -> dict:
     if config and any(env_config.values()):
         logging.warning('Both config file and environment variables are set. Using config file.')
 
-    # Apply tool filtering
+    # Apply tool filtering, update the TOOL_REGISTRY
     process_tool_filter(
         filter_path=config if config else None,
         **{k: v for k, v in env_config.items() if not config},
     )
 
-    # Check if running in OpenSearch Serverless mode
-    from opensearch.client import is_serverless
-
-    is_serverless = is_serverless(baseToolArgs())
-
     for name, info in TOOL_REGISTRY.items():
         # Create a copy to avoid modifying the original tool info
         tool_info = info.copy()
 
-        # Skip version compatibility check for serverless mode
-        # In serverless, all tools are available regardless of version
-        if not is_serverless and not is_tool_compatible(version, info):
+        # If tool is not compatible with the current OpenSearch version, skip, don't enable
+        if not is_tool_compatible(version, info):
             continue
 
         # Remove baseToolArgs fields from input schema for single mode

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -21,11 +21,6 @@ from opensearch.helper import (
 
 
 def check_tool_compatibility(tool_name: str, args: baseToolArgs = None):
-    from opensearch.client import is_serverless
-
-    if is_serverless(args):
-        return
-
     opensearch_version = get_opensearch_version(args)
     if not is_tool_compatible(opensearch_version, TOOL_REGISTRY[tool_name]):
         raise Exception(

--- a/src/tools/utils.py
+++ b/src/tools/utils.py
@@ -6,7 +6,7 @@ import yaml
 from semver import Version
 
 
-def is_tool_compatible(current_version: Version, tool_info: dict = {}):
+def is_tool_compatible(current_version: Version | None, tool_info: dict = {}):
     """Check if a tool is compatible with the current OpenSearch version.
 
     Args:
@@ -16,6 +16,9 @@ def is_tool_compatible(current_version: Version, tool_info: dict = {}):
     Returns:
         bool: True if the tool is compatible, False otherwise
     """
+    # Find a version equivalent in serverless mode
+    if not current_version:
+        return True
     min_tool_version = Version.parse(
         tool_info.get('min_version', '0.0.0'), optional_minor_and_patch=True
     )

--- a/tests/opensearch/test_helper.py
+++ b/tests/opensearch/test_helper.py
@@ -212,6 +212,5 @@ class TestOpenSearchHelper:
         mock_client.info.side_effect = Exception('Failed to get version')
         args = baseToolArgs()
         # Execute and assert
-        with pytest.raises(Exception) as exc_info:
-            get_opensearch_version(args)
-        assert str(exc_info.value) == 'Failed to get version'
+        result = get_opensearch_version(args)
+        assert result is None

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -153,10 +153,10 @@ class TestGetTools:
             assert 'index' in schema['required']
 
     @patch.dict('os.environ', {'AWS_OPENSEARCH_SERVERLESS': 'true'})
-    def test_get_tools_single_mode_serverless_skips_version_check(
+    def test_get_tools_single_mode_serverless_passes_compatibility_check(
         self, mock_tool_registry, mock_patches
     ):
-        """Test that serverless mode skips version compatibility checks."""
+        """Test that serverless mode passes version compatibility checks."""
         mock_get_version, mock_tool_reg, mock_is_compatible = mock_patches
 
         with (
@@ -165,7 +165,7 @@ class TestGetTools:
             mock_is_compatible as mock_compat,
         ):
             # Setup mocks
-            mock_version.return_value = Version.parse('2.5.0')
+            mock_version.return_value = None
             mock_reg.items.return_value = mock_tool_registry.items()
 
             # Call get_tools in single mode with serverless environment
@@ -175,9 +175,6 @@ class TestGetTools:
             assert len(result) == 2
             assert 'ListIndexTool' in result
             assert 'SearchIndexTool' in result
-
-            # Version compatibility check should not be called
-            mock_compat.assert_not_called()
 
     def test_get_tools_single_mode_handles_missing_properties(self, mock_patches):
         """Test that single mode handles schemas without properties field."""


### PR DESCRIPTION
### Description
Fixed the Version based Tool Filtering Bug #72 by gracefully handling the version check failure. 
If the Version check fails, the server will not fail anymore, it will expose all tools.

Created a priority order to get the AWS region from different variables and profiles

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._
#72


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).