### PR TITLE
Add ensure_ascii=False to JSON formatting

### DIFF
--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -121,7 +121,7 @@ async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
                 }
             ]
         else:
-            formatted_result = json.dumps(result, indent=2)
+            formatted_result = json.dumps(result, indent=2, ensure_ascii=False)
             return [
                 {
                     'type': 'text',


### PR DESCRIPTION
Fix the issue where all non ASCII characters (including Chinese) are escaped to Unicode escape sequences

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).