### PR TITLE
Fix tool filtering logic to handle tool renaming properly

### DIFF
--- a/src/tools/utils.py
+++ b/src/tools/utils.py
@@ -51,13 +51,15 @@ def load_yaml_config(filter_path):
         return None
 
 
-def validate_tools(tool_list, registry_lookup, source_name):
+def validate_tools(tool_list, display_lookup, source_name):
     """Validate tools against registry and return valid tools."""
     valid_tools = set()
     for tool in tool_list:
         tool_lower = tool.lower()
-        if tool_lower in registry_lookup:
-            valid_tools.add(tool_lower)
+        # Check if it matches tool display name
+        if tool_lower in display_lookup:
+            actual_tool = display_lookup[tool_lower]
+            valid_tools.add(actual_tool.lower())
         else:
             logging.warning(f"Ignoring invalid tool from '{source_name}': '{tool}'")
     return valid_tools


### PR DESCRIPTION
### Description
There are some issues in the tool filtering logic after renaming tool name. 
- Tool filtering doesn't work after renaming tool name
  - Steps to reproduce:
    - Rename `ListIndexTool` to `IndexManager`
    - Disable `ListIndexTool` or `IndexManager`
    - We can still see `IndexManager` in the tool list
- Log messages display old tool names instead of new display names ([ref](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/src/tools/tool_filter.py#L154))
  - Example: shows `Available tools after filtering: ['ListIndexTool']` 
  - Expected: `Available tools after filtering: ['IndexManager']` 


To fix the above issue, original tool names will become invalid once users rename it. For example:
- After renaming  `ListIndexTool` to `IndexManager`, users must use `IndexManager` for filtering
- `ListIndexTool` is no longer valid

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).