### PR TITLE
Implement field filtering args to ListIndexTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Add include_detail as optional parameter to ListIndexTool ([#97](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/97))
+
 ### Fixed
 
 ### Removed

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -18,6 +18,10 @@ class ListIndicesArgs(baseToolArgs):
         default='',
         description='The name of the index to get detailed information for. If provided, returns detailed information about this specific index instead of listing all indices.',
     )
+    include_detail: bool = Field(
+        default=True,
+        description='Whether to include detailed information. When listing indices (no index specified), if False, returns only a pure list of index names. If True, returns full metadata. When a specific index is provided, detailed information (including mappings) will be returned.',
+    )
 
 
 class GetIndexMappingArgs(baseToolArgs):

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -48,7 +48,7 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
     try:
         check_tool_compatibility('ListIndexTool', args)
 
-        # If index is provided, get detailed information for that specific index
+        # If index is provided, always return detailed information for that specific index
         if args.index:
             index_info = get_index(args)
             formatted_info = json.dumps(index_info, indent=2)
@@ -56,11 +56,21 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
                 {'type': 'text', 'text': f'Index information for {args.index}:\n{formatted_info}'}
             ]
 
-        # Otherwise, list all indices with full information
+        # Otherwise, list all indices
         indices = list_indices(args)
-        formatted_indices = json.dumps(indices, indent=2)
 
-        # Return in MCP expected format
+        # If include_detail is False, return only pure list of index names
+        if not args.include_detail:
+            index_names = [
+                item.get('index')
+                for item in indices
+                if isinstance(item, dict) and 'index' in item
+            ]
+            formatted_names = json.dumps(index_names, indent=2)
+            return [{'type': 'text', 'text': f'Indices:\n{formatted_names}'}]
+
+        # include_detail is True: return full information
+        formatted_indices = json.dumps(indices, indent=2)
         return [{'type': 'text', 'text': f'All indices information:\n{formatted_indices}'}]
     except Exception as e:
         return [{'type': 'text', 'text': f'Error listing indices: {str(e)}'}]
