### PR TITLE
Fix SearchIndexTool AttributeError after query to query_dsl rename

### DIFF
--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -55,8 +55,8 @@ async def search_index(args: SearchIndexArgs) -> json:
     from .client import get_opensearch_client
     from tools.tools import TOOL_REGISTRY
 
-    if isinstance(args.query, str):
-        validate_json_string(args.query)
+    if isinstance(args.query_dsl, str):
+        validate_json_string(args.query_dsl)
 
     async with get_opensearch_client(args) as client:
         query = normalize_scientific_notation(args.query_dsl)


### PR DESCRIPTION
### Description
The parameter rename in #172 missed updating the validation check in search_index(), which still accessed args.query instead of args.query_dsl.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).