### PR TITLE
add tool args description modify feature to config file parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Add new operational tools for comprehensive OpenSearch cluster analysis: `GetClusterStateTool`, `GetSegmentsTool`, `CatNodesTool`, `GetNodesTool`, `GetIndexInfoTool`, `GetIndexStatsTool`, `GetQueryInsightsTool`, `GetNodesHotThreadsTool`, `GetAllocationTool`, and `GetLongRunningTasksTool` and test cases (#78)
-
 - Add include_detail as optional parameter to ListIndexTool ([#97](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/97))
+- Allow customizing tool argument descriptions via configuration ([#100](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/100))
 
 ### Fixed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -143,6 +143,8 @@ tools:
   ListIndexTool:
     display_name: "Index Manager"
     description: "List and manage OpenSearch indices with enhanced functionality"
+    args:
+      index: "Custom description for the 'index' argument in ListIndexTool."
   SearchIndexTool:
     display_name: "Super Searcher"
   GetShardsTool:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -517,21 +517,6 @@ OpenSearch MCP server supports tool customization to modify tool display names, 
 
 **Note:** Display names must follow the pattern `^[a-zA-Z0-9_-]+$` (alphanumeric characters, underscores, and hyphens only).
 
-### Supported Field Aliases
-
-The following field aliases are supported for tool customization:
-
-**Display Name Aliases:**
-- `display_name` (standard)
-- `name`
-- `displayName` 
-- `customName`
-
-**Description Aliases:**
-- `description` (standard)
-- `desc`
-- `customDescription`
-
 ### Configuration Methods
 
 1. **YAML Configuration File**

--- a/example_config.yml
+++ b/example_config.yml
@@ -29,10 +29,17 @@ tools:
   ListIndexTool:
     display_name: "My_Custom_Index_Lister"
     description: "This is a custom description for the tool that lists indices. It's much more descriptive now!"
+    args:
+      index: "Custom description for the 'index' argument in ListIndexTool."
   SearchIndexTool:
     display_name: "Super_Searcher"
+    args:
+      index: "Custom description for the 'index' argument in SearchIndexTool."
+      query: "Explain what kind of query JSON is expected here."
   GetShardsTool:
     description: "A better description to get information about shards in OpenSearch."
+    args:
+      index: "Target index whose shards will be listed."
 
 # ==============================================================================
 # Tool filtering configurations (ONLY supported in Single Mode)

--- a/src/tools/config.py
+++ b/src/tools/config.py
@@ -208,6 +208,52 @@ def _load_config_from_cli(cli_tool_overrides: Dict[str, str]) -> Dict[str, Dict[
     return cli_configs
 
 
+def _put_nested_dict(nested: dict, keys: list[str], value: Any) -> dict:
+    current = nested
+    for key in keys[:-1]:
+        if not isinstance(current.get(key), dict):
+            current[key] = {}
+        current = current[key]
+    # Coerce common scalar types using YAML parser (bool/int/float/null/quoted strings, etc.)
+    if isinstance(value, str) and value.strip():
+        try:
+            coerced = yaml.safe_load(value)
+        except Exception:
+            coerced = value
+    else:
+        coerced = value
+    current[keys[-1]] = coerced
+    return nested
+
+
+def parse_cli_to_nested_config(cli_tool_overrides: Dict[str, str]) -> Dict[str, Dict[str, Any]]:
+    """
+    Parse generic CLI overrides of the form 'tool.<ToolName>.<path>=<value>' into a nested dict.
+
+    Examples:
+    - tool.ListIndexTool.http_methods=POST
+      -> { 'ListIndexTool': { 'http_methods': 'POST' } }
+
+    - tool.ListIndexTool.args.index.required=true
+      -> { 'ListIndexTool': { 'args': { 'index': { 'required': True } } } }
+
+    :param cli_tool_overrides: Mapping of CLI key -> value
+    :return: Nested overrides per tool name
+    """
+    if not cli_tool_overrides:
+        return {}
+
+    nested = {}
+    for full_key, raw_value in cli_tool_overrides.items():
+        nested_keys = [key for key in full_key.split('.') if key != '']
+        if len(nested_keys) < 3 or nested_keys[0] != 'tool':
+            continue
+        nested_keys[2] = _find_actual_field(nested_keys[2]) or nested_keys[2]
+
+        nested = _put_nested_dict(nested, nested_keys[1:], raw_value)
+
+    return nested
+
 def _validate_config(config: Dict[str, Dict[str, Any]], reference_registry: Dict[str, Any]) -> None:
     """
     Validate the configuration.
@@ -357,7 +403,7 @@ def apply_custom_tool_config(
             _apply_validated_configs(custom_registry, file_configs)
     else:
         # Use CLI arguments only if no config file
-        cli_configs = _load_config_from_cli(cli_tool_overrides)
+        cli_configs = parse_cli_to_nested_config(cli_tool_overrides)
         if cli_configs:
             _validate_config(cli_configs, custom_registry)
             _apply_validated_configs(custom_registry, cli_configs)

--- a/src/tools/config.py
+++ b/src/tools/config.py
@@ -5,14 +5,8 @@ import copy
 import logging
 import re
 import yaml
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any
 from tools.tools import TOOL_REGISTRY as default_tool_registry
-
-# Field aliases mapping: actual field name -> list of accepted aliases
-FIELD_ALIASES = {
-    'display_name': ['name', 'displayName', 'display_name', 'customName'],
-    'description': ['description', 'desc', 'customDescription'],
-}
 
 # Constants for field names
 DISPLAY_NAME_STRING = 'display_name'
@@ -21,35 +15,6 @@ ARGS_STRING = 'args'
 
 # Regex pattern for tool display name validation
 DISPLAY_NAME_PATTERN = r'^[a-zA-Z0-9_-]+$'
-
-
-def _find_actual_field(field_alias: str) -> Optional[str]:
-    """
-    Find the actual field name for a given alias.
-
-    :param field_alias: The alias to look up
-    :return: The actual field name or None if not found
-    """
-    for actual_field, aliases in FIELD_ALIASES.items():
-        if field_alias in aliases:
-            return actual_field
-    return None
-
-
-def _get_all_aliases() -> Tuple[List[str], List[str]]:
-    """
-    Get all aliases for display name and description fields.
-
-    :return: Tuple of (display_name_aliases, description_aliases)
-    """
-    all_display_name_aliases = []
-    all_description_aliases = []
-    for actual_field, aliases in FIELD_ALIASES.items():
-        if actual_field == DISPLAY_NAME_STRING:
-            all_display_name_aliases.extend(aliases)
-        elif actual_field == DESCRIPTION_STRING:
-            all_description_aliases.extend(aliases)
-    return all_display_name_aliases, all_description_aliases
 
 
 def is_valid_display_name_pattern(name: str) -> bool:
@@ -80,132 +45,24 @@ def _load_config_from_file(config_from_file: Dict[str, Any]) -> Dict[str, Dict[s
     file_configs: dict[str, dict[str, Any]] = {}
     for tool_name, custom in (config_from_file or {}).items():
         out: dict[str, Any] = {}
-        seen: dict[str, list[str]] = {DISPLAY_NAME_STRING: [], DESCRIPTION_STRING: []}
 
         for key, value in (custom or {}).items():
-            # field = _normalize_top_level_field(key)
             if key == ARGS_STRING:
                 if parsed_args := _parse_args_map(tool_name, value):
                     out.setdefault(ARGS_STRING, {}).update(parsed_args)
                 continue
-            field = _find_actual_field(key)
-            if field in (DISPLAY_NAME_STRING, DESCRIPTION_STRING):
-                seen[field].append(key)
-                out[field] = value
+            if key in (DISPLAY_NAME_STRING, DESCRIPTION_STRING):
+                out[key] = value
                 continue
-
-            logging.warning(
-                f"Invalid field '{key}' for tool '{tool_name}' in config file will be ignored. "
-                f"Only display_name, description and args are supported."
+            # Disallow non-standard top-level fields in YAML config
+            raise ValueError(
+                f"Invalid field '{key}' for tool '{tool_name}' in config file. "
+                f"Only '{DISPLAY_NAME_STRING}', '{DESCRIPTION_STRING}' and '{ARGS_STRING}' are supported."
             )
-
-        for f in (DISPLAY_NAME_STRING, DESCRIPTION_STRING):
-            if len(seen[f]) > 1:
-                raise ValueError(
-                    f"Duplicate {f.replace('_', ' ')} field for tool '{tool_name}' in config file. "
-                    f"Found multiple aliases: {seen[f]}"
-                )
 
         file_configs[tool_name] = out
 
     return file_configs
-
-
-def _check_cli_duplicate_field_aliases(cli_tool_overrides: Dict[str, str], display_name_pattern: str, description_pattern: str) -> None:
-    """
-    Check for duplicate field aliases in CLI arguments and raise ValueError if found.
-    
-    :param cli_tool_overrides: Command line tool overrides
-    :param display_name_pattern: Regex pattern for display name arguments
-    :param description_pattern: Regex pattern for description arguments
-    :raises ValueError: If duplicate field aliases are found for the same tool
-    """
-    # Collect all arguments by tool and field type to detect duplicates
-    tool_display_name_args = {}  # tool_name -> list of (arg, value)
-    tool_description_args = {}   # tool_name -> list of (arg, value)
-
-    for arg, value in cli_tool_overrides.items():
-        display_name_match = re.match(display_name_pattern, arg)
-        description_match = re.match(description_pattern, arg)
-
-        if display_name_match:
-            original_tool_name = display_name_match.group(1)
-            if original_tool_name not in tool_display_name_args:
-                tool_display_name_args[original_tool_name] = []
-            tool_display_name_args[original_tool_name].append((arg, value))
-        elif description_match:
-            original_tool_name = description_match.group(1)
-            if original_tool_name not in tool_description_args:
-                tool_description_args[original_tool_name] = []
-            tool_description_args[original_tool_name].append((arg, value))
-        else:
-            logging.warning(
-                f"Invalid argument '{arg}' will be ignored. Expected format: tool.<ToolName>.<field>=<value>"
-            )
-
-    # Check for duplicate display name fields
-    for tool_name, args_list in tool_display_name_args.items():
-        if len(args_list) > 1:
-            duplicate_args = [arg for arg, value in args_list]
-            raise ValueError(
-                f"Duplicate display name field for tool '{tool_name}' in CLI arguments. "
-                f'Found multiple aliases: {duplicate_args}'
-            )
-
-    # Check for duplicate description fields
-    for tool_name, args_list in tool_description_args.items():
-        if len(args_list) > 1:
-            duplicate_args = [arg for arg, value in args_list]
-            raise ValueError(
-                f"Duplicate description field for tool '{tool_name}' in CLI arguments. "
-                f'Found multiple aliases: {duplicate_args}'
-            )
-
-
-def _load_config_from_cli(cli_tool_overrides: Dict[str, str]) -> Dict[str, Dict[str, str]]:
-    """
-    Load configurations from CLI arguments.
-
-    Creates a dict mapping original tool names to their custom configurations.
-    Example: {'ListIndexTool': {'display_name': 'CustomLister', 'description': 'Custom desc'}}
-
-    :param cli_tool_overrides: Command line tool overrides
-    :return: Dictionary of tool names and their custom configurations
-    """
-    cli_configs = {}
-    if not cli_tool_overrides:
-        return cli_configs
-
-    # Generate regex patterns for display name and description aliases (once)
-    all_display_name_aliases, all_description_aliases = _get_all_aliases()
-    display_name_alias_pattern = '|'.join(re.escape(alias) for alias in all_display_name_aliases)
-    description_alias_pattern = '|'.join(re.escape(alias) for alias in all_description_aliases)
-    display_name_pattern = rf'tool\.(\w+)\.({display_name_alias_pattern})'
-    description_pattern = rf'tool\.(\w+)\.({description_alias_pattern})'
-
-    # Check for duplicate field aliases first
-    _check_cli_duplicate_field_aliases(cli_tool_overrides, display_name_pattern, description_pattern)
-
-    # Apply the configurations
-    for arg, value in cli_tool_overrides.items():
-        display_name_match = re.match(display_name_pattern, arg)
-        description_match = re.match(description_pattern, arg)
-
-        if display_name_match:
-            # Argument format: tool.ListIndexTool.display_name=MyCustomIndexLister
-            original_tool_name = display_name_match.group(1)
-            if original_tool_name not in cli_configs:
-                cli_configs[original_tool_name] = {}
-            cli_configs[original_tool_name][DISPLAY_NAME_STRING] = value
-
-        elif description_match:
-            # Argument format: tool.ListIndexTool.description=MyCustomDescription
-            original_tool_name = description_match.group(1)
-            if original_tool_name not in cli_configs:
-                cli_configs[original_tool_name] = {}
-            cli_configs[original_tool_name][DESCRIPTION_STRING] = value
-
-    return cli_configs
 
 
 def _put_nested_dict(nested: dict, keys: list[str], value: Any) -> dict:
@@ -248,8 +105,10 @@ def parse_cli_to_nested_config(cli_tool_overrides: Dict[str, str]) -> Dict[str, 
         nested_keys = [key for key in full_key.split('.') if key != '']
         if len(nested_keys) < 3 or nested_keys[0] != 'tool':
             continue
-        nested_keys[2] = _find_actual_field(nested_keys[2]) or nested_keys[2]
-
+        # Only allow top-level fields: display_name, description, args
+        top_field = nested_keys[2]
+        if top_field not in (DISPLAY_NAME_STRING, DESCRIPTION_STRING, ARGS_STRING):
+            continue
         nested = _put_nested_dict(nested, nested_keys[1:], raw_value)
 
     return nested

--- a/src/tools/config.py
+++ b/src/tools/config.py
@@ -17,6 +17,7 @@ FIELD_ALIASES = {
 # Constants for field names
 DISPLAY_NAME_STRING = 'display_name'
 DESCRIPTION_STRING = 'description'
+ARGS_STRING = 'args'
 
 # Regex pattern for tool display name validation
 DISPLAY_NAME_PATTERN = r'^[a-zA-Z0-9_-]+$'
@@ -61,47 +62,52 @@ def is_valid_display_name_pattern(name: str) -> bool:
     return re.match(DISPLAY_NAME_PATTERN, name) is not None
 
 
-def _load_config_from_file(config_from_file: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
-    """
-    Load configurations from YAML file data.
+def _parse_args_map(tool_name: str, raw_args: Any) -> dict[str, dict[str, str]]:
+    if not isinstance(raw_args, dict):
+        logging.warning(f"Invalid 'args' for tool '{tool_name}'. Must be a mapping of arg -> string.")
+        return {}
+    parsed: dict[str, dict[str, str]] = {}
+    for arg_name, value in raw_args.items():
+        if isinstance(value, str):
+            parsed[arg_name] = {DESCRIPTION_STRING: value}
+        else:
+            raise ValueError(
+                f"Description for argument '{arg_name}' in tool '{tool_name}' must be a string."
+            )
+    return parsed
 
-    Creates a dict mapping original tool names to their custom configurations.
-    Example: {'ListIndexTool': {'display_name': 'CustomLister', 'description': 'Custom desc'}}
+def _load_config_from_file(config_from_file: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    file_configs: dict[str, dict[str, Any]] = {}
+    for tool_name, custom in (config_from_file or {}).items():
+        out: dict[str, Any] = {}
+        seen: dict[str, list[str]] = {DISPLAY_NAME_STRING: [], DESCRIPTION_STRING: []}
 
-    :param config_from_file: Configuration data from YAML file
-    :return: Dictionary of tool names and their custom configurations
-    """
-    file_configs = {}
-    for original_tool_name, custom_config in config_from_file.items():
-        if original_tool_name not in file_configs:
-            file_configs[original_tool_name] = {}
+        for key, value in (custom or {}).items():
+            # field = _normalize_top_level_field(key)
+            if key == ARGS_STRING:
+                if parsed_args := _parse_args_map(tool_name, value):
+                    out.setdefault(ARGS_STRING, {}).update(parsed_args)
+                continue
+            field = _find_actual_field(key)
+            if field in (DISPLAY_NAME_STRING, DESCRIPTION_STRING):
+                seen[field].append(key)
+                out[field] = value
+                continue
 
-        # Track which actual fields have been set to detect duplicates
-        set_fields = set()
+            logging.warning(
+                f"Invalid field '{key}' for tool '{tool_name}' in config file will be ignored. "
+                f"Only display_name, description and args are supported."
+            )
 
-        for config_key, config_value in custom_config.items():
-            actual_field = _find_actual_field(config_key)
-            if actual_field == DISPLAY_NAME_STRING:
-                if DISPLAY_NAME_STRING in set_fields:
-                    raise ValueError(
-                        f"Duplicate display name field for tool '{original_tool_name}' in config file. "
-                        f'Found multiple aliases: {[k for k, v in custom_config.items() if _find_actual_field(k) == DISPLAY_NAME_STRING]}'
-                    )
-                file_configs[original_tool_name][DISPLAY_NAME_STRING] = config_value
-                set_fields.add(DISPLAY_NAME_STRING)
-            elif actual_field == DESCRIPTION_STRING:
-                if DESCRIPTION_STRING in set_fields:
-                    raise ValueError(
-                        f"Duplicate description field for tool '{original_tool_name}' in config file. "
-                        f'Found multiple aliases: {[k for k, v in custom_config.items() if _find_actual_field(k) == DESCRIPTION_STRING]}'
-                    )
-                file_configs[original_tool_name][DESCRIPTION_STRING] = config_value
-                set_fields.add(DESCRIPTION_STRING)
-            else:
-                logging.warning(
-                    f"Invalid field '{config_key}' for tool '{original_tool_name}' in config file will be ignored. "
-                    f'Only display_name and description are supported.'
+        for f in (DISPLAY_NAME_STRING, DESCRIPTION_STRING):
+            if len(seen[f]) > 1:
+                raise ValueError(
+                    f"Duplicate {f.replace('_', ' ')} field for tool '{tool_name}' in config file. "
+                    f"Found multiple aliases: {seen[f]}"
                 )
+
+        file_configs[tool_name] = out
+
     return file_configs
 
 
@@ -202,7 +208,7 @@ def _load_config_from_cli(cli_tool_overrides: Dict[str, str]) -> Dict[str, Dict[
     return cli_configs
 
 
-def _validate_config(config: Dict[str, Dict[str, str]]) -> None:
+def _validate_config(config: Dict[str, Dict[str, Any]], reference_registry: Dict[str, Any]) -> None:
     """
     Validate the configuration.
 
@@ -214,7 +220,8 @@ def _validate_config(config: Dict[str, Dict[str, str]]) -> None:
     :param config: The configuration to validate
     """
     # Track available tool names (original names minus configured ones)
-    available_tool_names = set(default_tool_registry.keys())
+    # Build available tool names from both reference and default registries
+    available_tool_names = set(default_tool_registry.keys()) | set(reference_registry.keys())
 
     # Validate that all configured tools exist
     for original_name in config.keys():
@@ -241,9 +248,38 @@ def _validate_config(config: Dict[str, Dict[str, str]]) -> None:
                 f"does not follow the required pattern '{DISPLAY_NAME_PATTERN}'."
             )
 
+    # Validate args customizations
+    for original_name, custom_config in config.items():
+        if ARGS_STRING in custom_config:
+            # Prefer registry that contains input_schema properties
+            tool_info_ref = reference_registry.get(original_name)
+            tool_info_def = default_tool_registry.get(original_name)
+            def_has_props = bool((tool_info_def or {}).get('input_schema', {}).get('properties'))
+            ref_has_props = bool((tool_info_ref or {}).get('input_schema', {}).get('properties'))
+            if ref_has_props:
+                tool_info = tool_info_ref
+            elif def_has_props:
+                tool_info = tool_info_def
+            else:
+                tool_info = tool_info_ref or tool_info_def
+            if not tool_info:
+                raise ValueError(f"Tool '{original_name}' is not a valid tool name.")
+            properties = (tool_info.get('input_schema') or {}).get('properties') or {}
+            for arg_name, overrides in custom_config[ARGS_STRING].items():
+                if arg_name not in properties:
+                    raise ValueError(
+                        f"Argument '{arg_name}' does not exist on tool '{original_name}'."
+                    )
+                # Only description supported now
+                desc_val = overrides.get(DESCRIPTION_STRING)
+                if desc_val is not None and not isinstance(desc_val, str):
+                    raise ValueError(
+                        f"Description for argument '{arg_name}' in tool '{original_name}' must be a string."
+                    )
+
 
 def _apply_validated_configs(
-    custom_registry: Dict[str, Any], configs: Dict[str, Dict[str, str]]
+    custom_registry: Dict[str, Any], configs: Dict[str, Dict[str, Any]]
 ) -> None:
     """
     Apply validated configurations to the registry.
@@ -255,8 +291,31 @@ def _apply_validated_configs(
         if original_tool_name not in custom_registry:
             continue
 
+        tool_info = custom_registry[original_tool_name]
+
         for field_name, field_value in custom_config.items():
-            custom_registry[original_tool_name][field_name] = field_value
+            if field_name == ARGS_STRING:
+                # Start from the tool's existing schema, falling back to default registry if missing
+                base_schema = (
+                    tool_info.get('input_schema')
+                    or (default_tool_registry.get(original_tool_name) or {}).get('input_schema')
+                    or {}
+                )
+                input_schema = copy.deepcopy(base_schema)
+                properties = input_schema.get('properties') or {}
+                args_model = tool_info.get('args_model')
+
+                for arg_name, overrides in field_value.items():
+                    if DESCRIPTION_STRING in overrides and arg_name in properties:
+                        properties[arg_name]['description'] = overrides[DESCRIPTION_STRING]
+                        try:
+                            if args_model and hasattr(args_model, 'model_fields') and arg_name in args_model.model_fields:
+                                args_model.model_fields[arg_name].description = overrides[DESCRIPTION_STRING]
+                        except Exception:
+                            pass
+                tool_info['input_schema'] = input_schema
+            else:
+                tool_info[field_name] = field_value
 
 
 def apply_custom_tool_config(
@@ -294,13 +353,13 @@ def apply_custom_tool_config(
         # Use config file and completely ignore CLI
         file_configs = _load_config_from_file(config_from_file)
         if file_configs:
-            _validate_config(file_configs)
+            _validate_config(file_configs, custom_registry)
             _apply_validated_configs(custom_registry, file_configs)
     else:
         # Use CLI arguments only if no config file
         cli_configs = _load_config_from_cli(cli_tool_overrides)
         if cli_configs:
-            _validate_config(cli_configs)
+            _validate_config(cli_configs, custom_registry)
             _apply_validated_configs(custom_registry, cli_configs)
 
     # Update the default registry

--- a/tests/tools/test_config.py
+++ b/tests/tools/test_config.py
@@ -11,6 +11,17 @@ MOCK_TOOL_REGISTRY = {
         'display_name': 'ListIndexTool',
         'description': 'Original description for ListIndexTool',
         'other_field': 'some_value',
+        # mimic real registry structure for validation of args
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'index': {
+                    'title': 'Index',
+                    'type': 'string',
+                    'description': 'The name of the index to get detailed information for. If provided, returns detailed information about this specific index instead of listing all indices.',
+                }
+            },
+        },
     },
     'SearchIndexTool': {
         'display_name': 'SearchIndexTool',
@@ -582,5 +593,114 @@ def test_mixed_valid_invalid_configurations():
     # Invalid fields should not be added
     assert 'invalid_field' not in custom_registry['ListIndexTool']
     assert 'another_invalid' not in custom_registry['ListIndexTool']
+
+    os.remove(config_path)
+
+
+def test_yaml_args_description_update():
+    """Test that argument descriptions can be updated via YAML config."""
+    config_content = {
+        'tools': {
+            'ListIndexTool': {
+                'args': {
+                    'index': 'Custom description for index argument',
+                }
+            }
+        }
+    }
+    config_path = 'test_args_config.yml'
+    with open(config_path, 'w') as f:
+        yaml.dump(config_content, f)
+
+    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
+    custom_registry = apply_custom_tool_config(registry, config_path, {})
+
+    # Verify input_schema is updated
+    index_prop = custom_registry['ListIndexTool']['input_schema']['properties']['index']
+    assert index_prop['description'] == 'Custom description for index argument'
+
+    # Verify args_model field description is also updated when available
+    args_model = custom_registry['ListIndexTool'].get('args_model')
+    if args_model is not None and hasattr(args_model, 'model_fields'):
+        assert (
+            args_model.model_fields['index'].description
+            == 'Custom description for index argument'
+        )
+
+    os.remove(config_path)
+
+
+def test_yaml_args_description_alias_desc():
+    """Test that 'desc' alias works for args description inside YAML."""
+    config_content = {
+        'tools': {
+            'ListIndexTool': {
+                'args': {
+                    'index': 'Alias description for index',
+                }
+            }
+        }
+    }
+    config_path = 'test_args_desc_alias.yml'
+    with open(config_path, 'w') as f:
+        yaml.dump(config_content, f)
+
+    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
+    custom_registry = apply_custom_tool_config(registry, config_path, {})
+
+    index_prop = custom_registry['ListIndexTool']['input_schema']['properties']['index']
+    assert index_prop['description'] == 'Alias description for index'
+
+    os.remove(config_path)
+
+
+def test_yaml_args_invalid_argument_raises():
+    """Test that updating a non-existent argument raises an error."""
+    config_content = {
+        'tools': {
+            'ListIndexTool': {
+                'args': {
+                    'nonexistent': 'Should fail',
+                }
+            }
+        }
+    }
+    config_path = 'test_args_invalid_arg.yml'
+    with open(config_path, 'w') as f:
+        yaml.dump(config_content, f)
+
+    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
+
+    try:
+        apply_custom_tool_config(registry, config_path, {})
+        assert False, 'Expected ValueError for invalid argument name'
+    except ValueError as e:
+        assert "does not exist on tool 'ListIndexTool'" in str(e)
+
+    os.remove(config_path)
+
+
+def test_yaml_args_description_must_be_string():
+    """Test that args description must be a string."""
+    config_content = {
+        'tools': {
+            'ListIndexTool': {
+                'args': {
+                    'index': 123,
+                }
+            }
+        }
+    }
+    config_path = 'test_args_desc_type.yml'
+    with open(config_path, 'w') as f:
+        yaml.dump(config_content, f)
+
+    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
+
+    try:
+        apply_custom_tool_config(registry, config_path, {})
+        assert False, 'Expected ValueError for non-string description'
+    except ValueError as e:
+        assert 'must be a string' in str(e)
 
     os.remove(config_path)

--- a/tests/tools/test_config.py
+++ b/tests/tools/test_config.py
@@ -62,7 +62,7 @@ def test_apply_config_from_yaml_file():
 def test_apply_config_from_cli_args():
     """Test that tool names and descriptions are updated from CLI arguments."""
     cli_overrides = {
-        'tool.ListIndexTool.displayName': 'CLI_Custom_Name',
+        'tool.ListIndexTool.display_name': 'CLI_Custom_Name',
         'tool.SearchIndexTool.description': 'CLI custom description.',
     }
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
@@ -100,26 +100,15 @@ def test_cli_overrides_yaml():
     os.remove(config_path)
 
 
-def test_cli_name_alias():
-    """Test that 'name' alias works for 'display_name' in CLI arguments."""
-    cli_overrides = {'tool.ListIndexTool.name': 'CLI_Name_Alias'}
-    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, '', cli_overrides)
-
-    assert custom_registry['ListIndexTool']['display_name'] == 'CLI_Name_Alias'
-
-
-def test_yaml_field_aliases():
-    """Test that various field aliases work correctly in YAML configuration."""
+def test_yaml_rejects_non_standard_keys():
+    """YAML should reject non-standard top-level keys for tools."""
     config_content = {
         'tools': {
             'ListIndexTool': {
-                'name': 'YAML_Name_Alias',  # Should map to display_name
-                'desc': 'YAML Desc Alias',  # Should map to description
+                'customKey': 'Value1',
             },
             'SearchIndexTool': {
-                'displayName': 'YAML_DisplayName_Alias',  # Should map to display_name
-                'description': 'Regular Description',  # Direct mapping
+                'customKey2': 'Value2',
             },
         }
     }
@@ -128,41 +117,23 @@ def test_yaml_field_aliases():
         yaml.dump(config_content, f)
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, config_path, {})
-
-    assert custom_registry['ListIndexTool']['display_name'] == 'YAML_Name_Alias'
-    assert custom_registry['ListIndexTool']['description'] == 'YAML Desc Alias'
-    assert custom_registry['SearchIndexTool']['display_name'] == 'YAML_DisplayName_Alias'
-    assert custom_registry['SearchIndexTool']['description'] == 'Regular Description'
+    try:
+        apply_custom_tool_config(registry, config_path, {})
+        assert False, 'Expected ValueError for non-standard top-level keys'
+    except ValueError as e:
+        assert "Invalid field 'customKey'" in str(e) or "Invalid field 'customKey2'" in str(e)
 
     os.remove(config_path)
 
 
-def test_cli_field_aliases():
-    """Test that various field aliases work correctly in CLI arguments."""
-    cli_overrides = {
-        'tool.ListIndexTool.name': 'CLI_Name_Alias',
-        'tool.ListIndexTool.desc': 'CLI Desc Alias',
-        'tool.SearchIndexTool.displayName': 'CLI_DisplayName_Alias',
-        'tool.SearchIndexTool.description': 'CLI Regular Description',
-    }
-    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, '', cli_overrides)
-
-    assert custom_registry['ListIndexTool']['display_name'] == 'CLI_Name_Alias'
-    assert custom_registry['ListIndexTool']['description'] == 'CLI Desc Alias'
-    assert custom_registry['SearchIndexTool']['display_name'] == 'CLI_DisplayName_Alias'
-    assert custom_registry['SearchIndexTool']['description'] == 'CLI Regular Description'
-
-
-def test_yaml_unsupported_fields_ignored():
-    """Test that unsupported field names are ignored in YAML configuration."""
+def test_yaml_arbitrary_fields_rejected():
+    """Non-standard top-level fields should be rejected in YAML configuration."""
     config_content = {
         'tools': {
             'ListIndexTool': {
-                'name': 'Valid_Name',
-                'unsupported_field': 'Should be ignored',
-                'another_invalid': 'Also ignored',
+                'display_name': 'Valid_Name',
+                'unsupported_field': 'Should be rejected',
+                'another_field': 123,
             },
         }
     }
@@ -171,49 +142,40 @@ def test_yaml_unsupported_fields_ignored():
         yaml.dump(config_content, f)
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, config_path, {})
-
-    # Valid changes should be applied
-    assert custom_registry['ListIndexTool']['display_name'] == 'Valid_Name'
-
-    # Invalid fields should not be added to the registry
-    assert 'unsupported_field' not in custom_registry['ListIndexTool']
-    assert 'another_invalid' not in custom_registry['ListIndexTool']
-
-    # Other fields should remain unchanged
-    assert custom_registry['ListIndexTool']['other_field'] == 'some_value'
-
+    try:
+        apply_custom_tool_config(registry, config_path, {})
+        assert False, 'Expected ValueError for non-standard top-level fields in YAML'
+    except ValueError as e:
+        msg = str(e)
+        assert "Invalid field 'unsupported_field'" in msg or "Invalid field 'another_field'" in msg
     os.remove(config_path)
 
 
-def test_cli_unsupported_fields_ignored():
-    """Test that unsupported field names are ignored in CLI arguments."""
+def test_cli_arbitrary_fields_rejected():
+    """Non-standard top-level fields should be ignored via CLI parser."""
     cli_overrides = {
-        'tool.ListIndexTool.name': 'Valid_Name',
-        'tool.ListIndexTool.invalid_field': 'Should be ignored by regex',
-        'tool.SearchIndexTool.bad_field': 'Also ignored by regex',
+        'tool.ListIndexTool.display_name': 'Valid_Name',
+        'tool.ListIndexTool.invalid_field': 'Ignored',
+        'tool.SearchIndexTool.bad_field': 'AlsoIgnored',
         'invalid.format': 'Wrong format entirely',
     }
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
     custom_registry = apply_custom_tool_config(registry, '', cli_overrides)
 
-    # Only valid field should be applied
     assert custom_registry['ListIndexTool']['display_name'] == 'Valid_Name'
-
-    # Invalid fields should not be added
     assert 'invalid_field' not in custom_registry['ListIndexTool']
     assert 'bad_field' not in custom_registry['SearchIndexTool']
 
 
-def test_yaml_unsupported_field_warning(caplog):
-    """Test that warnings are logged for unsupported fields in YAML configuration."""
+def test_yaml_unsupported_field_now_errors():
+    """YAML should error on unsupported/non-standard fields."""
     config_content = {
         'tools': {
             'ListIndexTool': {
                 'name': 'Valid_Name',
-                'invalid_field': 'Should trigger warning',
-                'another_bad_field': 'Also triggers warning',
+                'invalid_field': 'Value',
+                'another_bad_field': 'Value2',
             },
         }
     }
@@ -222,47 +184,24 @@ def test_yaml_unsupported_field_warning(caplog):
         yaml.dump(config_content, f)
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, config_path, {})
-
-    # Valid field should be applied
-    assert custom_registry['ListIndexTool']['display_name'] == 'Valid_Name'
-
-    # Check that warnings were logged
-    assert len(caplog.records) == 2
-    warning_messages = [record.message for record in caplog.records]
-
-    assert any("Invalid field 'invalid_field'" in msg for msg in warning_messages)
-    assert any("Invalid field 'another_bad_field'" in msg for msg in warning_messages)
-
+    try:
+        apply_custom_tool_config(registry, config_path, {})
+        assert False, 'Expected ValueError for non-standard fields'
+    except ValueError as e:
+        msg = str(e)
+        assert "Invalid field 'invalid_field'" in msg or "Invalid field 'another_bad_field'" in msg
     os.remove(config_path)
 
 
-def test_cli_unsupported_field_ignored():
-    """Test that CLI arguments with unsupported fields are ignored by regex pattern."""
-    cli_overrides = {
-        'tool.ListIndexTool.name': 'Valid_Name',
-        'tool.ListIndexTool.invalid_field': 'Should be ignored by regex',
-        'tool.SearchIndexTool.bad_field': 'Also ignored by regex',
-        'invalid.format': 'Wrong format entirely',
-    }
-
-    registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, '', cli_overrides)
-
-    # Only valid field should be applied
-    assert custom_registry['ListIndexTool']['display_name'] == 'Valid_Name'
-
-    # Invalid fields should not be added
-    assert 'invalid_field' not in custom_registry['ListIndexTool']
-    assert 'bad_field' not in custom_registry['SearchIndexTool']
+    # Removed: behavior changed to ignore non-standard keys via CLI
 
 
 def test_parse_cli_to_nested_config_top_level_and_args():
     from tools.config import parse_cli_to_nested_config
 
     cli_overrides = {
-        'tool.ListIndexTool.http_methods': 'POST',
-        'tool.ListIndexTool.customTag': 'analytics',
+        'tool.ListIndexTool.http_methods': 'POST',  # should be ignored (non-standard)
+        'tool.ListIndexTool.customTag': 'analytics',  # should be ignored (non-standard)
         'tool.ListIndexTool.args.index.required': 'true',
         'tool.ListIndexTool.args.index.default': 'my-index',
         'tool.SearchIndexTool.args.query.default': '{"match_all": {}}',
@@ -273,8 +212,8 @@ def test_parse_cli_to_nested_config_top_level_and_args():
     nested = parse_cli_to_nested_config(cli_overrides)
 
     assert 'ListIndexTool' in nested
-    assert nested['ListIndexTool']['http_methods'] == 'POST'
-    assert nested['ListIndexTool']['customTag'] == 'analytics'
+    assert 'http_methods' not in nested['ListIndexTool']
+    assert 'customTag' not in nested['ListIndexTool']
     assert nested['ListIndexTool']['args']['index']['required'] is True
     assert nested['ListIndexTool']['args']['index']['default'] == 'my-index'
 
@@ -289,52 +228,33 @@ def test_parse_cli_to_nested_config_type_coercion():
     from tools.config import parse_cli_to_nested_config
 
     cli_overrides = {
-        'tool.T.boolTrue': 'true',
-        'tool.T.boolFalse': 'false',
-        'tool.T.intVal': '10',
-        'tool.T.floatVal': '1.5',
-        'tool.T.jsonObj': '{"a": 1}',
-        'tool.T.raw': 'POST',
+        'tool.T.args.boolTrue': 'true',
+        'tool.T.args.boolFalse': 'false',
+        'tool.T.args.intVal': '10',
+        'tool.T.args.floatVal': '1.5',
+        'tool.T.args.jsonObj': '{"a": 1}',
+        'tool.T.args.raw': 'POST',
     }
 
     nested = parse_cli_to_nested_config(cli_overrides)
 
-    assert nested['T']['boolTrue'] is True
-    assert nested['T']['boolFalse'] is False
-    assert nested['T']['intVal'] == 10
-    assert nested['T']['floatVal'] == 1.5
-    assert nested['T']['jsonObj'] == {'a': 1}
-    assert nested['T']['raw'] == 'POST'
+    assert nested['T']['args']['boolTrue'] is True
+    assert nested['T']['args']['boolFalse'] is False
+    assert nested['T']['args']['intVal'] == 10
+    assert nested['T']['args']['floatVal'] == 1.5
+    assert nested['T']['args']['jsonObj'] == {'a': 1}
+    assert nested['T']['args']['raw'] == 'POST'
 
-def test_field_aliases_structure():
-    """Test that the FIELD_ALIASES structure and utility functions work correctly."""
-    from tools.config import FIELD_ALIASES, _find_actual_field, _get_all_aliases
-
-    # Test the structure
-    assert 'display_name' in FIELD_ALIASES
-    assert 'description' in FIELD_ALIASES
-    assert isinstance(FIELD_ALIASES['display_name'], list)
-    assert isinstance(FIELD_ALIASES['description'], list)
-
-    # Test _find_actual_field function
-    assert _find_actual_field('name') == 'display_name'
-    assert _find_actual_field('displayName') == 'display_name'
-    assert _find_actual_field('display_name') == 'display_name'
-    assert _find_actual_field('customName') == 'display_name'
-    assert _find_actual_field('description') == 'description'
-    assert _find_actual_field('desc') == 'description'
-    assert _find_actual_field('customDescription') == 'description'
-    assert _find_actual_field('invalid_field') is None
-
-    # Test _get_all_aliases function
-    display_name_aliases, description_aliases = _get_all_aliases()
-    expected_display_aliases = ['name', 'displayName', 'display_name', 'customName']
-    expected_description_aliases = ['description', 'desc', 'customDescription']
-
-    for alias in expected_display_aliases:
-        assert alias in display_name_aliases
-    for alias in expected_description_aliases:
-        assert alias in description_aliases
+def test_alias_artifacts_removed():
+    """Alias helpers are removed; importing them should fail at runtime if attempted."""
+    try:
+        from tools import config as cfg  # noqa: F401
+        assert not hasattr(cfg, 'FIELD_ALIASES')
+        assert not hasattr(cfg, '_find_actual_field')
+        assert not hasattr(cfg, '_get_all_aliases')
+    except Exception:
+        # Import should still succeed; attributes should not exist
+        assert False, 'tools.config should be importable'
 
 
 def test_load_config_from_file():
@@ -343,11 +263,11 @@ def test_load_config_from_file():
 
     config_data = {
         'tool1': {
-            'name': 'Tool_One',
+            'display_name': 'Tool_One',
             'description': 'First tool',
         },
         'tool2': {
-            'displayName': 'Tool_Two',
+            'display_name': 'Tool_Two',
         },
     }
 
@@ -362,25 +282,25 @@ def test_load_config_from_file():
     assert configs['tool2']['display_name'] == 'Tool_Two'
 
 
-def test_load_config_from_cli():
-    """Test the _load_config_from_cli function directly."""
-    from tools.config import _load_config_from_cli
+def test_parse_cli_to_nested_config_multiple_tools():
+    from tools.config import parse_cli_to_nested_config
 
     cli_overrides = {
-        'tool.tool1.name': 'CLI_Tool_One',
+        'tool.tool1.display_name': 'CLI_Tool_One',
         'tool.tool2.description': 'CLI Tool Two Description',
         'invalid.format': 'Should be ignored',
-        'tool.tool3.invalid_field': 'Should be ignored by regex',
+        'tool.tool3.invalid_field': 'Kept',
     }
 
-    configs = _load_config_from_cli(cli_overrides)
+    configs = parse_cli_to_nested_config(cli_overrides)
 
-    # Should return dictionary mapping tool names to their configs
-    assert len(configs) == 2
+    assert len(configs) == 2  # tool3 has non-standard top-level field and is ignored
     assert 'tool1' in configs
     assert 'tool2' in configs
+    assert 'tool3' not in configs
     assert configs['tool1']['display_name'] == 'CLI_Tool_One'
     assert configs['tool2']['description'] == 'CLI Tool Two Description'
+    # tool3 should not appear due to non-standard field
 
 
 def test_apply_validated_configs():
@@ -442,8 +362,8 @@ def test_config_file_priority_over_cli():
     os.remove(config_path)
 
 
-def test_yaml_duplicate_field_aliases_error():
-    """Test that duplicate field aliases in YAML configuration raise an error."""
+def test_yaml_duplicate_aliases_now_error():
+    """Alias keys are non-standard and should error in YAML."""
     config_content = {
         'tools': {
             'ListIndexTool': {
@@ -458,23 +378,18 @@ def test_yaml_duplicate_field_aliases_error():
         yaml.dump(config_content, f)
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-
     try:
         apply_custom_tool_config(registry, config_path, {})
-        assert False, 'Expected ValueError for duplicate field aliases'
+        assert False, 'Expected ValueError for non-standard alias fields in YAML'
     except ValueError as e:
-        error_msg = str(e)
-        assert 'Duplicate display name field' in error_msg
-        assert 'Found multiple aliases' in error_msg
-        assert 'name' in error_msg
-        assert 'displayName' in error_msg
-        assert 'customName' in error_msg
+        msg = str(e)
+        assert "Invalid field 'name'" in msg or "Invalid field 'displayName'" in msg or "Invalid field 'customName'" in msg
 
     os.remove(config_path)
 
 
-def test_cli_duplicate_field_aliases_error():
-    """Test that duplicate field aliases in CLI arguments raise an error."""
+def test_cli_duplicate_aliases_ignored():
+    """Alias keys are non-standard and should be ignored via CLI parser."""
     cli_overrides = {
         'tool.ListIndexTool.name': 'First CLI Alias',
         'tool.ListIndexTool.displayName': 'Second CLI Alias',
@@ -482,17 +397,11 @@ def test_cli_duplicate_field_aliases_error():
     }
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
+    custom_registry = apply_custom_tool_config(registry, '', cli_overrides)
 
-    try:
-        apply_custom_tool_config(registry, '', cli_overrides)
-        assert False, 'Expected ValueError for duplicate CLI field aliases'
-    except ValueError as e:
-        error_msg = str(e)
-        assert 'Duplicate display name field' in error_msg
-        assert 'CLI arguments' in error_msg
-        assert 'tool.ListIndexTool.name' in error_msg
-        assert 'tool.ListIndexTool.displayName' in error_msg
-        assert 'tool.ListIndexTool.customName' in error_msg
+    assert 'name' not in custom_registry['ListIndexTool']
+    assert 'displayName' not in custom_registry['ListIndexTool']
+    assert 'customName' not in custom_registry['ListIndexTool']
 
 
 def test_display_name_pattern_validation():
@@ -632,16 +541,12 @@ def test_mixed_valid_invalid_configurations():
         yaml.dump(config_content, f)
 
     registry = copy.deepcopy(MOCK_TOOL_REGISTRY)
-    custom_registry = apply_custom_tool_config(registry, config_path, {})
-
-    # Valid configurations should be applied
-    assert custom_registry['ListIndexTool']['display_name'] == 'Valid_Name'
-    assert custom_registry['ListIndexTool']['description'] == 'Valid description'
-    assert custom_registry['SearchIndexTool']['display_name'] == 'Valid_Name_2'
-
-    # Invalid fields should not be added
-    assert 'invalid_field' not in custom_registry['ListIndexTool']
-    assert 'another_invalid' not in custom_registry['ListIndexTool']
+    try:
+        apply_custom_tool_config(registry, config_path, {})
+        assert False, 'Expected ValueError for non-standard top-level fields in YAML'
+    except ValueError as e:
+        msg = str(e)
+        assert "Invalid field 'invalid_field'" in msg or "Invalid field 'another_invalid'" in msg
 
     os.remove(config_path)
 

--- a/tests/tools/test_config.py
+++ b/tests/tools/test_config.py
@@ -257,6 +257,55 @@ def test_cli_unsupported_field_ignored():
     assert 'bad_field' not in custom_registry['SearchIndexTool']
 
 
+def test_parse_cli_to_nested_config_top_level_and_args():
+    from tools.config import parse_cli_to_nested_config
+
+    cli_overrides = {
+        'tool.ListIndexTool.http_methods': 'POST',
+        'tool.ListIndexTool.customTag': 'analytics',
+        'tool.ListIndexTool.args.index.required': 'true',
+        'tool.ListIndexTool.args.index.default': 'my-index',
+        'tool.SearchIndexTool.args.query.default': '{"match_all": {}}',
+        'invalid.no_prefix': 'ignored',
+        'tool.Bad': 'ignored',  # missing fieldPath
+    }
+
+    nested = parse_cli_to_nested_config(cli_overrides)
+
+    assert 'ListIndexTool' in nested
+    assert nested['ListIndexTool']['http_methods'] == 'POST'
+    assert nested['ListIndexTool']['customTag'] == 'analytics'
+    assert nested['ListIndexTool']['args']['index']['required'] is True
+    assert nested['ListIndexTool']['args']['index']['default'] == 'my-index'
+
+    assert 'SearchIndexTool' in nested
+    assert nested['SearchIndexTool']['args']['query']['default'] == {'match_all': {}}
+
+    # invalid keys should not create entries
+    assert 'Bad' not in nested
+
+
+def test_parse_cli_to_nested_config_type_coercion():
+    from tools.config import parse_cli_to_nested_config
+
+    cli_overrides = {
+        'tool.T.boolTrue': 'true',
+        'tool.T.boolFalse': 'false',
+        'tool.T.intVal': '10',
+        'tool.T.floatVal': '1.5',
+        'tool.T.jsonObj': '{"a": 1}',
+        'tool.T.raw': 'POST',
+    }
+
+    nested = parse_cli_to_nested_config(cli_overrides)
+
+    assert nested['T']['boolTrue'] is True
+    assert nested['T']['boolFalse'] is False
+    assert nested['T']['intVal'] == 10
+    assert nested['T']['floatVal'] == 1.5
+    assert nested['T']['jsonObj'] == {'a': 1}
+    assert nested['T']['raw'] == 'POST'
+
 def test_field_aliases_structure():
     """Test that the FIELD_ALIASES structure and utility functions work correctly."""
     from tools.config import FIELD_ALIASES, _find_actual_field, _get_all_aliases


### PR DESCRIPTION
### Description

This PR introduces support for editing not only the tool name and description, but also the argument descriptions via the `config.yaml` file.
A new args field can now be added in config.yaml. If invalid args are provided, a ValueError will be raised.

In config.yaml

~~~ yaml
tools:
  ListIndexTool:
    display_name: "CustomIndexTool"
    description: "This is a custom description"
    args:
      index: "Custom description for the 'index' argument in ListIndexTool."
~~~

UPDATE: Users can also modify the args description using CLI runtime parameters. For example,

~~~
python -m mcp_server_opensearch --transport stream  --tool.GetShardsTool.args.index.description="Custom descriptions by ssunno" 
~~~

### Issues Resolved
Closes #75 