@@ -122,7 +132,7 @@ async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
 TOOL_REGISTRY = {
     'ListIndexTool': {
         'display_name': 'ListIndexTool',
-        'description': 'Lists all indices in the OpenSearch cluster with full information including docs.count, docs.deleted, store.size, etc. If an index parameter is provided, returns detailed information about that specific index.',
+        'description': 'Lists indices in the OpenSearch cluster. By default, returns a filtered list of index names only to minimize response size. Set include_detail=true to return full metadata from cat.indices (docs.count, store.size, etc.). If an index parameter is provided, returns detailed information for that specific index including mappings and settings.',
         'input_schema': ListIndicesArgs.model_json_schema(),
         'function': list_indices_tool,
         'args_model': ListIndicesArgs,

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -65,8 +65,8 @@ class TestTools:
         self.init_client_patcher.stop()
 
     @pytest.mark.asyncio
-    async def test_list_indices_tool(self):
-        """Test list_indices_tool returns full JSON info for all indices."""
+    async def test_list_indices_tool_default_filtered(self):
+        """Default behavior: returns only pure list of index names (filtered)."""
         # Setup: mock full index info as returned by OpenSearch cat.indices
         self.mock_client.cat.indices.return_value = [
             {
@@ -99,7 +99,47 @@ class TestTools:
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
-        # Should include the full JSON output
+        # Should include only names
+        payload = json.loads(result[0]['text'].split('\n', 1)[1])
+        assert payload == ['index1', 'index2']
+        assert 'docs.count' not in result[0]['text']
+        self.mock_client.cat.indices.assert_called_once_with(format='json')
+
+    @pytest.mark.asyncio
+    async def test_list_indices_tool_include_detail_true(self):
+        """When include_detail=True, returns full JSON info for all indices."""
+        # Setup
+        self.mock_client.cat.indices.return_value = [
+            {
+                'health': 'green',
+                'status': 'open',
+                'index': 'index1',
+                'uuid': 'uuid1',
+                'pri': '1',
+                'rep': '1',
+                'docs.count': '100',
+                'docs.deleted': '5',
+                'store.size': '1mb',
+                'pri.store.size': '0.5mb',
+            },
+            {
+                'health': 'yellow',
+                'status': 'open',
+                'index': 'index2',
+                'uuid': 'uuid2',
+                'pri': '2',
+                'rep': '2',
+                'docs.count': '200',
+                'docs.deleted': '10',
+                'store.size': '2mb',
+                'pri.store.size': '1mb',
+            },
+        ]
+        # Execute
+        result = await self._list_indices_tool(self.ListIndicesArgs(include_detail=True))
+        # Assert
+        assert len(result) == 1
+        assert result[0]['type'] == 'text'
         assert '"index": "index1"' in result[0]['text']
         assert '"docs.count": "100"' in result[0]['text']
         assert '"index": "index2"' in result[0]['text']
@@ -108,7 +148,7 @@ class TestTools:
 
     @pytest.mark.asyncio
     async def test_list_indices_tool_with_index(self):
-        """Test list_indices_tool returns detailed info for a single index."""
+        """When index is provided, returns detailed info for a single index."""
         # Setup: mock detailed index info as returned by OpenSearch indices.get
         mock_index_info = {
             'index1': {
@@ -131,6 +171,27 @@ class TestTools:
             '"field1": {"type": "text"}' in result[0]['text']
             or '"type": "text"' in result[0]['text']
         )
+        self.mock_client.indices.get.assert_called_once_with(index='index1')
+
+    @pytest.mark.asyncio
+    async def test_list_indices_tool_with_index_filtered(self):
+        """Deprecated behavior removed: index with include_detail=False should still return details (kept to ensure no regression to name-only)."""
+        # Setup detailed info
+        mock_index_info = {
+            'index1': {
+                'aliases': {},
+                'mappings': {'properties': {'field1': {'type': 'text'}}},
+                'settings': {'index': {'number_of_shards': '1', 'number_of_replicas': '1'}},
+            }
+        }
+        self.mock_client.indices.get.return_value = mock_index_info
+        # Execute
+        args = self.ListIndicesArgs(index='index1', include_detail=False)
+        result = await self._list_indices_tool(args)
+        # Assert still returns details
+        assert len(result) == 1
+        assert result[0]['type'] == 'text'
+        assert 'Index information for index1' in result[0]['text']
         self.mock_client.indices.get.assert_called_once_with(index='index1')
 
     @pytest.mark.asyncio

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -65,8 +65,8 @@ class TestTools:
         self.init_client_patcher.stop()
 
     @pytest.mark.asyncio
-    async def test_list_indices_tool_default_filtered(self):
-        """Default behavior: returns only pure list of index names (filtered)."""
+    async def test_list_indices_tool_default_full(self):
+        """Default behavior: returns full JSON info for all indices (include_detail=True)."""
         # Setup: mock full index info as returned by OpenSearch cat.indices
         self.mock_client.cat.indices.return_value = [
             {
@@ -99,15 +99,16 @@ class TestTools:
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
-        # Should include only names
-        payload = json.loads(result[0]['text'].split('\n', 1)[1])
-        assert payload == ['index1', 'index2']
-        assert 'docs.count' not in result[0]['text']
+        # Should include the full JSON output by default
+        assert '"index": "index1"' in result[0]['text']
+        assert '"docs.count": "100"' in result[0]['text']
+        assert '"index": "index2"' in result[0]['text']
+        assert '"docs.count": "200"' in result[0]['text']
         self.mock_client.cat.indices.assert_called_once_with(format='json')
 
     @pytest.mark.asyncio
-    async def test_list_indices_tool_include_detail_true(self):
-        """When include_detail=True, returns full JSON info for all indices."""
+    async def test_list_indices_tool_include_detail_false(self):
+        """When include_detail=False, returns only pure list of index names (filtered)."""
         # Setup
         self.mock_client.cat.indices.return_value = [
             {
@@ -136,14 +137,13 @@ class TestTools:
             },
         ]
         # Execute
-        result = await self._list_indices_tool(self.ListIndicesArgs(include_detail=True))
+        result = await self._list_indices_tool(self.ListIndicesArgs(include_detail=False))
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
-        assert '"index": "index1"' in result[0]['text']
-        assert '"docs.count": "100"' in result[0]['text']
-        assert '"index": "index2"' in result[0]['text']
-        assert '"docs.count": "200"' in result[0]['text']
+        payload = json.loads(result[0]['text'].split('\n', 1)[1])
+        assert payload == ['index1', 'index2']
+        assert 'docs.count' not in result[0]['text']
         self.mock_client.cat.indices.assert_called_once_with(format='json')
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Description
This PR adds the argument to choose whether to include detailed responses (mapping, settings, aliases) in the `ListIndexTool` output. When the Agent simply wants to get a list of indices, it can retrieve the list with less context.

### Issues Resolved
Resolves #76 
