### PR TITLE
Cache OpenSearch version to avoid redundant HTTP calls per tool invocation

### DIFF
--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -686,18 +686,38 @@ def _flatten_object(obj: dict, row: dict, prefix: str = '') -> None:
             row[field_name] = str(value) if value is not None else ''
 
 
+_version_cache: dict[str, Version] = {}
+
+
+def clear_version_cache():
+    """Clear the cached OpenSearch version(s).
+
+    Useful for testing or when cluster version changes.
+    """
+    _version_cache.clear()
+
+
 async def get_opensearch_version(args: baseToolArgs) -> Version:
     """Get the version of OpenSearch cluster.
+
+    Returns the cached version if available, otherwise fetches it from the
+    cluster and caches the result. Failed lookups (None) are not cached.
 
     Returns:
         Version: The version of OpenSearch cluster (SemVer style)
     """
     from .client import get_opensearch_client
 
+    cache_key = args.opensearch_cluster_name or ''
+    if cache_key in _version_cache:
+        return _version_cache[cache_key]
+
     try:
         async with get_opensearch_client(args) as client:
             response = await client.info()
-            return Version.parse(response['version']['number'])
+            version = Version.parse(response['version']['number'])
+            _version_cache[cache_key] = version
+            return version
     except Exception as e:
         logger.error(f'Error getting OpenSearch version: {e}')
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,16 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if item.get_closest_marker('eval'):
                 item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True)
+def _clear_version_cache():
+    """Reset the OpenSearch version cache between tests.
+
+    The version cache is module-level state that persists across tests.
+    Clearing it before each test prevents stale cached values from leaking
+    between test cases that mock client.info() at different version levels.
+    """
+    from opensearch.helper import clear_version_cache
+
+    clear_version_cache()

--- a/tests/opensearch/test_helper.py
+++ b/tests/opensearch/test_helper.py
@@ -315,7 +315,105 @@ class TestOpenSearchHelper:
         # Execute and assert
         result = await get_opensearch_version(args)
         assert result is None
-        
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
+    async def test_get_opensearch_version_caches_result(self, mock_get_client):
+        from opensearch.helper import get_opensearch_version
+
+        mock_response = {'version': {'number': '2.11.1'}}
+        mock_client = AsyncMock()
+        mock_client.info = AsyncMock(return_value=mock_response)
+        mock_client.close = AsyncMock()
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        args = baseToolArgs(opensearch_cluster_name='')
+        result1 = await get_opensearch_version(args)
+        result2 = await get_opensearch_version(args)
+
+        assert str(result1) == '2.11.1'
+        assert str(result2) == '2.11.1'
+        mock_client.info.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
+    async def test_get_opensearch_version_cache_separate_clusters(self, mock_get_client):
+        from opensearch.helper import get_opensearch_version
+
+        mock_client = AsyncMock()
+        mock_client.info = AsyncMock(
+            side_effect=[
+                {'version': {'number': '2.11.1'}},
+                {'version': {'number': '2.18.0'}},
+            ]
+        )
+        mock_client.close = AsyncMock()
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        args_a = baseToolArgs(opensearch_cluster_name='cluster-a')
+        args_b = baseToolArgs(opensearch_cluster_name='cluster-b')
+
+        result_a = await get_opensearch_version(args_a)
+        result_b = await get_opensearch_version(args_b)
+
+        assert str(result_a) == '2.11.1'
+        assert str(result_b) == '2.18.0'
+        assert mock_client.info.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
+    async def test_get_opensearch_version_does_not_cache_failure(self, mock_get_client):
+        from opensearch.helper import get_opensearch_version
+
+        mock_client = AsyncMock()
+        mock_client.info = AsyncMock(
+            side_effect=[
+                Exception('Connection refused'),
+                {'version': {'number': '2.11.1'}},
+            ]
+        )
+        mock_client.close = AsyncMock()
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        args = baseToolArgs(opensearch_cluster_name='')
+        result1 = await get_opensearch_version(args)
+        assert result1 is None
+        result2 = await get_opensearch_version(args)
+        assert str(result2) == '2.11.1'
+        assert mock_client.info.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
+    async def test_clear_version_cache(self, mock_get_client):
+        from opensearch.helper import clear_version_cache, get_opensearch_version
+
+        mock_client = AsyncMock()
+        mock_client.info = AsyncMock(
+            side_effect=[
+                {'version': {'number': '2.11.1'}},
+                {'version': {'number': '2.18.0'}},
+            ]
+        )
+        mock_client.close = AsyncMock()
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        args = baseToolArgs(opensearch_cluster_name='')
+        result1 = await get_opensearch_version(args)
+        assert str(result1) == '2.11.1'
+
+        clear_version_cache()
+        result2 = await get_opensearch_version(args)
+        assert str(result2) == '2.18.0'
+        assert mock_client.info.call_count == 2
+
     def test_convert_search_results_to_csv_hits_only(self):
         """Test convert_search_results_to_csv with hits only."""
         import importlib.util


### PR DESCRIPTION
### Description
Cache the OpenSearch cluster version after the first successful retrieval to eliminate the redundant HTTP call made by `get_opensearch_version()` on every tool invocation. Previously, each tool call made 2 HTTP round-trips (version check + actual operation); now, subsequent calls return the cached version.

- Add `_version_cache` module-level dict in `helper.py` keyed by cluster name
- Add `clear_version_cache()` for cache reset
- Add autouse conftest fixture to prevent cache leaking between tests 
- Add 4 tests covering cache hit, per-cluster isolation, failure retry, and cache clearing

### Issues Resolved
Closes #185 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.