### PR TITLE
Fix SearchIndexTool size parameter schema

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -582,7 +582,7 @@ tools:
   GetShardsTool:
     description: "Retrieve detailed information about OpenSearch shards"
   SearchIndexTool:
-     max_size_limit: "20"
+     max_size_limit: 20
 ```
 
 Use the configuration file when starting the server:

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -81,7 +81,7 @@ class SearchIndexArgs(baseToolArgs):
     index: str = Field(description='The name of the index to search in')
     query: Any = Field(description='The search query in OpenSearch query DSL format')
     format: str = Field(default='json', description='Output format: "json" or "csv"')
-    size: Optional[int] = Field(default=10, description='Number of search results to return. The maximum allowed value is 100, unless overridden by configuration.')
+    size: int = Field(default=10, description='Number of search results to return. The maximum allowed value is 100, unless overridden by configuration.')
 
 
 class GetShardsArgs(baseToolArgs):


### PR DESCRIPTION
### Description
Fix SearchIndexTool size parameter schema

Using Optional[int] for the size parameter generates an anyOf schema that causes validation errors when string values are provided.
```
{
  "method": "tools/call",
  "params": {
    "name": "SearchIndexTool",
    "arguments": {
      "index": "fitness_memory-memory-long-term",
      "query": "{\"_source\": [\"memory\", \"owner_id\", \"created_time\"], \"query\": {\"range\": {\"created_time\": {\"gte\": 1764889074E+3, \"lte\": 1764889375266}}}}",
      "format": "json",
      "size": "4" // String value causes "Incorrect type. Expected 'integer'" error
    }
  }
}
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).