### PR TITLE
feat: Add index-level access control with pattern-based filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,189 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an OpenSearch MCP (Model Context Protocol) Server implemented in Python. It provides a bridge between AI assistants and OpenSearch clusters, supporting both stdio and streaming transports (SSE/HTTP streaming).
+
+## Development Commands
+
+### Setup
+```bash
+# Create & activate virtual environment
+uv venv
+source .venv/bin/activate
+
+# Install dependencies
+uv sync
+```
+
+### Running the Server
+**Important**: Server commands must be run from the `src/` directory.
+
+```bash
+cd src
+
+# Run stdio server (default)
+uv run python -m mcp_server_opensearch
+
+# Run streaming server
+uv run python -m mcp_server_opensearch --transport stream
+
+# Run multi-cluster mode with config
+uv run python -m mcp_server_opensearch --mode multi --config ../config/dev-clusters.yml
+
+# Run with AWS profile
+uv run python -m mcp_server_opensearch --profile my-profile
+```
+
+### Testing
+```bash
+# Run all tests
+uv run pytest
+
+# Run with coverage
+uv run pytest --cov=mcp_server_opensearch
+
+# Run specific test file
+uv run pytest tests/test_tools.py
+
+# Run with verbose output
+uv run pytest -v
+```
+
+### Code Quality
+```bash
+# Format code (required before commits)
+uv run ruff format .
+
+# Check code quality
+uv run ruff check .
+
+# Type checking
+uv run mypy src/
+```
+
+### Dependency Management
+```bash
+# Add new package
+uv add <package-name>
+
+# Add development dependency
+uv add --dev <package-name>
+
+# Update dependencies after manual pyproject.toml changes
+uv lock
+uv sync
+
+# Update all dependencies to latest versions
+uv lock --upgrade
+uv sync
+```
+
+## Architecture
+
+### Core Components
+
+- **Server Layer** (`src/mcp_server_opensearch/`)
+  - `stdio_server.py`: Standard input/output transport
+  - `streaming_server.py`: SSE and HTTP streaming transport
+  - `clusters_information.py`: Multi-cluster configuration management
+  - `__main__.py`: Entry point with argument parsing
+
+- **OpenSearch Integration** (`src/opensearch/`)
+  - `client.py`: OpenSearch client initialization with authentication
+  - `helper.py`: Single REST call functions to OpenSearch API (one function = one API call)
+
+- **Tool System** (`src/tools/`)
+  - `tools.py`: Tool definitions and implementations using `TOOL_REGISTRY` dictionary
+  - `tool_params.py`: Pydantic models for tool arguments (all extend `baseToolArgs`)
+  - `tool_filter.py`: Tool filtering by name, category, or regex pattern
+  - `tool_generator.py`: Dynamic tool schema generation
+  - `config.py`: YAML configuration parsing for tool filters and customization
+  - `utils.py`: Tool compatibility checking based on OpenSearch version
+
+### Server Modes
+
+1. **Single Mode** (default)
+   - Connects to one OpenSearch cluster via environment variables
+   - Automatically filters tools based on OpenSearch version compatibility
+   - Tools do not require `opensearch_cluster_name` parameter
+
+2. **Multi Mode**
+   - Supports multiple OpenSearch clusters defined in YAML config
+   - All tools available regardless of version (compatibility checked at execution)
+   - All tools require `opensearch_cluster_name` parameter
+   - Tool filtering not supported
+
+### Authentication Flow
+
+Priority order: No Auth → IAM Role → Basic Auth → AWS Credentials
+
+### Tool Architecture
+
+**Key Design Principle**: Each helper function in `opensearch/helper.py` performs a single REST call to OpenSearch. This promotes:
+- Clear separation of concerns
+- Easy testing and maintenance
+- Reusable OpenSearch operations
+
+Tools in `tools/tools.py` orchestrate these helper functions and are registered in the `TOOL_REGISTRY` dictionary with:
+- `description`: Tool documentation
+- `input_schema`: Pydantic model JSON schema
+- `function`: Async tool implementation
+- `args_model`: Pydantic model class
+- Optional: `min_version`, `max_version` for version compatibility
+
+## Adding New Tools
+
+1. **Create Tool Arguments Model** in `src/tools/tool_params.py`:
+   ```python
+   class YourToolArgs(baseToolArgs):
+       """Arguments for YourTool."""
+       param1: str = Field(description="Description")
+   ```
+
+2. **Add Helper Function** in `src/opensearch/helper.py`:
+   ```python
+   def your_helper_function(args: YourToolArgs) -> json:
+       """Perform single REST call to OpenSearch."""
+       from .client import initialize_client
+       client = initialize_client(args)
+       response = client.your_api_call()
+       return response
+   ```
+
+3. **Implement Tool Function** in `src/tools/tools.py`:
+   ```python
+   async def your_tool_function(args: YourToolArgs) -> list[dict]:
+       try:
+           check_tool_compatibility('YourToolName', args)
+           result = your_helper_function(args)
+           return [{"type": "text", "text": json.dumps(result, indent=2)}]
+       except Exception as e:
+           return [{"type": "text", "text": f"Error: {str(e)}"}]
+   ```
+
+4. **Register Tool** in `TOOL_REGISTRY` dict in `src/tools/tools.py`:
+   ```python
+   TOOL_REGISTRY = {
+       "YourToolName": {
+           "description": "What this tool does",
+           "input_schema": YourToolArgs.model_json_schema(),
+           "function": your_tool_function,
+           "args_model": YourToolArgs,
+       }
+   }
+   ```
+
+## Important Notes
+
+- By default, only **core tools** are enabled (tool filtering only works in single mode)
+- Tool filtering supports: exact names, categories, regex patterns, and write operation controls
+- Tool customization (display names, descriptions) works in both single and multi modes
+- All commands must be run from the `src/` directory
+- The server supports both stdio and streaming (SSE/HTTP) transports
+- Version compatibility is checked automatically in single mode, at runtime in multi mode
+- Ruff line length is set to 99 characters
+- Pydocstyle convention: Google
+- Quote style: single quotes

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Built-in tools for common OpenSearch operations
 - Easy integration with Claude Desktop and LangChain
 - Secure authentication using basic auth or IAM roles
