### PR TITLE
feat: add configuration validation for YAML config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           source .venv/bin/activate
           uv sync
 
+      - name: Validate Configuration
+        run: |
+          source .venv/bin/activate
+          python validate_config.py example_config.yml
+
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -53,6 +58,11 @@ jobs:
           uv venv
           source .venv/bin/activate
           uv sync
+
+      - name: Validate Configuration
+        run: |
+          source .venv/bin/activate
+          python validate_config.py example_config.yml
 
       - name: Run tests
         run: |
@@ -81,6 +91,12 @@ jobs:
           uv venv
           .\.venv\Scripts\Activate.ps1
           uv sync
+
+      - name: Validate Configuration
+        shell: pwsh
+        run: |
+          .\.venv\Scripts\Activate.ps1
+          python validate_config.py example_config.yml
 
       - name: Run tests
         shell: pwsh

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -1,0 +1,78 @@
+name: Configuration Validation
+
+on:
+  push:
+    paths:
+      - 'example_config.yml'
+      - 'src/tools/config_validator.py'
+      - 'validate_config.py'
+      - 'src/mcp_server_opensearch/clusters_information.py'
+  pull_request:
+    paths:
+      - 'example_config.yml'
+      - 'src/tools/config_validator.py'
+      - 'validate_config.py'
+      - 'src/mcp_server_opensearch/clusters_information.py'
+
+jobs:
+  validate-config:
+    name: Validate Configuration Files
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv sync
+
+      - name: Validate Example Configuration
+        run: |
+          source .venv/bin/activate
+          python validate_config.py example_config.yml
+
+      - name: Test Invalid Configuration Detection
+        run: |
+          source .venv/bin/activate
+          
+          # Create test invalid config
+          cat > test_invalid.yml << EOF
+          version: "bad-version"
+          clusters:
+            bad-cluster:
+              opensearch_url: "invalid-url"
+              iam_arn: "invalid-arn"
+          EOF
+          
+          # Should fail validation
+          if python validate_config.py test_invalid.yml; then
+            echo "❌ Validation should have failed for invalid config"
+            exit 1
+          else
+            echo "✅ Invalid configuration correctly rejected"
+          fi
+          
+          # Cleanup
+          rm -f test_invalid.yml
+
+      - name: Create Sample Configuration
+        run: |
+          source .venv/bin/activate
+          python validate_config.py --create-sample
+          
+          # Validate the created sample
+          python validate_config.py sample_config_with_validation.yml
+          
+          # Cleanup
+          rm -f sample_config_with_validation.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Convert JSON to CSV for search index tool result ([#140](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/140))
 - Add Normalize scientific-notation floats in a request body for search index tool ([#142](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/142))
+- Add configuration validation utility for YAML config files with comprehensive validation of clusters, tools, and authentication settings ([#139](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/139))
 
 ### Fixed
 - Fix AWS auth issues for cat based tools, pin OpenSearchPy to 2.18.0 ([#135](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/135))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -151,6 +151,54 @@ tools:
     description: "Retrieve detailed information about OpenSearch shards"
 ```
 
+### Validating Your Configuration
+
+Before using your configuration file, it's recommended to validate it to catch any errors early. The server includes a built-in validation utility:
+
+```bash
+# Validate your configuration file
+python validate_config.py /path/to/your/config.yml
+
+# Validate with verbose output
+python validate_config.py /path/to/your/config.yml --verbose
+
+# Create a sample configuration file
+python validate_config.py --create-sample
+```
+
+**Validation Output Example:**
+```
+Validating configuration file: config.yml
+============================================================
+SUCCESS: Configuration is VALID
+
+Configuration Summary:
+   • Version: 1.0
+   • Clusters: 3
+   • Tool customizations: 2
+   • Tool categories: 0
+   • Tool filters: None
+
+Clusters:
+   • local-dev - Auth: basic_auth
+   • production - Auth: iam_role, aws_profile
+   • staging - Auth: aws_profile
+
+Warnings (1):
+   1. Cluster 'production': Multiple authentication methods configured: iam_role, aws_profile
+============================================================
+```
+
+**What the validator checks:**
+- Configuration file structure and syntax
+- Required fields (version, opensearch_url for each cluster)
+- URL format validation
+- IAM ARN format validation
+- AWS region format validation
+- Authentication method consistency
+- Tool configuration validity
+- Duplicate display names
+
 **Key Points about Multi Mode:**
 - **Cluster Names**: The keys under `clusters` (e.g., `local-dev`, `production`, `staging`) are used as the `opensearch_cluster_name` parameter when calling tools
 - **Authentication**: Each cluster can use different authentication methods (basic auth, IAM roles, AWS profiles)

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,57 +1,87 @@
 version: "1.0"
 description: "Unified OpenSearch MCP Server Configuration"
 
+# =============================================================================
 # Cluster configurations (used in Multi Mode)
+# =============================================================================
+# Each cluster can use different authentication methods. Configure only one
+# authentication method per cluster to avoid warnings.
+
 clusters:
+  # Basic Authentication Example
   local-cluster:
     opensearch_url: "http://localhost:9200"
     opensearch_username: "admin"
     opensearch_password: "your_password_here"
+    ssl_verify: false  # Set to false for local development with self-signed certs
+    timeout: 30
 
+  # AWS Profile Authentication Example
   remote-cluster:
     opensearch_url: "https://your-opensearch-domain.us-east-2.es.amazonaws.com"
     profile: "your-aws-profile"
+    aws_region: "us-east-2"  # Optional: will be inferred from profile if not specified
+    timeout: 30
   
+  # IAM Role Authentication Example (Recommended for production)
   remote-cluster-with-iam:
     opensearch_url: "https://your-opensearch-domain.us-east-2.es.amazonaws.com"
     iam_arn: "arn:aws:iam::123456789012:role/YourOpenSearchRole"
     aws_region: "us-east-2"
-    profile: "your-aws-profile"
+    profile: "your-aws-profile"  # Profile used for assuming the IAM role
+    timeout: 30
 
+  # OpenSearch Serverless Example
   serverless-cluster:
     opensearch_url: "https://collection-id.us-east-1.aoss.amazonaws.com"
     aws_region: "us-east-1"
     profile: "your-aws-profile"
     is_serverless: true
+    timeout: 30
 
+  # No Authentication Example (Development only)
   no-auth-cluster:
     opensearch_url: "http://localhost:9200"
     opensearch_no_auth: true
+    timeout: 30
   
+  # Header-based Authentication Example
+  # Useful for dynamic authentication where credentials are passed in headers
   header-auth-cluster:
     opensearch_url: "https://your-opensearch-domain.us-east-2.es.amazonaws.com"
     opensearch_header_auth: true
+    timeout: 30
 
-Tool customization configurations (supported in both Single and Multi Mode)
+# =============================================================================
+# Tool customization configurations (supported in both Single and Multi Mode)
+# =============================================================================
+# Customize tool display names, descriptions, and argument descriptions
+# to better match your use case and provide clearer guidance to users.
+
 tools:
   ListIndexTool:
-    display_name: "My_Custom_Index_Lister"
-    description: "This is a custom description for the tool that lists indices. It's much more descriptive now!"
+    display_name: "Index_Lister"
+    description: "Lists all indices in the OpenSearch cluster with detailed information including document count, storage size, and health status."
     args:
-      index: "Custom description for the 'index' argument in ListIndexTool."
+      index: "The name of a specific index to get detailed information for. If not provided, lists all indices."
+      include_detail: "Set to true to include full metadata (default), or false to return only index names."
+  
   SearchIndexTool:
-    display_name: "Super_Searcher"
+    display_name: "Document_Searcher"
+    description: "Searches for documents in an index using OpenSearch Query DSL. Supports complex queries including full-text search, filters, aggregations, and sorting."
     args:
-      index: "Custom description for the 'index' argument in SearchIndexTool."
-      query: "Explain what kind of query JSON is expected here."
+      index: "The target index to search in. Use wildcards (*) to search multiple indices."
+      query: "OpenSearch Query DSL JSON object defining the search criteria, filters, and sorting."
+  
   GetShardsTool:
-    description: "A better description to get information about shards in OpenSearch."
+    display_name: "Shard_Information"
+    description: "Retrieves detailed information about shard allocation, state, and size across the cluster."
     args:
-      index: "Target index whose shards will be listed."
+      index: "The index name to get shard information for. Use wildcards (*) for multiple indices."
 
-# ==============================================================================
+# =============================================================================
 # Tool filtering configurations (ONLY supported in Single Mode)
-# ==============================================================================
+# =============================================================================
 # Note: These sections are ignored in Multi Mode. Tool filtering only works
 # when using Single Mode (--mode single or default mode).
 # Uncomment the sections below if you're using Single Mode and want to filter tools.
@@ -60,20 +90,35 @@ tools:
 #   search_tools:
 #     - "SearchIndexTool"
 #     - "MsearchTool"
+#     - "CountTool"
 #   management_tools:
 #     - "ListIndexTool"
-#     - "CreateIndexTool"
-#     - "DeleteIndexTool"
+#     - "GetIndexInfoTool"
+#     - "GetIndexStatsTool"
+#   monitoring_tools:
+#     - "ClusterHealthTool"
+#     - "GetShardsTool"
+#     - "CatNodesTool"
 
 # tool_filters:
+#   enabled_tools:
+#     - "ListIndexTool"
+#     - "SearchIndexTool"
+#     - "ClusterHealthTool"
 #   disabled_tools:
-#     - "DangerousTool"  # Example: disable dangerous tools
+#     - "GetClusterStateTool"  # Example: disable verbose cluster information
+#     - "GetNodesHotThreadsTool"  # Example: disable advanced debugging tools
+#   enabled_categories:
+#     - "search_tools"
+#     - "management_tools"
 #   disabled_categories:
-#     - "experimental_tools"  # Example: disable experimental tool category  
+#     - "experimental_tools"  # Example: disable experimental category
+#   enabled_tools_regex:
+#     - "Get.*"  # Example: enable all tools starting with "Get"
 #   disabled_tools_regex:
-#     - "debug.*"  # Example: disable all tools starting with debug
+#     - "debug.*"  # Example: disable all tools starting with "debug"
 #   settings:
-#     allow_write: true  # Enable/disable write operations
+#     allow_write: false  # Disable write operations for enhanced security
 
 
 # Example configurations for different authentication methods:

--- a/src/mcp_server_opensearch/clusters_information.py
+++ b/src/mcp_server_opensearch/clusters_information.py
@@ -6,6 +6,7 @@ import os
 import yaml
 from pydantic import BaseModel
 from typing import Dict, Optional
+from tools.config_validator import ConfigurationValidator, ClusterConfig
 
 
 class ClusterInfo(BaseModel):
@@ -64,6 +65,7 @@ async def load_clusters_from_yaml(file_path: str) -> None:
         yaml.YAMLError: If the YAML file is malformed
         UnicodeDecodeError: If the file has encoding issues
         OSError: For other file system related errors
+        ValueError: If the configuration validation fails
     """
     if not file_path:
         return
@@ -72,7 +74,7 @@ async def load_clusters_from_yaml(file_path: str) -> None:
     if not os.path.exists(file_path):
         raise FileNotFoundError(f'YAML file not found: {file_path}')
 
-    result = {'loaded_clusters': [], 'errors': [], 'total_clusters': 0}
+    result = {'loaded_clusters': [], 'errors': [], 'warnings': [], 'validation_errors': []}
 
     try:
         # Try to open and read the file with proper error handling
@@ -92,44 +94,74 @@ async def load_clusters_from_yaml(file_path: str) -> None:
         except OSError as e:
             raise OSError(f'OS error reading YAML file {file_path}: {str(e)}')
 
-        # Process clusters
-        clusters = config.get('clusters', {})
+        # Validate the entire configuration first
+        validation_result = ConfigurationValidator.validate_config_file(config or {})
+        
+        # Log validation warnings
+        for warning in validation_result.get('warnings', []):
+            logging.warning(f'Configuration warning: {warning}')
+            result['warnings'].append(warning)
+        
+        # Check for validation errors
+        if validation_result.get('errors'):
+            error_msg = 'Configuration validation failed:'
+            for error in validation_result['errors']:
+                error_msg += f'\n  - {error}'
+                result['validation_errors'].append(error)
+            logging.error(error_msg)
+            raise ValueError(error_msg)
+
+        # Get normalized configuration
+        normalized_config = validation_result.get('normalized_config', {})
+        clusters = normalized_config.get('clusters', {})
         result['total_clusters'] = len(clusters)
         logging.info(f'Total clusters found in config file: {result["total_clusters"]}')
 
+        # Process each validated cluster
         for cluster_name, cluster_config in clusters.items():
             try:
-                # Validate required fields
-                if 'opensearch_url' not in cluster_config:
-                    result['errors'].append(f'Missing opensearch_url for cluster: {cluster_name}')
-                    continue
+                # Create ClusterInfo from validated configuration
                 cluster_info = ClusterInfo(
                     opensearch_url=cluster_config['opensearch_url'],
-                    iam_arn=cluster_config.get('iam_arn', None),
-                    aws_region=cluster_config.get('aws_region', None),
-                    opensearch_username=cluster_config.get('opensearch_username', None),
-                    opensearch_password=cluster_config.get('opensearch_password', None),
-                    profile=cluster_config.get('profile', None),
-                    is_serverless=cluster_config.get('is_serverless', None),
-                    timeout=cluster_config.get('timeout', None),
-                    opensearch_no_auth=cluster_config.get('opensearch_no_auth', None),
-                    ssl_verify=cluster_config.get('ssl_verify', None),
-                    opensearch_header_auth=cluster_config.get('opensearch_header_auth', None),
+                    iam_arn=cluster_config.get('iam_arn'),
+                    aws_region=cluster_config.get('aws_region'),
+                    opensearch_username=cluster_config.get('opensearch_username'),
+                    opensearch_password=cluster_config.get('opensearch_password'),
+                    profile=cluster_config.get('profile'),
+                    is_serverless=cluster_config.get('is_serverless'),
+                    timeout=cluster_config.get('timeout'),
+                    opensearch_no_auth=cluster_config.get('opensearch_no_auth'),
+                    ssl_verify=cluster_config.get('ssl_verify'),
+                    opensearch_header_auth=cluster_config.get('opensearch_header_auth'),
                 )
 
-                # Add cluster to registry without checking connection
+                # Add cluster to registry
                 add_cluster(name=cluster_name, cluster_info=cluster_info)
                 result['loaded_clusters'].append(cluster_name)
+                logging.info(f'Successfully loaded cluster: {cluster_name}')
 
             except Exception as e:
-                result['errors'].append(f"Error processing cluster '{cluster_name}': {str(e)}")
+                error_msg = f"Error processing cluster '{cluster_name}': {str(e)}"
+                result['errors'].append(error_msg)
+                logging.error(error_msg)
 
-        result['loaded_clusters'] = list(cluster_registry.keys())
+        # Final summary
+        if result['loaded_clusters']:
+            logging.info(f'Successfully loaded {len(result["loaded_clusters"])} clusters: {result["loaded_clusters"]}')
+        else:
+            logging.warning('No clusters were successfully loaded')
+        
         if result['errors']:
             logging.error(f'Loading errors: {result["errors"]}')
-
-        logging.info(f'Loaded clusters: {result["loaded_clusters"]}')
-        return
+        
+        # Return summary for potential monitoring/telemetry
+        return result
 
     except yaml.YAMLError as e:
         raise yaml.YAMLError(f'Invalid YAML format in {file_path}: {str(e)}')
+    except ValueError:
+        # Re-raise validation errors
+        raise
+    except Exception as e:
+        logging.error(f'Unexpected error loading clusters from {file_path}: {e}')
+        raise

--- a/src/tools/config_validator.py
+++ b/src/tools/config_validator.py
@@ -1,0 +1,432 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Configuration validation module for OpenSearch MCP Server.
+
+Provides schema validation and enhanced error handling for YAML configuration files.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, Field, validator, ValidationError
+from urllib.parse import urlparse
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class ClusterConfig(BaseModel):
+    """Validation model for individual cluster configuration."""
+    
+    opensearch_url: str = Field(..., description="OpenSearch cluster URL")
+    iam_arn: Optional[str] = Field(None, description="AWS IAM role ARN for authentication")
+    aws_region: Optional[str] = Field(None, description="AWS region for the cluster")
+    opensearch_username: Optional[str] = Field(None, description="Username for basic authentication")
+    opensearch_password: Optional[str] = Field(None, description="Password for basic authentication")
+    profile: Optional[str] = Field(None, description="AWS profile name")
+    is_serverless: Optional[bool] = Field(None, description="Whether this is an OpenSearch Serverless cluster")
+    timeout: Optional[int] = Field(None, ge=1, le=300, description="Connection timeout in seconds (1-300)")
+    opensearch_no_auth: Optional[bool] = Field(None, description="Disable authentication for this cluster")
+    ssl_verify: Optional[bool] = Field(None, description="Verify SSL certificates")
+    opensearch_header_auth: Optional[bool] = Field(None, description="Enable header-based authentication")
+
+    @validator('opensearch_url')
+    def validate_url(cls, v):
+        """Validate OpenSearch URL format."""
+        if not v or not v.strip():
+            raise ValueError('OpenSearch URL cannot be empty')
+        
+        try:
+            parsed = urlparse(v.strip())
+            if not parsed.scheme or not parsed.netloc:
+                raise ValueError('Invalid URL format')
+            if parsed.scheme not in ['http', 'https']:
+                raise ValueError('URL must use http or https scheme')
+        except Exception as e:
+            raise ValueError(f'Invalid OpenSearch URL: {e}')
+        
+        return v.strip()
+
+    @validator('iam_arn')
+    def validate_iam_arn(cls, v):
+        """Validate AWS IAM ARN format."""
+        if v is None:
+            return v
+        
+        arn_pattern = r'^arn:aws:iam::\d{12}:role/[a-zA-Z0-9+=,.@_-]+$'
+        if not re.match(arn_pattern, v):
+            raise ValueError('Invalid IAM ARN format. Expected: arn:aws:iam::123456789012:role/RoleName')
+        
+        return v
+
+    @validator('aws_region')
+    def validate_aws_region(cls, v):
+        """Validate AWS region format."""
+        if v is None:
+            return v
+        
+        # Pattern supports standard regions (us-east-1), GovCloud (us-gov-west-1), and China (cn-north-1)
+        region_pattern = r'^[a-z]{2}(-gov)?-[a-z]+-\d+$'
+        if not re.match(region_pattern, v):
+            raise ValueError('Invalid AWS region format. Expected: us-east-1, us-gov-west-1, eu-west-2, etc.')
+        
+        return v
+
+    @validator('opensearch_username')
+    def validate_username(cls, v):
+        """Validate username format."""
+        if v is not None and (not v.strip() or len(v.strip()) < 1):
+            raise ValueError('Username cannot be empty if provided')
+        return v.strip() if v else v
+
+    @validator('opensearch_password')
+    def validate_password(cls, v):
+        """Validate password format."""
+        # Note: Passwords are not stripped to preserve intentional whitespace
+        if v is not None and len(v) < 1:
+            raise ValueError('Password cannot be empty if provided')
+        return v
+
+    @validator('profile')
+    def validate_profile(cls, v):
+        """Validate AWS profile name."""
+        if v is not None and (not v.strip() or len(v.strip()) < 1):
+            raise ValueError('Profile name cannot be empty if provided')
+        
+        # AWS profile names should be alphanumeric with hyphens and underscores
+        if v is not None and not re.match(r'^[a-zA-Z0-9_-]+$', v.strip()):
+            raise ValueError('Profile name contains invalid characters')
+        
+        return v.strip() if v else v
+
+    def validate_authentication_consistency(self) -> List[str]:
+        """Validate authentication method consistency."""
+        warnings = []
+        
+        # Check for conflicting authentication methods
+        auth_methods = [
+            self.opensearch_username and self.opensearch_password,
+            self.iam_arn,
+            self.profile,
+            self.opensearch_no_auth,
+            self.opensearch_header_auth
+        ]
+        
+        active_methods = [i for i, method in enumerate(auth_methods) if method]
+        
+        if len(active_methods) > 1:
+            method_names = ['basic_auth', 'iam_role', 'aws_profile', 'no_auth', 'header_auth']
+            conflicting = [method_names[i] for i in active_methods]
+            warnings.append(f"Multiple authentication methods configured: {', '.join(conflicting)}")
+        
+        # Check for missing required fields
+        if self.opensearch_username and not self.opensearch_password:
+            warnings.append("Username provided but password is missing")
+        
+        if self.opensearch_password and not self.opensearch_username:
+            warnings.append("Password provided but username is missing")
+        
+        if self.iam_arn and not self.aws_region:
+            warnings.append("IAM role ARN provided but AWS region is missing")
+        
+        # Serverless-specific checks
+        if self.is_serverless and self.opensearch_url and not self.opensearch_url.endswith('.aoss.amazonaws.com'):
+            warnings.append("Serverless mode enabled but URL doesn't appear to be an OpenSearch Serverless endpoint")
+        
+        return warnings
+
+
+class ToolCustomization(BaseModel):
+    """Validation model for tool customization."""
+    
+    display_name: Optional[str] = Field(None, description="Custom display name for the tool")
+    description: Optional[str] = Field(None, description="Custom description for the tool")
+    args: Optional[Dict[str, str]] = Field(None, description="Custom argument descriptions")
+
+    @validator('display_name')
+    def validate_display_name(cls, v):
+        """Validate tool display name."""
+        if v is None:
+            return v
+        
+        if not v.strip():
+            raise ValueError('Display name cannot be empty')
+        
+        # Must match pattern: alphanumeric, hyphens, underscores only
+        pattern = r'^[a-zA-Z0-9_-]+$'
+        if not re.match(pattern, v.strip()):
+            raise ValueError('Display name can only contain letters, numbers, hyphens, and underscores')
+        
+        if len(v.strip()) > 50:
+            raise ValueError('Display name cannot exceed 50 characters')
+        
+        return v.strip()
+
+    @validator('args')
+    def validate_args(cls, v):
+        """Validate argument descriptions."""
+        if v is None:
+            return v
+        
+        if not isinstance(v, dict):
+            raise ValueError('Args must be a dictionary')
+        
+        for arg_name, description in v.items():
+            if not isinstance(arg_name, str) or not arg_name.strip():
+                raise ValueError('Argument names must be non-empty strings')
+            
+            if not isinstance(description, str) or not description.strip():
+                raise ValueError(f'Argument description for "{arg_name}" must be a non-empty string')
+            
+            if len(description) > 200:
+                raise ValueError(f'Argument description for "{arg_name}" cannot exceed 200 characters')
+        
+        return v
+
+
+class ToolCategory(BaseModel):
+    """Validation model for tool categories."""
+    
+    category_name: str = Field(..., description="Name of the tool category")
+    tools: List[str] = Field(..., description="List of tool names in this category")
+
+    @validator('category_name')
+    def validate_category_name(cls, v):
+        """Validate category name."""
+        if not v.strip():
+            raise ValueError('Category name cannot be empty')
+        
+        pattern = r'^[a-zA-Z0-9_-]+$'
+        if not re.match(pattern, v.strip()):
+            raise ValueError('Category name can only contain letters, numbers, hyphens, and underscores')
+        
+        return v.strip()
+
+    @validator('tools')
+    def validate_tools(cls, v):
+        """Validate tool list."""
+        if not v:
+            raise ValueError('Tool category must contain at least one tool')
+        
+        for tool in v:
+            if not isinstance(tool, str) or not tool.strip():
+                raise ValueError('Tool names must be non-empty strings')
+        
+        return [tool.strip() for tool in v]
+
+
+class ToolFilter(BaseModel):
+    """Validation model for tool filtering configuration."""
+    
+    enabled_tools: Optional[List[str]] = Field(None, description="List of enabled tools")
+    disabled_tools: Optional[List[str]] = Field(None, description="List of disabled tools")
+    enabled_categories: Optional[List[str]] = Field(None, description="List of enabled categories")
+    disabled_categories: Optional[List[str]] = Field(None, description="List of disabled categories")
+    enabled_tools_regex: Optional[List[str]] = Field(None, description="List of enabled tool regex patterns")
+    disabled_tools_regex: Optional[List[str]] = Field(None, description="List of disabled tool regex patterns")
+    settings: Optional[Dict[str, Any]] = Field(None, description="Tool filter settings")
+
+    @validator('settings')
+    def validate_settings(cls, v):
+        """Validate tool filter settings."""
+        if v is None:
+            return v
+        
+        if not isinstance(v, dict):
+            raise ValueError('Settings must be a dictionary')
+        
+        # Validate allow_write setting
+        if 'allow_write' in v and not isinstance(v['allow_write'], bool):
+            raise ValueError('allow_write setting must be a boolean')
+        
+        return v
+
+    def validate_filter_consistency(self) -> List[str]:
+        """Validate filter configuration consistency."""
+        warnings = []
+        
+        # Check for conflicting enable/disable
+        if self.enabled_tools and self.disabled_tools:
+            common_tools = set(self.enabled_tools) & set(self.disabled_tools)
+            if common_tools:
+                warnings.append(f"Tools both enabled and disabled: {', '.join(common_tools)}")
+        
+        if self.enabled_categories and self.disabled_categories:
+            common_categories = set(self.enabled_categories) & set(self.disabled_categories)
+            if common_categories:
+                warnings.append(f"Categories both enabled and disabled: {', '.join(common_categories)}")
+        
+        return warnings
+
+
+class ServerConfig(BaseModel):
+    """Main configuration validation model."""
+    
+    version: str = Field(..., description="Configuration version")
+    description: Optional[str] = Field(None, description="Configuration description")
+    clusters: Optional[Dict[str, ClusterConfig]] = Field(None, description="Cluster configurations")
+    tools: Optional[Dict[str, ToolCustomization]] = Field(None, description="Tool customizations")
+    tool_category: Optional[Dict[str, List[str]]] = Field(None, description="Tool categories")
+    tool_filters: Optional[ToolFilter] = Field(None, description="Tool filtering configuration")
+
+    @validator('version')
+    def validate_version(cls, v):
+        """Validate configuration version."""
+        if not v.strip():
+            raise ValueError('Version cannot be empty')
+        
+        # Simple semantic version validation
+        version_pattern = r'^\d+\.\d+(\.\d+)?$'
+        if not re.match(version_pattern, v.strip()):
+            raise ValueError('Version must be in semantic version format (e.g., "1.0", "1.2.3")')
+        
+        return v.strip()
+
+    @validator('description')
+    def validate_description(cls, v):
+        """Validate configuration description."""
+        if v is None:
+            return v
+        
+        if len(v.strip()) > 500:
+            raise ValueError('Description cannot exceed 500 characters')
+        
+        return v.strip()
+
+    def validate_configuration(self) -> Dict[str, List[str]]:
+        """Perform comprehensive configuration validation."""
+        validation_result = {
+            'errors': [],
+            'warnings': []
+        }
+        
+        # Validate cluster configurations
+        if self.clusters is not None:
+            if len(self.clusters) == 0:
+                validation_result['warnings'].append("Clusters section is empty - no clusters configured")
+            else:
+                for cluster_name, cluster_config in self.clusters.items():
+                    # Validate cluster name
+                    if not cluster_name.strip():
+                        validation_result['errors'].append("Cluster name cannot be empty")
+                    elif not re.match(r'^[a-zA-Z0-9_-]+$', cluster_name):
+                        validation_result['errors'].append(f"Invalid cluster name '{cluster_name}': only letters, numbers, hyphens, and underscores allowed")
+                    
+                    # Validate cluster configuration
+                    cluster_warnings = cluster_config.validate_authentication_consistency()
+                    for warning in cluster_warnings:
+                        validation_result['warnings'].append(f"Cluster '{cluster_name}': {warning}")
+        
+        # Validate tool customizations
+        if self.tools:
+            # Check for duplicate display names
+            display_names = []
+            for tool_name, tool_config in self.tools.items():
+                if tool_config.display_name:
+                    if tool_config.display_name in display_names:
+                        validation_result['errors'].append(f"Duplicate display name '{tool_config.display_name}' found")
+                    else:
+                        display_names.append(tool_config.display_name)
+        
+        # Validate tool categories
+        if self.tool_category:
+            for category_name, tools in self.tool_category.items():
+                if not tools:
+                    validation_result['errors'].append(f"Tool category '{category_name}' cannot be empty")
+        
+        # Validate tool filters
+        if self.tool_filters:
+            filter_warnings = self.tool_filters.validate_filter_consistency()
+            validation_result['warnings'].extend(filter_warnings)
+        
+        return validation_result
+
+
+class ConfigurationValidator:
+    """Main configuration validator class."""
+    
+    @staticmethod
+    def validate_config_file(config_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validate a complete configuration file.
+        
+        Args:
+            config_data: Raw configuration dictionary from YAML
+            
+        Returns:
+            Dictionary with validation results including errors, warnings, and normalized config
+        """
+        result = {
+            'valid': False,
+            'errors': [],
+            'warnings': [],
+            'normalized_config': None
+        }
+        
+        try:
+            # Parse and validate the configuration
+            config = ServerConfig(**config_data)
+            
+            # Perform comprehensive validation
+            validation_result = config.validate_configuration()
+            
+            # Collect all errors and warnings
+            result['errors'].extend(validation_result['errors'])
+            result['warnings'].extend(validation_result['warnings'])
+            
+            # If no errors, mark as valid and return normalized config
+            if not result['errors']:
+                result['valid'] = True
+                result['normalized_config'] = config.dict() if hasattr(config, 'dict') else config.model_dump()
+            
+        except ValidationError as e:
+            # Handle Pydantic validation errors
+            for error in e.errors():
+                field_path = '.'.join(str(x) for x in error['loc'])
+                message = error['msg']
+                result['errors'].append(f"Field '{field_path}': {message}")
+        
+        except Exception as e:
+            result['errors'].append(f"Unexpected validation error: {str(e)}")
+        
+        return result
+    
+    @staticmethod
+    def validate_cluster_only(cluster_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validate only cluster configuration (for partial validation).
+        
+        Args:
+            cluster_data: Raw cluster configuration dictionary
+            
+        Returns:
+            Dictionary with validation results
+        """
+        result = {
+            'valid': False,
+            'errors': [],
+            'warnings': [],
+            'normalized_config': None
+        }
+        
+        try:
+            cluster = ClusterConfig(**cluster_data)
+            warnings = cluster.validate_authentication_consistency()
+            
+            result['warnings'].extend(warnings)
+            
+            if not result['errors']:
+                result['valid'] = True
+                result['normalized_config'] = cluster.dict() if hasattr(cluster, 'dict') else cluster.model_dump()
+                
+        except ValidationError as e:
+            for error in e.errors():
+                field_path = '.'.join(str(x) for x in error['loc'])
+                message = error['msg']
+                result['errors'].append(f"Field '{field_path}': {message}")
+        
+        except Exception as e:
+            result['errors'].append(f"Unexpected validation error: {str(e)}")
+        
+        return result

--- a/tests/mcp_server_opensearch/test_clusters_information.py
+++ b/tests/mcp_server_opensearch/test_clusters_information.py
@@ -114,7 +114,7 @@ class TestLoadClustersFromYaml:
     async def test_load_clusters_from_yaml_empty_file(self):
         """Test loading from empty YAML file."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
-            f.write('clusters: {}')
+            f.write('version: "1.0"\nclusters: {}')
             f.flush()
 
             await load_clusters_from_yaml(f.name)
@@ -126,6 +126,7 @@ class TestLoadClustersFromYaml:
     async def test_load_clusters_from_yaml_valid_clusters(self):
         """Test loading valid clusters from YAML."""
         yaml_content = """
+version: "1.0"
 clusters:
   cluster1:
     opensearch_url: "https://localhost:9200"
@@ -165,6 +166,7 @@ clusters:
     async def test_load_clusters_from_yaml_with_no_auth(self):
         """Test loading cluster with opensearch_no_auth from YAML."""
         yaml_content = """
+version: "1.0"
 clusters:
   no-auth-cluster:
     opensearch_url: "http://localhost:9200"
@@ -201,6 +203,7 @@ clusters:
     async def test_load_clusters_from_yaml_missing_opensearch_url(self):
         """Test loading cluster without required opensearch_url."""
         yaml_content = """
+version: "1.0"
 clusters:
   invalid_cluster:
     opensearch_username: "admin"
@@ -210,17 +213,21 @@ clusters:
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write(yaml_content)
             f.flush()
-            await load_clusters_from_yaml(f.name)
+            
+            # Should raise ValueError due to validation failure
+            with pytest.raises(ValueError, match="Configuration validation failed"):
+                await load_clusters_from_yaml(f.name)
 
         os.unlink(f.name)
 
-        # Cluster should not be added due to missing opensearch_url
+        # Cluster should not be added due to validation failure
         assert len(cluster_registry) == 0
 
     @pytest.mark.asyncio
     async def test_load_clusters_from_yaml_without_connection_check(self):
         """Test loading cluster without connection validation."""
         yaml_content = """
+version: "1.0"
 clusters:
   unreachable_cluster:
     opensearch_url: "https://unreachable:9200"

--- a/validate_config.py
+++ b/validate_config.py
@@ -130,17 +130,19 @@ def create_sample_config():
         "version": "1.0",
         "description": "Sample OpenSearch MCP Server Configuration",
         "clusters": {
-            "valid-cluster": {
+            "local-dev": {
                 "opensearch_url": "https://localhost:9200",
                 "opensearch_username": "admin",
                 "opensearch_password": "password",
                 "ssl_verify": False,
                 "timeout": 30
             },
-            "invalid-cluster": {
-                "opensearch_url": "invalid-url",  # This will cause validation error
-                "iam_arn": "invalid-arn",  # This will cause validation error
-                "aws_region": "invalid-region"  # This will cause validation error
+            "aws-prod": {
+                "opensearch_url": "https://search-my-domain.us-east-1.es.amazonaws.com",
+                "iam_arn": "arn:aws:iam::123456789012:role/OpenSearchRole",
+                "aws_region": "us-east-1",
+                "profile": "production",
+                "timeout": 60
             }
         },
         "tools": {
@@ -167,7 +169,7 @@ def create_sample_config():
         yaml.dump(sample_config, f, default_flow_style=False, indent=2)
     
     print(f"Created sample configuration file: {sample_file}")
-    print("   This file contains both valid and invalid configurations for testing.")
+    print("   This file demonstrates both basic auth and AWS IAM authentication configurations.")
     return str(sample_file)
 
 

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Configuration validation utility for OpenSearch MCP Server.
+
+This script can be used to validate YAML configuration files before deploying
+the MCP server. It provides detailed error messages and warnings.
+"""
+
+import argparse
+import json
+import logging
+import sys
+import yaml
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from tools.config_validator import ConfigurationValidator
+
+
+def setup_logging(verbose: bool = False):
+    """Setup logging configuration."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+
+def validate_config_file(file_path: str, verbose: bool = False) -> bool:
+    """
+    Validate a configuration file and print results.
+    
+    Args:
+        file_path: Path to the YAML configuration file
+        verbose: Enable verbose logging
+        
+    Returns:
+        True if validation passed, False otherwise
+    """
+    try:
+        # Read the configuration file
+        with open(file_path, 'r', encoding='utf-8') as f:
+            config_data = yaml.safe_load(f)
+        
+        if not config_data:
+            print(f"ERROR: Configuration file '{file_path}' is empty or invalid")
+            return False
+        
+        # Validate the configuration
+        print(f"Validating configuration file: {file_path}")
+        print("=" * 60)
+        
+        validation_result = ConfigurationValidator.validate_config_file(config_data)
+        
+        # Print results
+        if validation_result['valid']:
+            print("SUCCESS: Configuration is VALID")
+            
+            # Print summary
+            normalized_config = validation_result['normalized_config']
+            clusters = normalized_config.get('clusters', {}) or {}
+            tools = normalized_config.get('tools', {}) or {}
+            categories = normalized_config.get('tool_category', {}) or {}
+            filters = normalized_config.get('tool_filters')
+            
+            print(f"\nConfiguration Summary:")
+            print(f"   • Version: {normalized_config.get('version', 'N/A')}")
+            print(f"   • Clusters: {len(clusters)}")
+            print(f"   • Tool customizations: {len(tools)}")
+            print(f"   • Tool categories: {len(categories) if categories else 0}")
+            print(f"   • Tool filters: {'Configured' if filters else 'None'}")
+            
+            if clusters:
+                print(f"\nClusters:")
+                for name, cluster in clusters.items():
+                    auth_methods = []
+                    if cluster.get('opensearch_username'):
+                        auth_methods.append('basic_auth')
+                    if cluster.get('iam_arn'):
+                        auth_methods.append('iam_role')
+                    if cluster.get('profile'):
+                        auth_methods.append('aws_profile')
+                    if cluster.get('opensearch_no_auth'):
+                        auth_methods.append('no_auth')
+                    if cluster.get('opensearch_header_auth'):
+                        auth_methods.append('header_auth')
+                    
+                    serverless = " (Serverless)" if cluster.get('is_serverless') else ""
+                    print(f"   • {name}{serverless} - Auth: {', '.join(auth_methods) or 'None'}")
+        
+        else:
+            print("ERROR: Configuration is INVALID")
+        
+        # Print errors
+        if validation_result['errors']:
+            print(f"\nErrors ({len(validation_result['errors'])}):")
+            for i, error in enumerate(validation_result['errors'], 1):
+                print(f"   {i}. {error}")
+        
+        # Print warnings
+        if validation_result['warnings']:
+            print(f"\nWarnings ({len(validation_result['warnings'])}):")
+            for i, warning in enumerate(validation_result['warnings'], 1):
+                print(f"   {i}. {warning}")
+        
+        print("=" * 60)
+        
+        return validation_result['valid']
+        
+    except FileNotFoundError:
+        print(f"ERROR: File '{file_path}' not found")
+        return False
+    except yaml.YAMLError as e:
+        print(f"YAML ERROR: {e}")
+        return False
+    except Exception as e:
+        print(f"ERROR: Unexpected error: {e}")
+        return False
+
+
+def create_sample_config():
+    """Create a sample configuration file with validation examples."""
+    sample_config = {
+        "version": "1.0",
+        "description": "Sample OpenSearch MCP Server Configuration",
+        "clusters": {
+            "valid-cluster": {
+                "opensearch_url": "https://localhost:9200",
+                "opensearch_username": "admin",
+                "opensearch_password": "password",
+                "ssl_verify": False,
+                "timeout": 30
+            },
+            "invalid-cluster": {
+                "opensearch_url": "invalid-url",  # This will cause validation error
+                "iam_arn": "invalid-arn",  # This will cause validation error
+                "aws_region": "invalid-region"  # This will cause validation error
+            }
+        },
+        "tools": {
+            "ListIndexTool": {
+                "display_name": "CustomIndexLister",
+                "description": "Custom description for listing indices"
+            }
+        },
+        "tool_category": {
+            "search_tools": ["SearchIndexTool", "MsearchTool"],
+            "management_tools": ["ListIndexTool"]
+        },
+        "tool_filters": {
+            "enabled_tools": ["ListIndexTool", "SearchIndexTool"],
+            "disabled_tools": ["GetClusterStateTool"],
+            "settings": {
+                "allow_write": True
+            }
+        }
+    }
+    
+    sample_file = Path("sample_config_with_validation.yml")
+    with open(sample_file, 'w', encoding='utf-8') as f:
+        yaml.dump(sample_config, f, default_flow_style=False, indent=2)
+    
+    print(f"Created sample configuration file: {sample_file}")
+    print("   This file contains both valid and invalid configurations for testing.")
+    return str(sample_file)
+
+
+def main():
+    """Main entry point for the validation utility."""
+    parser = argparse.ArgumentParser(
+        description="Validate OpenSearch MCP Server configuration files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Validate a configuration file
+  python validate_config.py config.yml
+  
+  # Validate with verbose output
+  python validate_config.py config.yml --verbose
+  
+  # Create a sample configuration file
+  python validate_config.py --create-sample
+  
+  # Validate and output JSON results
+  python validate_config.py config.yml --json
+        """
+    )
+    
+    parser.add_argument(
+        'config_file',
+        nargs='?',
+        help='Path to the YAML configuration file to validate'
+    )
+    
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Enable verbose logging output'
+    )
+    
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Output validation results in JSON format'
+    )
+    
+    parser.add_argument(
+        '--create-sample',
+        action='store_true',
+        help='Create a sample configuration file with validation examples'
+    )
+    
+    args = parser.parse_args()
+    
+    setup_logging(args.verbose)
+    
+    # Handle create sample flag
+    if args.create_sample:
+        sample_file = create_sample_config()
+        if args.config_file:
+            # Also validate the provided file
+            is_valid = validate_config_file(args.config_file, args.verbose)
+            if args.json:
+                # Output JSON results would require modifying validate_config_file
+                pass
+            sys.exit(0 if is_valid else 1)
+        sys.exit(0)
+    
+    # Require config file unless creating sample
+    if not args.config_file:
+        parser.print_help()
+        print("\nERROR: Configuration file is required")
+        sys.exit(1)
+    
+    # Validate the configuration
+    is_valid = validate_config_file(args.config_file, args.verbose)
+    
+    if args.json:
+        # For JSON output, we'd need to modify the validation function
+        # to return structured data instead of printing
+        print("JSON output not yet implemented")
+        sys.exit(1)
+    
+    sys.exit(0 if is_valid else 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description
_Describe what this change achieves._

This PR adds a validation script to automatically verify the structure and correctness of OpenSearch MCP Python configuration YAML files. The script ensures that configuration files follow the expected schema and helps prevent misconfigurations or runtime failures during MCP server initialization.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._  

Closes https://github.com/opensearch-project/opensearch-mcp-server-py/issues/139

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.  
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
