### PR TITLE
Fix IAM role based auth

### DIFF
--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -455,7 +455,12 @@ def _create_opensearch_client(
                 assumed_role = sts_client.assume_role(
                     RoleArn=iam_arn.strip(), RoleSessionName='OpenSearchClientSession'
                 )
-                credentials = assumed_role['Credentials']
+                creds_dict = assumed_role['Credentials']
+                credentials = Credentials(
+                    access_key=creds_dict['AccessKeyId'],
+                    secret_key=creds_dict['SecretAccessKey'],
+                    token=creds_dict.get('SessionToken'),
+                )
 
                 aws_auth = AWSV4SignerAsyncAuth(
                     credentials=credentials, region=aws_region.strip(), service=service_name

--- a/tests/opensearch/test_client.py
+++ b/tests/opensearch/test_client.py
@@ -23,6 +23,10 @@ class TestOpenSearchClient:
             'OPENSEARCH_NO_AUTH',
             'OPENSEARCH_SSL_VERIFY',
             'OPENSEARCH_TIMEOUT',
+            'AWS_IAM_ARN',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_SESSION_TOKEN',
         ]:
             if key in os.environ:
                 self.original_env[key] = os.environ[key]
@@ -39,6 +43,10 @@ class TestOpenSearchClient:
             'OPENSEARCH_NO_AUTH',
             'OPENSEARCH_SSL_VERIFY',
             'OPENSEARCH_TIMEOUT',
+            'AWS_IAM_ARN',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_SESSION_TOKEN',
         ]:
             if key in os.environ:
                 del os.environ[key]
@@ -351,6 +359,10 @@ class TestOpenSearchClientContextManager:
             'OPENSEARCH_NO_AUTH',
             'OPENSEARCH_SSL_VERIFY',
             'OPENSEARCH_TIMEOUT',
+            'AWS_IAM_ARN',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_SESSION_TOKEN',
         ]:
             if key in os.environ:
                 del os.environ[key]


### PR DESCRIPTION
### Description
The credentials returned from IAM role assumption are in a different format and needs to be converted into a `botocore.credentials` object

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).