### PR TITLE
Add ListClusters Tool In Multi-Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add Search Relevance Workbench tools for judgment list management (create, get, delete) ([#190](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/190))
 - Add Search Relevance Workbench tools for experiment management (create, get, delete) ([#192](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/192))
 - Add Search Relevance Workbench `_search` API tools for querying query sets, search configurations, judgments, and experiments using OpenSearch query DSL ([#193](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/193))
+- Add `ListClustersTool` for discovering available clusters in multi-cluster mode ([#210](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/210))
 
 ### Improved
 

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -385,6 +385,10 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
         tool_info = info.copy()
         tool_name = tool_info['display_name']
 
+        # Skip multi-only tools in single mode
+        if info.get('multi_only') and mode != 'multi':
+            continue
+
         # If tool is not compatible with the current OpenSearch version, skip, don't enable
         if not is_tool_compatible(version, info):
             continue

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -62,6 +62,12 @@ class baseToolArgs(BaseModel):
     opensearch_cluster_name: str = Field(description='The name of the OpenSearch cluster')
 
 
+class ListClustersArgs(BaseModel):
+    """Arguments for the ListClustersTool. No parameters required."""
+
+    pass
+
+
 class ListIndicesArgs(baseToolArgs):
     index: str = Field(
         default='',

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -23,6 +23,7 @@ from .tool_params import (
     GetSearchConfigurationArgs,
     GetSegmentsArgs,
     GetShardsArgs,
+    ListClustersArgs,
     ListIndicesArgs,
     SearchIndexArgs,
     GetQuerySetArgs,
@@ -79,6 +80,16 @@ from opensearch.helper import (
     search_experiments,
 )
 from .skills_tools import SKILLS_TOOLS_REGISTRY
+from mcp_server_opensearch.clusters_information import cluster_registry
+
+
+async def list_clusters_tool(args: ListClustersArgs) -> list[dict]:
+    try:
+        cluster_names = list(cluster_registry.keys())
+        formatted_names = json.dumps(cluster_names, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Available clusters:\n{formatted_names}'}]
+    except Exception as e:
+        return log_tool_error('ListClustersTool', e, 'listing clusters')
 
 
 async def check_tool_compatibility(tool_name: str, args: baseToolArgs = None):
@@ -1218,5 +1229,14 @@ TOOL_REGISTRY = {
         'args_model': CreateLLMJudgmentListArgs,
         'min_version': '3.1.0',
         'http_methods': 'PUT',
+    },
+    'ListClustersTool': {
+        'display_name': 'ListClustersTool',
+        'description': 'Lists all available OpenSearch clusters configured in the server. Returns the cluster names that can be used with other tools.',
+        'input_schema': ListClustersArgs.model_json_schema(),
+        'function': list_clusters_tool,
+        'args_model': ListClustersArgs,
+        'http_methods': 'GET',
+        'multi_only': True,
     },
 }

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -739,3 +739,91 @@ class TestAllowWriteSettings:
 
             mock_resolve.assert_called_once_with('/path/to/config.yml')
             mock_set.assert_called_once_with(False)
+
+
+class TestMultiOnlyFilter:
+    """Test cases for multi_only tool filtering in get_tools."""
+
+    def setup_method(self):
+        from mcp_server_opensearch.global_state import set_mode
+
+        set_mode('single')
+
+    @pytest.fixture
+    def registry_with_multi_only(self):
+        """Return a registry containing a multi_only tool and a normal tool."""
+        return {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {'param1': {'type': 'string'}}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.0.0',
+            },
+            'ListClustersTool': {
+                'display_name': 'ListClustersTool',
+                'description': 'Lists clusters',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'http_methods': 'GET',
+                'multi_only': True,
+            },
+        }
+
+    @pytest.fixture
+    def mock_patches(self):
+        with (
+            patch('tools.tool_filter.get_opensearch_version') as mock_get_version,
+            patch('tools.tool_filter.is_tool_compatible', return_value=True) as mock_is_compatible,
+        ):
+            yield mock_get_version, mock_is_compatible
+
+    @pytest.mark.asyncio
+    async def test_multi_only_tool_excluded_in_single_mode(
+        self, registry_with_multi_only, mock_patches
+    ):
+        """Test that multi_only tools are excluded when running in single mode."""
+        mock_get_version, _ = mock_patches
+        mock_get_version.return_value = Version.parse('2.5.0')
+
+        with patch('tools.tool_filter.TOOL_REGISTRY', registry_with_multi_only):
+            result = await get_tools(registry_with_multi_only)
+
+        assert 'ListIndexTool' in result
+        assert 'ListClustersTool' not in result
+
+    @pytest.mark.asyncio
+    async def test_multi_only_tool_included_in_multi_mode(self, registry_with_multi_only):
+        """Test that multi_only tools are included when running in multi mode."""
+        from mcp_server_opensearch.global_state import set_mode
+
+        set_mode('multi')
+
+        result = await get_tools(registry_with_multi_only)
+
+        assert 'ListIndexTool' in result
+        assert 'ListClustersTool' in result
+
+    @pytest.mark.asyncio
+    async def test_tools_without_multi_only_unaffected(self, mock_patches):
+        """Test that tools without multi_only flag are not affected by the filter."""
+        mock_get_version, _ = mock_patches
+        mock_get_version.return_value = Version.parse('2.5.0')
+
+        registry = {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.0.0',
+            },
+        }
+
+        with patch('tools.tool_filter.TOOL_REGISTRY', registry):
+            result = await get_tools(registry)
+
+        assert 'ListIndexTool' in result

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -1357,3 +1357,84 @@ class TestTools:
         )
         assert self.GetShardsArgs(index='test', opensearch_cluster_name='').index == 'test'
         assert isinstance(self.ListIndicesArgs(opensearch_cluster_name=''), self.ListIndicesArgs)
+
+
+class TestListClustersTool:
+    """Test cases for the list_clusters_tool function."""
+
+    def setup_method(self):
+        """Setup that runs before each test method."""
+        self.init_client_patcher = patch(
+            'opensearch.client.initialize_client', return_value=Mock()
+        )
+        self.init_client_patcher.start()
+
+        from tools.tools import list_clusters_tool, ListClustersArgs
+
+        self._list_clusters_tool = list_clusters_tool
+        self.ListClustersArgs = ListClustersArgs
+
+    def teardown_method(self):
+        self.init_client_patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_list_clusters_returns_cluster_names(self):
+        """Test that list_clusters_tool returns names from cluster_registry."""
+        with patch(
+            'tools.tools.cluster_registry',
+            {'cluster-a': Mock(), 'cluster-b': Mock(), 'cluster-c': Mock()},
+        ):
+            args = self.ListClustersArgs()
+            result = await self._list_clusters_tool(args)
+
+            assert len(result) == 1
+            assert result[0]['type'] == 'text'
+            assert 'cluster-a' in result[0]['text']
+            assert 'cluster-b' in result[0]['text']
+            assert 'cluster-c' in result[0]['text']
+            # Verify it's valid JSON in the output
+            text = result[0]['text']
+            json_part = text.split('\n', 1)[1]
+            parsed = json.loads(json_part)
+            assert parsed == ['cluster-a', 'cluster-b', 'cluster-c']
+
+    @pytest.mark.asyncio
+    async def test_list_clusters_empty_registry(self):
+        """Test that list_clusters_tool returns empty list when no clusters configured."""
+        with patch('tools.tools.cluster_registry', {}):
+            args = self.ListClustersArgs()
+            result = await self._list_clusters_tool(args)
+
+            assert len(result) == 1
+            assert result[0]['type'] == 'text'
+            text = result[0]['text']
+            json_part = text.split('\n', 1)[1]
+            parsed = json.loads(json_part)
+            assert parsed == []
+
+    @pytest.mark.asyncio
+    async def test_list_clusters_single_cluster(self):
+        """Test with a single cluster in the registry."""
+        with patch('tools.tools.cluster_registry', {'my-cluster': Mock()}):
+            args = self.ListClustersArgs()
+            result = await self._list_clusters_tool(args)
+
+            text = result[0]['text']
+            json_part = text.split('\n', 1)[1]
+            parsed = json.loads(json_part)
+            assert parsed == ['my-cluster']
+
+    def test_list_clusters_args_accepts_extra_fields(self):
+        """Test that ListClustersArgs doesn't reject extra fields like opensearch_cluster_name."""
+        args = self.ListClustersArgs(**{'opensearch_cluster_name': 'test'})
+        assert args is not None
+
+    def test_list_clusters_in_tool_registry(self):
+        """Test that ListClustersTool is present in TOOL_REGISTRY with correct metadata."""
+        from tools.tools import TOOL_REGISTRY
+
+        assert 'ListClustersTool' in TOOL_REGISTRY
+        tool_info = TOOL_REGISTRY['ListClustersTool']
+        assert tool_info['display_name'] == 'ListClustersTool'
+        assert tool_info['multi_only'] is True
+        assert tool_info['http_methods'] == 'GET'


### PR DESCRIPTION
### Description
This PR adds a new `ListClustersTool` when the MCP is in multi-mode. This is solving an issue where all MCP tools requires cluster name when running in multi-mode, BUT there's no tool to actually list the available cluster names. 

### Issues Resolved
N/A

### Testing
- All unit tests pass: `uv run pytest`
- Started MCP locally in multi-mode, confirmed `ListClustersTool` tool works:
<img width="645" height="420" alt="image" src="https://github.com/user-attachments/assets/22096336-902f-4483-b423-192461cc2736" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).