+- Index-level access control with pattern-based filtering
 
 ## Installing opensearch-mcp-server-py
 

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,6 +1,33 @@
 version: "1.0"
 description: "Unified OpenSearch MCP Server Configuration"
 
+# ==============================================================================
+# Index Security Configuration (supported in both Single and Multi Mode)
+# ==============================================================================
+# Control which indexes can be accessed by the MCP server.
+# This provides an additional security layer on top of OpenSearch permissions.
+#
+# Priority: Denied patterns are checked first. If an index matches a denied pattern,
+# access is blocked regardless of allowed patterns.
+#
+# Pattern types supported:
+# - Wildcards: Use * and ? for simple patterns (e.g., "logs-*", "test-?-index")
+# - Regex: Prefix with "regex:" for complex patterns (e.g., "regex:^logs-\d{4}-\d{2}$")
+#
+# Note: If no patterns are configured, all indexes are accessible.
+#
+# index_security:
+#   allowed_index_patterns:
+#     - "logs-*"              # Allow all indexes starting with "logs-"
+#     - "metrics-*"           # Allow all indexes starting with "metrics-"
+#     - "app-production-*"    # Allow all production app indexes
+#     - "regex:^test-\d+$"    # Allow indexes like "test-123", "test-456"
+#   denied_index_patterns:
+#     - "sensitive-*"         # Block all indexes starting with "sensitive-"
+#     - ".security*"          # Block security-related indexes
+#     - "*-internal"          # Block all indexes ending with "-internal"
+#     - "regex:.*-dev-.*"     # Block indexes containing "-dev-"
+
 # Cluster configurations (used in Multi Mode)
 clusters:
   local-cluster:

--- a/src/mcp_server_opensearch/stdio_server.py
+++ b/src/mcp_server_opensearch/stdio_server.py
@@ -10,6 +10,7 @@ from tools.tool_filter import get_tools
 from tools.tool_generator import generate_tools_from_openapi
 from tools.tools import TOOL_REGISTRY
 from tools.config import apply_custom_tool_config
+from tools.index_filter import load_index_filter_config
 
 
 # --- Server setup ---
