### PR TITLE
added mtls support for opensearch clusters. supports both single and multi-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 
+- Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings
+
 ### Fixed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 - Support for both stdio and streaming server transports (SSE and Streamable HTTP)
 - Built-in tools for common OpenSearch operations
 - Easy integration with Claude Desktop and LangChain
-- Secure authentication using basic auth or IAM roles
+- Secure authentication using basic auth, IAM roles, header-based auth, and OpenSearch mTLS
+
+For detailed setup, including Kubernetes deployment and mTLS configuration, see the [User Guide](USER_GUIDE.md).
 
 ## Installing opensearch-mcp-server-py
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -277,6 +277,18 @@ export OPENSEARCH_USERNAME="<your_opensearch_domain_username>"
 export OPENSEARCH_PASSWORD="<your_opensearch_domain_password>"
 ```
 
+#### Mutual TLS (mTLS)
+```bash
+export OPENSEARCH_URL="<your_opensearch_domain_url>"
+export OPENSEARCH_USERNAME="<your_opensearch_domain_username>"
+export OPENSEARCH_PASSWORD="<your_opensearch_domain_password>"
+export OPENSEARCH_CA_CERT_PATH="/path/to/ca.crt"
+export OPENSEARCH_CLIENT_CERT_PATH="/path/to/tls.crt"
+export OPENSEARCH_CLIENT_KEY_PATH="/path/to/tls.key"
+```
+
+`OPENSEARCH_CLIENT_CERT_PATH` and `OPENSEARCH_CLIENT_KEY_PATH` must be provided together. These settings add TLS client certificates to the existing authentication flow, so you can use mTLS alongside basic auth, IAM, or no-auth clusters.
+
 #### AWS Credentials Authentication
 ```bash
 export OPENSEARCH_URL="<your_opensearch_domain_url>"
@@ -314,6 +326,15 @@ clusters:
     opensearch_url: "http://localhost:9200"
     opensearch_username: "admin"
     opensearch_password: "your_password_here"
+
+  # Mutual TLS (mTLS)
+  mtls-cluster:
+    opensearch_url: "https://private-opensearch.example.com:9200"
+    opensearch_username: "admin"
+    opensearch_password: "your_password_here"
+    opensearch_ca_cert_path: "/var/run/opensearch-mtls/ca.crt"
+    opensearch_client_cert_path: "/var/run/opensearch-mtls/tls.crt"
+    opensearch_client_key_path: "/var/run/opensearch-mtls/tls.key"
 
   # AWS Credentials Authentication
   remote-cluster:
@@ -360,7 +381,12 @@ clusters:
 4. **Basic Authentication:**
    - Requires: `opensearch_url`, `opensearch_username`, `opensearch_password`
 
-5. **AWS Credentials Authentication:**
+5. **Mutual TLS (mTLS):**
+   - Optional: `opensearch_ca_cert_path`, `opensearch_client_cert_path`, `opensearch_client_key_path`
+   - `opensearch_client_cert_path` and `opensearch_client_key_path` must be configured together
+   - Adds TLS client certificates for OpenSearch connections and can be combined with the auth methods above
+
+6. **AWS Credentials Authentication:**
    - Requires: `opensearch_url`, `profile` (optional)
    - Uses AWS credentials from the specified profile or default credentials
 
@@ -400,6 +426,15 @@ python -m mcp_server_opensearch --transport stream
 
 # With AWS Profile
 python -m mcp_server_opensearch --profile my-aws-profile
+
+# Streaming Server with outbound mTLS
+OPENSEARCH_URL="https://private-opensearch.example.com:9200" \
+OPENSEARCH_USERNAME="admin" \
+OPENSEARCH_PASSWORD="password" \
+OPENSEARCH_CA_CERT_PATH="/path/to/ca.crt" \
+OPENSEARCH_CLIENT_CERT_PATH="/path/to/tls.crt" \
+OPENSEARCH_CLIENT_KEY_PATH="/path/to/tls.key" \
+python -m mcp_server_opensearch --transport stream
 ```
 
 ### Multi Mode
@@ -416,6 +451,21 @@ python -m mcp_server_opensearch --mode multi --config config.yml --profile my-aw
 # Fallback to single mode behavior (no config file)
 python -m mcp_server_opensearch --mode multi
 ```
