### PR TITLE
set stateless=True for streaming server by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Allow customizing tool argument descriptions via configuration ([#100](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/100))
 - Enhance tool filtering ([#101](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/101))
 - Add core tools as a category ([#103](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/103))
+- set stateless=True for streaming server by default ([#104](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/104))
 
 ### Fixed
 

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -83,7 +83,7 @@ async def create_mcp_server(
 
 
 class MCPStarletteApp:
-    def __init__(self, mcp_server: Server, stateless: bool = False):
+    def __init__(self, mcp_server: Server, stateless: bool = True):
         self.mcp_server = mcp_server
         self.sse = SseServerTransport('/messages/')
         self.session_manager = StreamableHTTPSessionManager(
@@ -147,7 +147,7 @@ async def serve(
     profile: str = '',
     config_file_path: str = '',
     cli_tool_overrides: dict = None,
-    stateless: bool = False,
+    stateless: bool = True,
 ) -> None:
     mcp_server = await create_mcp_server(mode, profile, config_file_path, cli_tool_overrides)
     app_handler = MCPStarletteApp(mcp_server, stateless=stateless)


### PR DESCRIPTION
### Description
Previous versions have `stateless=False` by default. This could cause issues for users trying to deploy their MCP server remotely as stateful is not supported on all platforms. However, from use cases we have seen and other popular MCP servers, stateless MCP server is the standard. Therefore, this change will set `stateless=True` by default.

This could be breaking for existing users who do have a remote and stateful use case, but that should be a minimal subset of users if such users exist at all. We will highlight this change in 0.4.0 release notes.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).