@@ -29,6 +30,13 @@ async def serve(
     # Load clusters from YAML file
     if mode == 'multi':
         load_clusters_from_yaml(config_file_path)
+
+    # Load index filter configuration
+    index_filter = load_index_filter_config(config_file_path)
+    logging.info(
+        f'Index filter configured - Allowed patterns: {index_filter.allowed_index_patterns}, '
+        f'Denied patterns: {index_filter.denied_index_patterns}'
+    )
 
     # Call tool generator
     await generate_tools_from_openapi()

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -19,6 +19,7 @@ from starlette.types import Scope, Receive, Send
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from tools.tools import TOOL_REGISTRY
 from tools.config import apply_custom_tool_config
+from tools.index_filter import load_index_filter_config
 
 
 async def create_mcp_server(
@@ -36,6 +37,13 @@ async def create_mcp_server(
     # Load clusters from YAML file
     if mode == 'multi':
         load_clusters_from_yaml(config_file_path)
+
+    # Load index filter configuration
+    index_filter = load_index_filter_config(config_file_path)
+    logging.info(
+        f'Index filter configured - Allowed patterns: {index_filter.allowed_index_patterns}, '
+        f'Denied patterns: {index_filter.denied_index_patterns}'
+    )
 
     server = Server('opensearch-mcp-server')
     # Call tool generator

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -16,7 +16,12 @@ def list_indices(args: ListIndicesArgs) -> json:
     from .client import initialize_client
 
     client = initialize_client(args)
-    response = client.cat.indices(format='json')
+    # Pass index parameter to OpenSearch if provided
+    # Supports comma-separated list and wildcards
+    if args.index:
+        response = client.cat.indices(index=args.index, format='json')
+    else:
+        response = client.cat.indices(format='json')
     return response
 
 

--- a/src/tools/index_filter.py
+++ b/src/tools/index_filter.py
@@ -1,0 +1,206 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import fnmatch
+import json
+import logging
+import os
+import re
+import yaml
+from typing import Dict, List, Optional
+
+
+class IndexFilterConfig:
+    """Configuration for index filtering."""
+
+    def __init__(
+        self,
+        allowed_index_patterns: Optional[List[str]] = None,
+        denied_index_patterns: Optional[List[str]] = None,
+    ):
+        """
+        Initialize index filter configuration.
+
+        :param allowed_index_patterns: List of allowed index patterns (wildcards and regex)
+        :param denied_index_patterns: List of denied index patterns (wildcards and regex)
+        """
+        self.allowed_index_patterns = allowed_index_patterns or []
+        self.denied_index_patterns = denied_index_patterns or []
+
+    def is_index_allowed(self, index_name: str) -> tuple[bool, Optional[str]]:
+        """
+        Check if an index is allowed based on configured patterns.
+
+        Priority: Denied patterns are checked first. If no patterns are configured,
+        all indexes are allowed.
+
+        :param index_name: The index name to check
+        :return: Tuple of (is_allowed, reason)
+        """
+        if not index_name:
+            return True, None
+
+        # Handle comma-separated index names or wildcards in a single string
+        # Some tools may pass multiple indexes like "index1,index2"
+        index_names = [name.strip() for name in index_name.split(',')]
+
+        for single_index in index_names:
+            allowed, reason = self._check_single_index(single_index)
+            if not allowed:
+                return False, reason
+
+        return True, None
+
+    def _check_single_index(self, index_name: str) -> tuple[bool, Optional[str]]:
+        """Check a single index name against patterns."""
+        # If index contains wildcards, we cannot validate it at this stage
+        # Allow it through - OpenSearch will handle the expansion
+        if '*' in index_name or '?' in index_name:
+            logging.debug(
+                f'Index pattern "{index_name}" contains wildcards, allowing through for OpenSearch expansion'
+            )
+            return True, None
+
+        # Check denied patterns first (higher priority)
+        if self.denied_index_patterns:
+            for pattern in self.denied_index_patterns:
+                if self._matches_pattern(index_name, pattern):
+                    reason = f'Index "{index_name}" matches denied pattern: {pattern}'
+                    logging.warning(reason)
+                    return False, reason
+
+        # If allowed patterns are configured, index must match at least one
+        if self.allowed_index_patterns:
+            for pattern in self.allowed_index_patterns:
+                if self._matches_pattern(index_name, pattern):
+                    logging.debug(f'Index "{index_name}" matches allowed pattern: {pattern}')
+                    return True, None
+
+            reason = f'Index "{index_name}" does not match any allowed patterns'
+            logging.warning(reason)
+            return False, reason
+
+        # No patterns configured, allow all indexes
+        return True, None
+
+    def _matches_pattern(self, index_name: str, pattern: str) -> bool:
+        """
+        Check if an index name matches a pattern.
+
+        Supports:
+        - Wildcards: * and ? (e.g., "logs-*", "test-?-index")
+        - Regex patterns: patterns starting with "regex:" (e.g., "regex:^logs-\\d{4}-\\d{2}$")
+
+        :param index_name: The index name to check
+        :param pattern: The pattern to match against
+        :return: True if matches, False otherwise
+        """
+        # Regex pattern (starts with "regex:")
+        if pattern.startswith('regex:'):
+            regex_pattern = pattern[6:]  # Remove "regex:" prefix
+            try:
+                return bool(re.match(regex_pattern, index_name))
+            except re.error as e:
+                logging.error(f'Invalid regex pattern "{regex_pattern}": {e}')
+                return False
+
+        # Wildcard pattern
+        return fnmatch.fnmatch(index_name, pattern)
+
+
+# Global index filter configuration
+_index_filter_config: Optional[IndexFilterConfig] = None
+
+
+def load_index_filter_config(config_file_path: str = '') -> IndexFilterConfig:
+    """
+    Load index filter configuration from YAML file or environment variables.
+
+    Priority order:
+    1. YAML configuration file (if provided)
+    2. Environment variables
+
+    :param config_file_path: Path to YAML configuration file
+    :return: IndexFilterConfig instance
+    """
+    global _index_filter_config
+
+    allowed_patterns = []
+    denied_patterns = []
+
+    # Load from YAML file first
+    if config_file_path:
+        try:
+            with open(config_file_path, 'r') as f:
+                config = yaml.safe_load(f)
+                if config and 'index_security' in config:
+                    security_config = config['index_security']
+                    allowed_patterns = security_config.get('allowed_index_patterns', [])
+                    denied_patterns = security_config.get('denied_index_patterns', [])
+                    logging.info(f'Loaded index filter config from {config_file_path}')
+        except Exception as e:
+            logging.error(f'Error loading index filter config from file: {e}')
+
+    # Load from environment variables (only if not loaded from file)
+    if not allowed_patterns and not denied_patterns:
+        allowed_env = os.getenv('OPENSEARCH_ALLOWED_INDEX_PATTERNS', '')
+        denied_env = os.getenv('OPENSEARCH_DENIED_INDEX_PATTERNS', '')
+
+        if allowed_env:
+            try:
+                # Support both JSON array and comma-separated list
+                if allowed_env.strip().startswith('['):
+                    allowed_patterns = json.loads(allowed_env)
+                else:
+                    allowed_patterns = [p.strip() for p in allowed_env.split(',') if p.strip()]
+                logging.info(f'Loaded allowed index patterns from environment: {allowed_patterns}')
+            except json.JSONDecodeError as e:
+                logging.error(f'Error parsing OPENSEARCH_ALLOWED_INDEX_PATTERNS: {e}')
+
+        if denied_env:
+            try:
+                # Support both JSON array and comma-separated list
+                if denied_env.strip().startswith('['):
+                    denied_patterns = json.loads(denied_env)
+                else:
+                    denied_patterns = [p.strip() for p in denied_env.split(',') if p.strip()]
+                logging.info(f'Loaded denied index patterns from environment: {denied_patterns}')
+            except json.JSONDecodeError as e:
+                logging.error(f'Error parsing OPENSEARCH_DENIED_INDEX_PATTERNS: {e}')
+
+    _index_filter_config = IndexFilterConfig(
+        allowed_index_patterns=allowed_patterns, denied_index_patterns=denied_patterns
+    )
+
+    return _index_filter_config
+
+
+def get_index_filter_config() -> IndexFilterConfig:
+    """
+    Get the current index filter configuration.
+
+    :return: IndexFilterConfig instance
+    """
+    global _index_filter_config
+    if _index_filter_config is None:
+        _index_filter_config = load_index_filter_config()
+    return _index_filter_config
+
+
+def validate_index_access(index_name: str) -> None:
+    """
+    Validate if an index can be accessed based on configured patterns.
+
+    Raises an exception if access is denied.
+
+    :param index_name: The index name to validate
+    :raises Exception: If index access is denied
+    """
+    if not index_name:
+        return
+
+    config = get_index_filter_config()
+    is_allowed, reason = config.is_index_allowed(index_name)
+
+    if not is_allowed:
+        raise Exception(f'Index access denied: {reason}')

--- a/src/tools/tool_generator.py
+++ b/src/tools/tool_generator.py
@@ -8,6 +8,7 @@ import ssl
 import os
 from .tool_params import baseToolArgs
 from .tools import TOOL_REGISTRY, check_tool_compatibility
+from .index_filter import validate_index_access
 from mcp.types import TextContent
 from pydantic import BaseModel, create_model
 from typing import Any, Dict, List
@@ -247,6 +248,11 @@ def generate_tool_from_group(base_name: str, endpoints: List[Dict]) -> Dict[str,
                     )
                 ]
             check_tool_compatibility(tool_name, args)
+
+            # Validate index access if index parameter is present
+            if 'index' in params_dict and params_dict['index']:
+                validate_index_access(params_dict['index'])
+
             # Process body and select endpoint
             body = process_body(params_dict.pop('body', None), tool_name)
             selected_endpoint = select_endpoint(endpoints, params_dict)

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -20,6 +20,7 @@ from .tool_params import (
     baseToolArgs,
 )
 from .utils import is_tool_compatible
+from .index_filter import validate_index_access
 from opensearch.helper import (
     get_allocation,
     get_cluster_state,
@@ -68,6 +69,10 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
     try:
         check_tool_compatibility('ListIndexTool', args)
 
+        # Validate index access if index parameter is provided
+        if args.index:
+            validate_index_access(args.index)
+
         # If index is provided, always return detailed information for that specific index
         if args.index:
             index_info = get_index(args)
@@ -99,6 +104,7 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
 async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
     try:
         check_tool_compatibility('IndexMappingTool', args)
+        validate_index_access(args.index)
         mapping = get_index_mapping(args)
         formatted_mapping = json.dumps(mapping, indent=2)
 
@@ -110,6 +116,7 @@ async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
 async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
     try:
         check_tool_compatibility('SearchIndexTool', args)
+        validate_index_access(args.index)
         result = search_index(args)
         formatted_result = json.dumps(result, indent=2)
 
@@ -126,6 +133,7 @@ async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
 async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
     try:
         check_tool_compatibility('GetShardsTool', args)
+        validate_index_access(args.index)
         result = get_shards(args)
 
         if isinstance(result, dict) and 'error' in result:
@@ -150,15 +158,17 @@ async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
 
 async def get_cluster_state_tool(args: GetClusterStateArgs) -> list[dict]:
     """Tool to get the current state of the cluster.
-    
+
     Args:
         args: GetClusterStateArgs containing optional metric and index filters
-        
+
     Returns:
         list[dict]: Cluster state information in MCP format
     """
     try:
         check_tool_compatibility('GetClusterStateTool', args)
+        if args.index:
+            validate_index_access(args.index)
         result = get_cluster_state(args)
         
         # Format the response for better readability
@@ -178,15 +188,17 @@ async def get_cluster_state_tool(args: GetClusterStateArgs) -> list[dict]:
 
 async def get_segments_tool(args: GetSegmentsArgs) -> list[dict]:
     """Tool to get information about Lucene segments in indices.
-    
+
     Args:
         args: GetSegmentsArgs containing optional index filter
-        
+
     Returns:
         list[dict]: Segment information in MCP format
     """
     try:
         check_tool_compatibility('GetSegmentsTool', args)
+        if args.index:
+            validate_index_access(args.index)
         result = get_segments(args)
         
         if isinstance(result, dict) and 'error' in result:
@@ -268,15 +280,16 @@ async def cat_nodes_tool(args: CatNodesArgs) -> list[dict]:
 
 async def get_index_info_tool(args: GetIndexInfoArgs) -> list[dict]:
     """Tool to get detailed information about an index including mappings, settings, and aliases.
-    
+
     Args:
         args: GetIndexInfoArgs containing the index name
-        
+
     Returns:
         list[dict]: Index information in MCP format
     """
     try:
         check_tool_compatibility('GetIndexInfoTool', args)
+        validate_index_access(args.index)
         result = get_index_info(args)
         
         # Format the response for better readability
@@ -292,15 +305,16 @@ async def get_index_info_tool(args: GetIndexInfoArgs) -> list[dict]:
 
 async def get_index_stats_tool(args: GetIndexStatsArgs) -> list[dict]:
     """Tool to get statistics about an index.
-    
+
     Args:
         args: GetIndexStatsArgs containing the index name and optional metric filter
-        
+
     Returns:
         list[dict]: Index statistics in MCP format
     """
     try:
         check_tool_compatibility('GetIndexStatsTool', args)
+        validate_index_access(args.index)
         result = get_index_stats(args)
         
         # Format the response for better readability

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -81,7 +81,15 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
                 {'type': 'text', 'text': f'Index information for {args.index}:\n{formatted_info}'}
             ]
 
-        # Otherwise, list all indices
+        # When no specific index is provided, use allowed index patterns if configured
+        from .index_filter import get_index_filter_config
+        filter_config = get_index_filter_config()
+        if filter_config.allowed_index_patterns:
+            # Set args.index to comma-separated list of allowed patterns
+            # This leverages OpenSearch's native pattern matching
+            args.index = ','.join(filter_config.allowed_index_patterns)
+
+        # List indices (filtered by allowed patterns if configured)
         indices = list_indices(args)
 
         # If include_detail is False, return only pure list of index names

--- a/tests/tools/test_index_filter.py
+++ b/tests/tools/test_index_filter.py
@@ -1,0 +1,333 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import tempfile
+import yaml
+from tools.index_filter import (
+    IndexFilterConfig,
+    load_index_filter_config,
+    validate_index_access,
+)
+
+
+class TestIndexFilterConfig:
+    """Test IndexFilterConfig class."""
+
+    def test_no_patterns_allows_all(self):
+        """Test that no patterns configured allows all indexes."""
+        config = IndexFilterConfig()
+        is_allowed, reason = config.is_index_allowed('any-index')
+        assert is_allowed is True
+        assert reason is None
+
+    def test_wildcard_allowed_pattern(self):
+        """Test wildcard pattern in allowed list."""
+        config = IndexFilterConfig(allowed_index_patterns=['logs-*', 'metrics-*'])
+
+        # Should allow matching indexes
+        is_allowed, _ = config.is_index_allowed('logs-2024-01')
+        assert is_allowed is True
+
+        is_allowed, _ = config.is_index_allowed('metrics-cpu')
+        assert is_allowed is True
+
+        # Should deny non-matching indexes
+        is_allowed, reason = config.is_index_allowed('other-index')
+        assert is_allowed is False
+        assert 'does not match any allowed patterns' in reason
+
+    def test_wildcard_denied_pattern(self):
+        """Test wildcard pattern in denied list."""
+        config = IndexFilterConfig(denied_index_patterns=['sensitive-*', '.security*'])
+
+        # Should deny matching indexes
+        is_allowed, reason = config.is_index_allowed('sensitive-data')
+        assert is_allowed is False
+        assert 'matches denied pattern' in reason
+
+        is_allowed, reason = config.is_index_allowed('.security-index')
+        assert is_allowed is False
+
+        # Should allow non-matching indexes (no allowed patterns)
+        is_allowed, _ = config.is_index_allowed('public-index')
+        assert is_allowed is True
+
+    def test_denied_takes_priority_over_allowed(self):
+        """Test that denied patterns have higher priority than allowed."""
+        config = IndexFilterConfig(
+            allowed_index_patterns=['logs-*'], denied_index_patterns=['logs-sensitive-*']
+        )
+
+        # Should deny even though it matches allowed pattern
+        is_allowed, reason = config.is_index_allowed('logs-sensitive-data')
+        assert is_allowed is False
+        assert 'matches denied pattern' in reason
+
+        # Should allow if matches allowed and not denied
+        is_allowed, _ = config.is_index_allowed('logs-public-data')
+        assert is_allowed is True
+
+    def test_regex_pattern_allowed(self):
+        """Test regex pattern in allowed list."""
+        config = IndexFilterConfig(allowed_index_patterns=[r'regex:^logs-\d{4}-\d{2}$'])
+
+        # Should allow matching indexes
+        is_allowed, _ = config.is_index_allowed('logs-2024-01')
+        assert is_allowed is True
+
+        # Should deny non-matching indexes
+        is_allowed, reason = config.is_index_allowed('logs-202-01')
+        assert is_allowed is False
+
+        is_allowed, reason = config.is_index_allowed('logs-2024-1')
+        assert is_allowed is False
+
+    def test_regex_pattern_denied(self):
+        """Test regex pattern in denied list."""
+        config = IndexFilterConfig(denied_index_patterns=[r'regex:.*-dev-.*'])
+
+        # Should deny matching indexes
+        is_allowed, reason = config.is_index_allowed('app-dev-testing')
+        assert is_allowed is False
+        assert 'matches denied pattern' in reason
+
+        # Should allow non-matching indexes
+        is_allowed, _ = config.is_index_allowed('app-prod-testing')
+        assert is_allowed is True
+
+    def test_comma_separated_indexes(self):
+        """Test handling of comma-separated index names."""
+        config = IndexFilterConfig(
+            allowed_index_patterns=['logs-*'], denied_index_patterns=['logs-sensitive-*']
+        )
+
+        # All allowed
+        is_allowed, _ = config.is_index_allowed('logs-public,logs-app')
+        assert is_allowed is True
+
+        # One denied
+        is_allowed, reason = config.is_index_allowed('logs-public,logs-sensitive-data')
+        assert is_allowed is False
+        assert 'logs-sensitive-data' in reason
+
+    def test_wildcard_in_index_name_bypasses_validation(self):
+        """Test that index names with wildcards bypass validation."""
+        config = IndexFilterConfig(allowed_index_patterns=['logs-*'])
+
+        # Wildcard in index name should be allowed through
+        # (OpenSearch will expand it)
+        is_allowed, _ = config.is_index_allowed('metrics-*')
+        assert is_allowed is True
+
+        is_allowed, _ = config.is_index_allowed('test-?-index')
+        assert is_allowed is True
+
+    def test_question_mark_wildcard(self):
+        """Test question mark wildcard pattern."""
+        config = IndexFilterConfig(allowed_index_patterns=['test-?-index'])
+
+        # Should allow single character match
+        is_allowed, _ = config.is_index_allowed('test-1-index')
+        assert is_allowed is True
+
+        is_allowed, _ = config.is_index_allowed('test-a-index')
+        assert is_allowed is True
+
+        # Should deny multi-character or no match
+        is_allowed, _ = config.is_index_allowed('test-12-index')
+        assert is_allowed is False
+
+        is_allowed, _ = config.is_index_allowed('test--index')
+        assert is_allowed is False
+
+    def test_empty_index_name(self):
+        """Test handling of empty index name."""
+        config = IndexFilterConfig(allowed_index_patterns=['logs-*'])
+
+        # Empty index name should be allowed
+        is_allowed, _ = config.is_index_allowed('')
+        assert is_allowed is True
+
+        is_allowed, _ = config.is_index_allowed(None)
+        assert is_allowed is True
+
+    def test_multiple_patterns(self):
+        """Test multiple allowed and denied patterns."""
+        config = IndexFilterConfig(
+            allowed_index_patterns=['logs-*', 'metrics-*', 'app-*'],
+            denied_index_patterns=['*-test', '*-dev', 'temp-*'],
+        )
+
+        # Should allow matching allowed and not denied
+        is_allowed, _ = config.is_index_allowed('logs-production')
+        assert is_allowed is True
+
+        # Should deny matching denied
+        is_allowed, _ = config.is_index_allowed('logs-test')
+        assert is_allowed is False
+
+        is_allowed, _ = config.is_index_allowed('temp-metrics')
+        assert is_allowed is False
+
+        # Should deny not matching allowed
+        is_allowed, _ = config.is_index_allowed('other-index')
+        assert is_allowed is False
+
+
+class TestLoadIndexFilterConfig:
+    """Test loading index filter configuration."""
+
+    def test_load_from_yaml_file(self):
+        """Test loading configuration from YAML file."""
+        config_data = {
+            'index_security': {
+                'allowed_index_patterns': ['logs-*', 'metrics-*'],
+                'denied_index_patterns': ['sensitive-*'],
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            config = load_index_filter_config(config_file)
+            assert config.allowed_index_patterns == ['logs-*', 'metrics-*']
+            assert config.denied_index_patterns == ['sensitive-*']
+        finally:
+            os.unlink(config_file)
+
+    def test_load_from_environment_json_array(self):
+        """Test loading configuration from environment variables (JSON array format)."""
+        os.environ['OPENSEARCH_ALLOWED_INDEX_PATTERNS'] = '["logs-*", "metrics-*"]'
+        os.environ['OPENSEARCH_DENIED_INDEX_PATTERNS'] = '["sensitive-*"]'
+
+        try:
+            config = load_index_filter_config()
+            assert config.allowed_index_patterns == ['logs-*', 'metrics-*']
+            assert config.denied_index_patterns == ['sensitive-*']
+        finally:
+            del os.environ['OPENSEARCH_ALLOWED_INDEX_PATTERNS']
+            del os.environ['OPENSEARCH_DENIED_INDEX_PATTERNS']
+
+    def test_load_from_environment_comma_separated(self):
+        """Test loading configuration from environment variables (comma-separated format)."""
+        os.environ['OPENSEARCH_ALLOWED_INDEX_PATTERNS'] = 'logs-*, metrics-*, app-*'
+        os.environ['OPENSEARCH_DENIED_INDEX_PATTERNS'] = 'sensitive-*, temp-*'
+
+        try:
+            config = load_index_filter_config()
+            assert config.allowed_index_patterns == ['logs-*', 'metrics-*', 'app-*']
+            assert config.denied_index_patterns == ['sensitive-*', 'temp-*']
+        finally:
+            del os.environ['OPENSEARCH_ALLOWED_INDEX_PATTERNS']
+            del os.environ['OPENSEARCH_DENIED_INDEX_PATTERNS']
+
+    def test_yaml_takes_priority_over_env(self):
+        """Test that YAML configuration takes priority over environment variables."""
+        config_data = {
+            'index_security': {
+                'allowed_index_patterns': ['from-yaml-*'],
+                'denied_index_patterns': ['yaml-denied-*'],
+            }
+        }
+
+        os.environ['OPENSEARCH_ALLOWED_INDEX_PATTERNS'] = '["from-env-*"]'
+        os.environ['OPENSEARCH_DENIED_INDEX_PATTERNS'] = '["env-denied-*"]'
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            config = load_index_filter_config(config_file)
+            # Should use YAML config, not env vars
+            assert config.allowed_index_patterns == ['from-yaml-*']
+            assert config.denied_index_patterns == ['yaml-denied-*']
+        finally:
+            os.unlink(config_file)
+            del os.environ['OPENSEARCH_ALLOWED_INDEX_PATTERNS']
+            del os.environ['OPENSEARCH_DENIED_INDEX_PATTERNS']
+
+    def test_load_empty_config(self):
+        """Test loading with no configuration."""
+        config = load_index_filter_config()
+        assert config.allowed_index_patterns == []
+        assert config.denied_index_patterns == []
+
+    def test_load_missing_index_security_section(self):
+        """Test loading YAML without index_security section."""
+        config_data = {'clusters': {'cluster1': {'opensearch_url': 'http://localhost:9200'}}}
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            config = load_index_filter_config(config_file)
+            assert config.allowed_index_patterns == []
+            assert config.denied_index_patterns == []
+        finally:
+            os.unlink(config_file)
+
+
+class TestValidateIndexAccess:
+    """Test validate_index_access function."""
+
+    def test_validate_allowed_index(self):
+        """Test validation of allowed index."""
+        config_data = {'index_security': {'allowed_index_patterns': ['logs-*']}}
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            # Load config
+            load_index_filter_config(config_file)
+
+            # Should not raise exception
+            validate_index_access('logs-2024-01')
+        finally:
+            os.unlink(config_file)
+
+    def test_validate_denied_index_raises_exception(self):
+        """Test validation of denied index raises exception."""
+        config_data = {'index_security': {'denied_index_patterns': ['sensitive-*']}}
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            # Load config
+            load_index_filter_config(config_file)
+
+            # Should raise exception
+            with pytest.raises(Exception) as exc_info:
+                validate_index_access('sensitive-data')
+
+            assert 'Index access denied' in str(exc_info.value)
+            assert 'sensitive-data' in str(exc_info.value)
+        finally:
+            os.unlink(config_file)
+
+    def test_validate_empty_index(self):
+        """Test validation of empty index."""
+        config_data = {'index_security': {'allowed_index_patterns': ['logs-*']}}
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            # Load config
+            load_index_filter_config(config_file)
+
+            # Empty index should not raise exception
+            validate_index_access('')
+            validate_index_access(None)
+        finally:
+            os.unlink(config_file)

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -33,6 +33,12 @@ class TestTools:
         )
         self.init_client_patcher.start()
 
+        # Reset the global index filter config to allow all indices (no filtering)
+        import tools.index_filter
+        tools.index_filter._index_filter_config = tools.index_filter.IndexFilterConfig(
+            allowed_index_patterns=[], denied_index_patterns=[]
+        )
+
         # Clear any existing imports to ensure fresh imports
         import sys
 

--- a/todos/ADD-DOCKER-AND-DOCKER-COMPOSE-SUPPORT.md
+++ b/todos/ADD-DOCKER-AND-DOCKER-COMPOSE-SUPPORT.md
@@ -1,0 +1,46 @@
+# Add Docker and Docker Compose Support
+
+**Priority**: Medium
+**Estimated Time**: 1-2 hours
+**Context**: Enable containerized deployment of the OpenSearch MCP Server with minimal Docker setup.
+
+---
+
+## Stage 1: Create Dockerfile
+**Goal**: Build a containerized version of the MCP server
+
+- [ ] Create `Dockerfile` in project root
+- [ ] Use Python base image (python:3.11-slim)
+- [ ] Install `uv` package manager
+- [ ] Copy `pyproject.toml` and `uv.lock`
+- [ ] Copy `src/` directory
+- [ ] Set working directory to `/app/src`
+- [ ] Set default command to run stdio server
+
+**Notes**: Commands must run from `src/` directory. Support both stdio and streaming modes.
+
+---
+
+## Stage 2: Create Docker Compose and Environment Files
+**Goal**: Provide docker-compose.yml and environment configuration
+
+- [ ] Create `docker-compose.yml` in project root
+- [ ] Define `mcp-server` service with build context
+- [ ] Configure environment variables via `.env` file support
+- [ ] Add volume mount for `config/` directory (multi-cluster mode)
+- [ ] Create `.env.example` with all required variables:
+  - OpenSearch connection (OPENSEARCH_URL, USERNAME, PASSWORD)
+  - AWS credentials and region
+  - IAM authentication settings
+  - Index security patterns
+
+**Notes**: Support both single and multi-cluster modes.
+
+---
+
+## Completion Checklist
+
+- [ ] `Dockerfile` created
+- [ ] `docker-compose.yml` created
+- [ ] `.env.example` created
+- [ ] Docker image builds successfully


### PR DESCRIPTION
## Summary

  Implements index-level access control to restrict which OpenSearch indexes can be accessed through the MCP server. This
  provides an additional security layer on top of OpenSearch's built-in permissions, allowing administrators to enforce access
   policies at the MCP server level.

  ## Motivation

  Users need the ability to limit MCP server access to specific OpenSearch indexes without modifying underlying OpenSearch
  security settings. This is particularly important for:
  - Multi-tenant environments where different AI agents should access different index sets
  - Production environments where sensitive indexes must be protected
  - Development/testing scenarios where access to production data needs to be restricted

  ## Changes

  ### Core Implementation
  - **New Module**: `src/tools/index_filter.py` - Pattern-based index filtering with support for:
    - Wildcard patterns (`logs-*`, `test-?-index`)
    - Regex patterns (`regex:^logs-\d{4}-\d{2}$`)
    - Allowed patterns (whitelist) and denied patterns (blacklist)
    - Priority-based validation (denied patterns checked first)

  ### Integration
  - Integrated validation into both `stdio_server.py` and `streaming_server.py`
  - Added `validate_index_access()` calls to all tools with index parameters:
    - `list_indices_tool`, `get_index_mapping_tool`, `search_index_tool`
    - `get_shards_tool`, `get_cluster_state_tool`, `get_segments_tool`
    - `get_index_info_tool`, `get_index_stats_tool`
    - Dynamically generated tools (Count, Explain, Msearch)
  - Special handling: `list_indices` without index parameter now uses allowed patterns to filter results via OpenSearch API

  ### Configuration
  - **YAML Configuration**:
    ```yaml
    index_security:
      allowed_index_patterns:
        - "logs-*"
        - "metrics-*"
      denied_index_patterns:
        - "sensitive-*"
        - ".security*"

  - Environment Variables:
  export OPENSEARCH_ALLOWED_INDEX_PATTERNS='["logs-*", "metrics-*"]'
  export OPENSEARCH_DENIED_INDEX_PATTERNS='["sensitive-*"]'