+
+### Kubernetes Deployment
+
+For Kubernetes deployments, run the server in streaming mode behind a `Service` and `Ingress`, and mount the OpenSearch CA/client certificate files from a secret:
+
+1. Build the image with the included [Dockerfile](./Dockerfile).
+2. Create a secret containing `ca.crt`, `tls.crt`, and `tls.key`.
+3. Mount that secret into the pod and set:
+   - `OPENSEARCH_CA_CERT_PATH`
+   - `OPENSEARCH_CLIENT_CERT_PATH`
+   - `OPENSEARCH_CLIENT_KEY_PATH`
+4. Expose the pod through a `Service`.
+5. Publish `/mcp` and `/health` through an `Ingress`.
+
+See [deploy/k8s/mcp-server.example.yaml](./deploy/k8s/mcp-server.example.yaml) for a complete example manifest.
 
 ## Command Line Parameters
 
@@ -454,6 +504,9 @@ python -m mcp_server_opensearch --mode multi
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `OPENSEARCH_SSL_VERIFY` | No | `"true"` | Control SSL certificate verification (`"true"` or `"false"`) |
+| `OPENSEARCH_CA_CERT_PATH` | No | `''` | Path to the CA certificate bundle used to verify the OpenSearch server |
+| `OPENSEARCH_CLIENT_CERT_PATH` | No | `''` | Path to the client certificate used for OpenSearch mTLS |
+| `OPENSEARCH_CLIENT_KEY_PATH` | No | `''` | Path to the client private key used for OpenSearch mTLS |
 
 ### Response Size Control Variables
 
@@ -497,6 +550,9 @@ When using multi-mode, each cluster in your YAML configuration file accepts the 
 | `is_serverless` | boolean | No | Set to `true` for OpenSearch Serverless |
 | `opensearch_no_auth` | boolean | No | Set to `true` to connect without authentication |
 | `opensearch_header_auth` | boolean | No | Set to `true` to enable header-based authentication (headers take priority over config values) |
+| `opensearch_ca_cert_path` | string | No | Path to the CA certificate bundle used to verify the OpenSearch server |
+| `opensearch_client_cert_path` | string | No | Path to the client certificate used for OpenSearch mTLS |
+| `opensearch_client_key_path` | string | No | Path to the client private key used for OpenSearch mTLS |
 | `timeout` | integer | No | Connection timeout in seconds for OpenSearch operations |
 | `max_response_size` | integer | No | Maximum response size in bytes (defaults to 10MB if not specified) |
 
@@ -510,6 +566,7 @@ When using multi-mode, each cluster in your YAML configuration file accepts the 
 | **Header-Based Authentication** | `opensearch_header_auth: true`, Required from header/config/env: `opensearch_url`, `aws-region`, `aws-access-key-id`, `aws-secret-access-key` | `aws-session-token`, `aws-service-name` |
 | **IAM Role Authentication** | `opensearch_url`, `iam_arn`, `aws_region` | `profile` |
 | **Basic Authentication** | `opensearch_url`, `opensearch_username`, `opensearch_password` | `profile` |
+| **Mutual TLS (mTLS)** | `opensearch_client_cert_path`, `opensearch_client_key_path` | `opensearch_ca_cert_path` |
 | **AWS Credentials Authentication** | `opensearch_url` | `aws_region`, `profile` |
 | **OpenSearch Serverless** | `opensearch_url`, `aws_region` | `profile`, `is_serverless: true` |
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -465,8 +465,6 @@ For Kubernetes deployments, run the server in streaming mode behind a `Service` 
 4. Expose the pod through a `Service`.
 5. Publish `/mcp` and `/health` through an `Ingress`.
 
