### PR TITLE
feat: Add pagination support to SearchIndexTool and GetSegmentsTool to prevent token overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The following tools are available but disabled by default. To enable them, see t
   - `opensearch_url` (optional): The OpenSearch cluster URL to connect to
   - `index` (required): The name of the index to search in
   - `query` (required): The search query in OpenSearch Query DSL format
+  - `size` (optional): Maximum number of hits to return (default: 10, max: 100). Limits response size to prevent token overflow
+  - `from` (optional): Starting offset for pagination (default: 0). Use with size for pagination
 
 - **GetShardsTool**
   - `opensearch_url` (optional): The OpenSearch cluster URL to connect to
@@ -115,6 +117,7 @@ The following tools are available but disabled by default. To enable them, see t
 
   - `opensearch_url` (optional): The OpenSearch cluster URL to connect to
   - `index` (optional): Limit the information returned to the specified indices. If not provided, returns segments for all indices
+  - `limit` (optional): Maximum number of segments to return (default: 1000). Limits response size to prevent token overflow
 
 - **CatNodesTool**
 

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -31,6 +31,21 @@ class GetIndexMappingArgs(baseToolArgs):
 class SearchIndexArgs(baseToolArgs):
     index: str = Field(description='The name of the index to search in')
     query: Any = Field(description='The search query in OpenSearch query DSL format')
+    size: Optional[int] = Field(
+        default=10,
+        description='Maximum number of hits to return (default: 10, max: 100). Limits response size to prevent token overflow. Values exceeding 100 will be capped at 100.',
+        ge=1,
+    )
+    from_: Optional[int] = Field(
+        default=0,
+        description='Starting offset for pagination (default: 0). Use with size for pagination.',
+        alias='from',
+        ge=0,
+        serialization_alias='from',
+    )
+
+    class Config:
+        populate_by_name = True
 
 
 class GetShardsArgs(baseToolArgs):
@@ -65,12 +80,17 @@ class GetClusterStateArgs(baseToolArgs):
 
 class GetSegmentsArgs(baseToolArgs):
     """Arguments for the GetSegmentsTool."""
-    
+
     index: Optional[str] = Field(
-        default=None, 
+        default=None,
         description='Limit the information returned to the specified indices. If not provided, returns segments for all indices.'
     )
-    
+    limit: Optional[int] = Field(
+        default=1000,
+        description='Maximum number of segments to return (default: 1000). Limits response size to prevent token overflow.',
+        ge=1,
+    )
+
     class Config:
         json_schema_extra = {
             "examples": [

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -499,7 +499,7 @@ TOOL_REGISTRY = {
     },
     'SearchIndexTool': {
         'display_name': 'SearchIndexTool',
-        'description': 'Searches an index using a query written in query domain-specific language (DSL) in OpenSearch',
+        'description': 'Searches an index using a query written in query domain-specific language (DSL) in OpenSearch. Supports pagination with size (default: 10, max: 100) and from parameters to limit response size and prevent token overflow.',
         'input_schema': SearchIndexArgs.model_json_schema(),
         'function': search_index_tool,
         'args_model': SearchIndexArgs,
@@ -524,7 +524,7 @@ TOOL_REGISTRY = {
     },
     'GetSegmentsTool': {
         'display_name': 'GetSegmentsTool',
-        'description': 'Gets information about Lucene segments in indices, including memory usage, document counts, and segment sizes. Can be filtered by specific indices.',
+        'description': 'Gets information about Lucene segments in indices, including memory usage, document counts, and segment sizes. Can be filtered by specific indices. Supports limit parameter (default: 1000) to prevent token overflow.',
         'input_schema': GetSegmentsArgs.model_json_schema(),
         'function': get_segments_tool,
         'args_model': GetSegmentsArgs,


### PR DESCRIPTION
### Description
  This change adds pagination support to SearchIndexTool and GetSegmentsTool to prevent token overflow errors when MCP tool responses exceed the 25,000 token limit.

  **SearchIndexTool changes:**
  - Added `size` parameter (default: 10, max: 100) to limit number of search results returned
  - Added `from` parameter (default: 0) to support offset-based pagination
  - Automatic capping at 100 results to prevent token overflow
  - 7 new comprehensive tests covering pagination scenarios

  **GetSegmentsTool changes:**
  - Added `limit` parameter (default: 1000) to cap number of segments returned
  - Prevents token overflow for clusters with many segments
  - 3 new tests covering limit functionality

  **Additional improvements:**
  - Updated README.md with new pagination parameters
  - Updated tool descriptions in TOOL_REGISTRY
  - All 50 tests passing with TDD approach (wrote failing tests first, then implemented features)
  - Maintains backward compatibility with default values

  ### Issues Resolved
  Fixes token overflow issues where SearchIndexTool and GetSegmentsTool responses exceed the 25,000 token MCP limit, causing errors like: `MCP tool 'SearchIndexTool' response (35969 tokens) exceeds maximum
  allowed tokens (25000)`.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