-See [deploy/k8s/mcp-server.example.yaml](./deploy/k8s/mcp-server.example.yaml) for a complete example manifest.
-
 ## Command Line Parameters
 
 | Parameter | Type | Default | Description |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -452,18 +452,7 @@ python -m mcp_server_opensearch --mode multi --config config.yml --profile my-aw
 python -m mcp_server_opensearch --mode multi
 ```
 
-### Kubernetes Deployment
 
-For Kubernetes deployments, run the server in streaming mode behind a `Service` and `Ingress`, and mount the OpenSearch CA/client certificate files from a secret:
-
-1. Build the image with the included [Dockerfile](./Dockerfile).
-2. Create a secret containing `ca.crt`, `tls.crt`, and `tls.key`.
-3. Mount that secret into the pod and set:
-   - `OPENSEARCH_CA_CERT_PATH`
-   - `OPENSEARCH_CLIENT_CERT_PATH`
-   - `OPENSEARCH_CLIENT_KEY_PATH`
-4. Expose the pod through a `Service`.
-5. Publish `/mcp` and `/health` through an `Ingress`.
 
 ## Command Line Parameters
 

--- a/example_config.yml
+++ b/example_config.yml
@@ -19,6 +19,14 @@ clusters:
     iam_arn: "arn:aws:iam::123456789012:role/YourOpenSearchRole"
     aws_region: "us-east-2"
     profile: "your-aws-profile"
+  
+  mtls-cluster:
+    opensearch_url: "https://your-private-opensearch.example.com:9200"
+    opensearch_username: "admin"
+    opensearch_password: "your_password_here"
+    opensearch_ca_cert_path: "/var/run/opensearch-mtls/ca.crt"
+    opensearch_client_cert_path: "/var/run/opensearch-mtls/tls.crt"
+    opensearch_client_key_path: "/var/run/opensearch-mtls/tls.key"
 
   serverless-cluster:
     opensearch_url: "https://collection-id.us-east-1.aoss.amazonaws.com"
@@ -34,7 +42,7 @@ clusters:
     opensearch_url: "https://your-opensearch-domain.us-east-2.es.amazonaws.com"
     opensearch_header_auth: true
 
-Tool customization configurations (supported in both Single and Multi Mode)
+# Tool customization configurations (supported in both Single and Multi Mode)
 tools:
   ListIndexTool:
     display_name: "My_Custom_Index_Lister"
@@ -105,4 +113,9 @@ tools:
 #    - Prevents memory issues by limiting response size
 #    - Default: 10MB (10485760 bytes)
 #    - Can be set per cluster or globally via OPENSEARCH_MAX_RESPONSE_SIZE env var
-#    - Example: max_response_size: 5242880  # 5MB limit 
+#    - Example: max_response_size: 5242880  # 5MB limit
+#
+# 7. mTLS:
+#    - Optional: opensearch_ca_cert_path, opensearch_client_cert_path, opensearch_client_key_path
+#    - Client certificate and key must be provided together
+#    - Useful when connecting from Kubernetes to private OpenSearch clusters over mutual TLS

--- a/src/mcp_server_opensearch/clusters_information.py
+++ b/src/mcp_server_opensearch/clusters_information.py
@@ -22,6 +22,9 @@ class ClusterInfo(BaseModel):
     opensearch_no_auth: Optional[bool] = None
     ssl_verify: Optional[bool] = None
     opensearch_header_auth: Optional[bool] = None
+    opensearch_ca_cert_path: Optional[str] = None
+    opensearch_client_cert_path: Optional[str] = None
+    opensearch_client_key_path: Optional[str] = None
     max_response_size: Optional[int] = None
 
 
@@ -116,6 +119,13 @@ async def load_clusters_from_yaml(file_path: str) -> None:
                     opensearch_no_auth=cluster_config.get('opensearch_no_auth', None),
                     ssl_verify=cluster_config.get('ssl_verify', None),
                     opensearch_header_auth=cluster_config.get('opensearch_header_auth', None),
+                    opensearch_ca_cert_path=cluster_config.get('opensearch_ca_cert_path', None),
+                    opensearch_client_cert_path=cluster_config.get(
+                        'opensearch_client_cert_path', None
+                    ),
+                    opensearch_client_key_path=cluster_config.get(
+                        'opensearch_client_key_path', None
+                    ),
                     max_response_size=cluster_config.get('max_response_size', None),
                 )
 

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -197,7 +197,10 @@ def _initialize_client_single_mode() -> AsyncOpenSearch:
         opensearch_timeout_str = os.getenv('OPENSEARCH_TIMEOUT', '').strip()
         opensearch_timeout = int(opensearch_timeout_str) if opensearch_timeout_str else None
         ssl_verify = os.getenv('OPENSEARCH_SSL_VERIFY', 'true').lower() != 'false'
-        
+        opensearch_ca_cert_path = _get_env_path('OPENSEARCH_CA_CERT_PATH')
+        opensearch_client_cert_path = _get_env_path('OPENSEARCH_CLIENT_CERT_PATH')
+        opensearch_client_key_path = _get_env_path('OPENSEARCH_CLIENT_KEY_PATH')
+
         # Parse max response size from environment
         max_response_size_str = os.getenv('OPENSEARCH_MAX_RESPONSE_SIZE', '').strip()
         max_response_size = None
@@ -278,6 +281,9 @@ def _initialize_client_single_mode() -> AsyncOpenSearch:
             aws_session_token=aws_session_token,
             max_response_size=max_response_size,
             bearer_auth_header=bearer_auth_header,
+            opensearch_ca_cert_path=opensearch_ca_cert_path,
+            opensearch_client_cert_path=opensearch_client_cert_path,
+            opensearch_client_key_path=opensearch_client_key_path,
         )
 
     except (ConfigurationError, AuthenticationError):
@@ -323,7 +329,14 @@ def _initialize_client_multi_mode(cluster_info: ClusterInfo) -> AsyncOpenSearch:
         ssl_verify = True  # Default to secure
         if cluster_info.ssl_verify is not None:
             ssl_verify = cluster_info.ssl_verify
-        
+        opensearch_ca_cert_path = _normalize_path_value(cluster_info.opensearch_ca_cert_path)
+        opensearch_client_cert_path = _normalize_path_value(
+            cluster_info.opensearch_client_cert_path
+        )
+        opensearch_client_key_path = _normalize_path_value(
+            cluster_info.opensearch_client_key_path
+        )
+
         # Get max response size from cluster config, fallback to environment variable
         max_response_size = cluster_info.max_response_size
         if max_response_size is None:
@@ -392,6 +405,9 @@ def _initialize_client_multi_mode(cluster_info: ClusterInfo) -> AsyncOpenSearch:
             aws_session_token=aws_session_token,
             max_response_size=max_response_size,
             bearer_auth_header=bearer_auth_header,
+            opensearch_ca_cert_path=opensearch_ca_cert_path,
+            opensearch_client_cert_path=opensearch_client_cert_path,
+            opensearch_client_key_path=opensearch_client_key_path,
         )
 
     except (ConfigurationError, AuthenticationError):
@@ -421,6 +437,9 @@ def _create_opensearch_client(
     aws_session_token: Optional[str] = None,
     max_response_size: Optional[int] = None,
     bearer_auth_header: Optional[str] = None,
+    opensearch_ca_cert_path: Optional[str] = None,
+    opensearch_client_cert_path: Optional[str] = None,
+    opensearch_client_key_path: Optional[str] = None,
 ) -> AsyncOpenSearch:
     """Common function to create OpenSearch client with authentication.
 
@@ -443,6 +462,9 @@ def _create_opensearch_client(
         aws_session_token: AWS session token from headers (optional)
         max_response_size: Maximum response size in bytes (None means no limit)
         bearer_auth_header: Authorization Bearer header value (optional)
+        opensearch_ca_cert_path: Path to the CA certificate bundle for verifying TLS
+        opensearch_client_cert_path: Path to the client certificate for mTLS
+        opensearch_client_key_path: Path to the client private key for mTLS
 
     Returns:
         OpenSearch: An initialized OpenSearch client instance
@@ -483,6 +505,12 @@ def _create_opensearch_client(
     response_size_limit = (
         max_response_size if max_response_size is not None else DEFAULT_MAX_RESPONSE_SIZE
     )
+    tls_config = _build_tls_kwargs(
+        ssl_verify=ssl_verify,
+        opensearch_ca_cert_path=opensearch_ca_cert_path,
+        opensearch_client_cert_path=opensearch_client_cert_path,
+        opensearch_client_key_path=opensearch_client_key_path,
+    )
 
     # Build client configuration with buffered connection
     client_kwargs: Dict[str, Any] = {
@@ -493,6 +521,7 @@ def _create_opensearch_client(
         'timeout': timeout,
         'max_response_size': response_size_limit,
     }
+    client_kwargs.update(tls_config)
     
     if response_size_limit is not None:
         logger.info(
@@ -619,6 +648,67 @@ def _create_opensearch_client(
 
     # This should never be reached, but just in case
     raise AuthenticationError('No valid authentication method provided for OpenSearch')
+
+
+def _get_env_path(env_var_name: str) -> Optional[str]:
+    """Return a normalized path value from the environment."""
+    return _normalize_path_value(os.getenv(env_var_name, ''))
+
+
+def _normalize_path_value(path_value: Optional[str]) -> Optional[str]:
+    """Normalize a configured filesystem path, treating blank values as unset."""
+    if path_value is None:
+        return None
+
+    normalized_path = path_value.strip()
+    if not normalized_path:
+        return None
+
+    return normalized_path
+
+
+def _validate_tls_file_path(path: str, description: str) -> str:
+    """Validate that a configured TLS file path exists."""
+    if not os.path.isfile(path):
+        raise ConfigurationError(f'{description} file does not exist or is not a file: {path}')
+
+    return path
+
+
+def _build_tls_kwargs(
+    ssl_verify: bool,
+    opensearch_ca_cert_path: Optional[str] = None,
+    opensearch_client_cert_path: Optional[str] = None,
+    opensearch_client_key_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build TLS-related OpenSearch client kwargs from configured certificate paths."""
+    tls_kwargs: Dict[str, Any] = {}
+    has_client_cert = opensearch_client_cert_path is not None
+    has_client_key = opensearch_client_key_path is not None
+
+    if has_client_cert != has_client_key:
+        raise ConfigurationError(
+            'OpenSearch mTLS requires both client certificate and client key paths to be set'
+        )
+
+    if opensearch_ca_cert_path is not None:
+        tls_kwargs['ca_certs'] = _validate_tls_file_path(
+            opensearch_ca_cert_path, 'OpenSearch CA certificate'
+        )
+
+    if has_client_cert and has_client_key:
+        tls_kwargs['client_cert'] = _validate_tls_file_path(
+            opensearch_client_cert_path, 'OpenSearch client certificate'
+        )
+        tls_kwargs['client_key'] = _validate_tls_file_path(
+            opensearch_client_key_path, 'OpenSearch client key'
+        )
+        if not ssl_verify and 'ca_certs' not in tls_kwargs:
+            logger.warning(
+                'OpenSearch mTLS is configured with SSL verification disabled and no CA bundle'
+            )
+
+    return tls_kwargs
 
 
 def get_aws_region_single_mode() -> Optional[str]:

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -668,9 +668,12 @@ def _normalize_path_value(path_value: Optional[str]) -> Optional[str]:
 
 
 def _validate_tls_file_path(path: str, description: str) -> str:
-    """Validate that a configured TLS file path exists."""
+    """Validate that a configured TLS file path exists and is readable."""
     if not os.path.isfile(path):
         raise ConfigurationError(f'{description} file does not exist or is not a file: {path}')
+
+    if not os.access(path, os.R_OK):
+        raise ConfigurationError(f'{description} file is not readable: {path}')
 
     return path
 

--- a/tests/mcp_server_opensearch/test_clusters_information.py
+++ b/tests/mcp_server_opensearch/test_clusters_information.py
@@ -35,6 +35,9 @@ class TestClusterInfo:
             profile='default',
             timeout=30,
             opensearch_no_auth=True,
+            opensearch_ca_cert_path='/tmp/ca.pem',
+            opensearch_client_cert_path='/tmp/client.pem',
+            opensearch_client_key_path='/tmp/client.key',
         )
         assert cluster.opensearch_url == 'https://localhost:9200'
         assert cluster.iam_arn == 'arn:aws:iam::123456789012:role/OpenSearchRole'
@@ -44,6 +47,9 @@ class TestClusterInfo:
         assert cluster.profile == 'default'
         assert cluster.timeout == 30
         assert cluster.opensearch_no_auth is True
+        assert cluster.opensearch_ca_cert_path == '/tmp/ca.pem'
+        assert cluster.opensearch_client_cert_path == '/tmp/client.pem'
+        assert cluster.opensearch_client_key_path == '/tmp/client.key'
 
     def test_cluster_info_with_timeout_only(self):
         """Test creating ClusterInfo with timeout parameter."""
@@ -132,6 +138,9 @@ clusters:
     opensearch_username: "admin"
     opensearch_password: "password"
     timeout: 45
+    opensearch_ca_cert_path: "/etc/opensearch/ca.pem"
+    opensearch_client_cert_path: "/etc/opensearch/tls.crt"
+    opensearch_client_key_path: "/etc/opensearch/tls.key"
   cluster2:
     opensearch_url: "https://localhost:9201"
     iam_arn: "arn:aws:iam::123456789012:role/OpenSearchRole"
@@ -154,6 +163,9 @@ clusters:
         assert cluster1.opensearch_username == 'admin'
         assert cluster1.opensearch_password == 'password'
         assert cluster1.timeout == 45
+        assert cluster1.opensearch_ca_cert_path == '/etc/opensearch/ca.pem'
+        assert cluster1.opensearch_client_cert_path == '/etc/opensearch/tls.crt'
+        assert cluster1.opensearch_client_key_path == '/etc/opensearch/tls.key'
 
         cluster2 = cluster_registry['cluster2']
         assert cluster2.opensearch_url == 'https://localhost:9201'

--- a/tests/opensearch/test_client.py
+++ b/tests/opensearch/test_client.py
@@ -3,6 +3,8 @@
 
 import boto3
 import os
+import tempfile
+
 import pytest
 from opensearch.client import initialize_client, ConfigurationError, AuthenticationError, BufferedAsyncHttpConnection
 from opensearchpy import AsyncOpenSearch, AsyncHttpConnection, AWSV4SignerAsyncAuth
@@ -22,6 +24,9 @@ class TestOpenSearchClient:
             'OPENSEARCH_URL',
             'OPENSEARCH_NO_AUTH',
             'OPENSEARCH_SSL_VERIFY',
+            'OPENSEARCH_CA_CERT_PATH',
+            'OPENSEARCH_CLIENT_CERT_PATH',
+            'OPENSEARCH_CLIENT_KEY_PATH',
             'OPENSEARCH_TIMEOUT',
             'AWS_IAM_ARN',
             'AWS_ACCESS_KEY_ID',
@@ -30,25 +35,6 @@ class TestOpenSearchClient:
         ]:
             if key in os.environ:
                 self.original_env[key] = os.environ[key]
-                del os.environ[key]
-
-    def setup_method(self):
-        """Setup before each test method."""
-        # Clear environment variables to ensure clean test state
-        for key in [
-            'OPENSEARCH_USERNAME',
-            'OPENSEARCH_PASSWORD',
-            'AWS_REGION',
-            'OPENSEARCH_URL',
-            'OPENSEARCH_NO_AUTH',
-            'OPENSEARCH_SSL_VERIFY',
-            'OPENSEARCH_TIMEOUT',
-            'AWS_IAM_ARN',
-            'AWS_ACCESS_KEY_ID',
-            'AWS_SECRET_ACCESS_KEY',
-            'AWS_SESSION_TOKEN',
-        ]:
-            if key in os.environ:
                 del os.environ[key]
 
         # Set global mode for tests
@@ -208,6 +194,47 @@ class TestOpenSearchClient:
             max_response_size=None,  # No limit by default
         )
 
+    @patch('opensearch.client.AsyncOpenSearch')
+    @patch('opensearch.client.get_aws_region_single_mode')
+    def test_initialize_client_basic_auth_with_mtls(self, mock_get_region, mock_opensearch):
+        """Test client initialization with CA, client cert, and client key."""
+        with (
+            tempfile.NamedTemporaryFile() as ca_file,
+            tempfile.NamedTemporaryFile() as cert_file,
+            tempfile.NamedTemporaryFile() as key_file,
+        ):
+            os.environ['OPENSEARCH_USERNAME'] = 'test-user'
+            os.environ['OPENSEARCH_PASSWORD'] = 'test-password'
+            os.environ['OPENSEARCH_URL'] = 'https://test-opensearch-domain.com'
+            os.environ['OPENSEARCH_CA_CERT_PATH'] = ca_file.name
+            os.environ['OPENSEARCH_CLIENT_CERT_PATH'] = cert_file.name
+            os.environ['OPENSEARCH_CLIENT_KEY_PATH'] = key_file.name
+
+            mock_get_region.return_value = 'us-east-1'
+            mock_client = Mock()
+            mock_opensearch.return_value = mock_client
+
+            client = initialize_client(baseToolArgs(opensearch_cluster_name=''))
+
+            assert client == mock_client
+            call_kwargs = mock_opensearch.call_args[1]
+            assert call_kwargs['ca_certs'] == ca_file.name
+            assert call_kwargs['client_cert'] == cert_file.name
+            assert call_kwargs['client_key'] == key_file.name
+            assert call_kwargs['http_auth'] == ('test-user', 'test-password')
+
+    def test_initialize_client_rejects_partial_mtls_env_config(self):
+        """Test that partial mTLS configuration is rejected in single mode."""
+        with tempfile.NamedTemporaryFile() as cert_file:
+            os.environ['OPENSEARCH_URL'] = 'https://test-opensearch-domain.com'
+            os.environ['OPENSEARCH_NO_AUTH'] = 'true'
+            os.environ['OPENSEARCH_CLIENT_CERT_PATH'] = cert_file.name
+
+            with pytest.raises(ConfigurationError) as exc_info:
+                initialize_client(baseToolArgs(opensearch_cluster_name=''))
+
+        assert 'requires both client certificate and client key paths' in str(exc_info.value)
+
     @patch('opensearch.client._initialize_client_single_mode')
     def test_initialize_client_with_timeout_env(self, mock_init):
         """Test client initialization with timeout from environment."""
@@ -277,6 +304,40 @@ class TestOpenSearchClient:
         assert call_kwargs['max_response_size'] is None  # No limit by default
         # Should not have http_auth when no-auth is True
         assert 'http_auth' not in call_kwargs
+
+    @patch('opensearch.client.AsyncOpenSearch')
+    @patch('opensearch.client.get_aws_region_multi_mode')
+    def test__initialize_client_multi_mode_with_mtls(self, mock_get_region, mock_opensearch):
+        """Test client initialization with mTLS paths from cluster config."""
+        from mcp_server_opensearch.clusters_information import ClusterInfo
+        from opensearch.client import _initialize_client_multi_mode
+
+        with (
+            tempfile.NamedTemporaryFile() as ca_file,
+            tempfile.NamedTemporaryFile() as cert_file,
+            tempfile.NamedTemporaryFile() as key_file,
+        ):
+            cluster_info = ClusterInfo(
+                opensearch_url='https://localhost:9200',
+                opensearch_username='admin',
+                opensearch_password='password',
+                opensearch_ca_cert_path=ca_file.name,
+                opensearch_client_cert_path=cert_file.name,
+                opensearch_client_key_path=key_file.name,
+            )
+
+            mock_get_region.return_value = 'us-east-1'
+            mock_client = Mock()
+            mock_opensearch.return_value = mock_client
+
+            client = _initialize_client_multi_mode(cluster_info)
+
+            assert client == mock_client
+            call_kwargs = mock_opensearch.call_args[1]
+            assert call_kwargs['ca_certs'] == ca_file.name
+            assert call_kwargs['client_cert'] == cert_file.name
+            assert call_kwargs['client_key'] == key_file.name
+            assert call_kwargs['http_auth'] == ('admin', 'password')
 
     @patch('opensearch.client.AsyncOpenSearch')
     @patch('opensearch.client.get_aws_region_multi_mode')
@@ -362,6 +423,9 @@ class TestOpenSearchClientContextManager:
             'OPENSEARCH_URL',
             'OPENSEARCH_NO_AUTH',
             'OPENSEARCH_SSL_VERIFY',
+            'OPENSEARCH_CA_CERT_PATH',
+            'OPENSEARCH_CLIENT_CERT_PATH',
+            'OPENSEARCH_CLIENT_KEY_PATH',
             'OPENSEARCH_TIMEOUT',
             'AWS_IAM_ARN',
             'AWS_ACCESS_KEY_ID',

--- a/tests/opensearch/test_response_size_limiting.py
+++ b/tests/opensearch/test_response_size_limiting.py
@@ -6,6 +6,8 @@ Unit tests for response size limiting functionality.
 """
 
 import asyncio
+import os
+import tempfile
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
@@ -13,6 +15,7 @@ from aiohttp import ClientResponse
 import ssl
 
 from opensearch.client import (
+    ConfigurationError,
     _create_opensearch_client,
 )
 from opensearch.connection import (
@@ -257,6 +260,57 @@ class TestCreateOpenSearchClient:
         assert call_kwargs['timeout'] == 60
         assert call_kwargs['verify_certs'] is False
         assert call_kwargs['http_auth'] == ('user', 'pass')
+
+    @patch('opensearch.client.AsyncOpenSearch')
+    def test_create_client_with_mtls_parameters(self, mock_opensearch):
+        """Test client creation with CA, client cert, and client key."""
+        mock_client = MagicMock()
+        mock_opensearch.return_value = mock_client
+
+        with (
+            tempfile.NamedTemporaryFile() as ca_file,
+            tempfile.NamedTemporaryFile() as cert_file,
+            tempfile.NamedTemporaryFile() as key_file,
+        ):
+            _create_opensearch_client(
+                opensearch_url='https://test.com:9200',
+                opensearch_no_auth=True,
+                opensearch_ca_cert_path=ca_file.name,
+                opensearch_client_cert_path=cert_file.name,
+                opensearch_client_key_path=key_file.name,
+            )
+
+        call_kwargs = mock_opensearch.call_args[1]
+        assert call_kwargs['ca_certs'] == ca_file.name
+        assert call_kwargs['client_cert'] == cert_file.name
+        assert call_kwargs['client_key'] == key_file.name
+
+    def test_create_client_rejects_partial_mtls_config(self):
+        """Test client creation rejects missing client key when client cert is set."""
+        with tempfile.NamedTemporaryFile() as cert_file:
+            with pytest.raises(ConfigurationError) as exc_info:
+                _create_opensearch_client(
+                    opensearch_url='https://test.com:9200',
+                    opensearch_no_auth=True,
+                    opensearch_client_cert_path=cert_file.name,
+                )
+
+        assert 'requires both client certificate and client key paths' in str(exc_info.value)
+
+    def test_create_client_rejects_missing_ca_file(self):
+        """Test client creation rejects non-existent CA file paths."""
+        missing_path = os.path.join(tempfile.gettempdir(), 'missing-ca.pem')
+        if os.path.exists(missing_path):
+            os.unlink(missing_path)
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            _create_opensearch_client(
+                opensearch_url='https://test.com:9200',
+                opensearch_no_auth=True,
+                opensearch_ca_cert_path=missing_path,
+            )
+
+        assert 'CA certificate file does not exist' in str(exc_info.value)
 
 
 class TestClusterInfoMaxResponseSize:


### PR DESCRIPTION
 ## Summary

  This PR adds outbound mutual TLS (mTLS) support to the Python OpenSearch MCP server so it can connect to OpenSearch clusters that require client certificates while preserving old behaviour

  It introduces mTLS configuration for both:
  - single mode via environment variables
  - multi mode via YAML cluster config

  It also adds:
  - validation for mTLS certificate/key path combinations
  - updated docs and example config
  - unit test coverage for env parsing, YAML parsing, and client construction

  Closes #168 (https://github.com/opensearch-project/opensearch-mcp-server-py/issues/168)

  ## Motivation

  The current server supports basic auth, AWS auth, header auth, and no-auth, but does not support OpenSearch clusters that require client certificate authentication.

  This blocks deployment scenarios where:
  - the MCP server runs inside Kubernetes
  - OpenSearch is accessible only over mTLS
  - the MCP endpoint needs to be exposed separately for remote clients

  This PR adds the missing transport-layer TLS configuration without changing the MCP tool interface.

  ## What Changed

  ### OpenSearch client
  - Added support for:
    - `OPENSEARCH_CA_CERT_PATH`
    - `OPENSEARCH_CLIENT_CERT_PATH`
    - `OPENSEARCH_CLIENT_KEY_PATH`
  - Threaded these through single-mode and multi-mode client initialization
  - Passed the resulting TLS kwargs into `AsyncOpenSearch`
  - Added validation:
    - client cert and client key must be provided together
    - configured TLS files must exist

  ### Multi-cluster config
  - Extended `ClusterInfo` with:
    - `opensearch_ca_cert_path`
    - `opensearch_client_cert_path`
    - `opensearch_client_key_path`
  - Added YAML loading support for these fields

  ## Testing

  Ran:
  ```bash
  uv run pytest tests/opensearch/test_client.py tests/opensearch/test_response_size_limiting.py tests/mcp_server_opensearch/test_clusters_information.py
  uv run pytest tests/mcp_server_opensearch/test_streaming_server.py