### PR TITLE
Add tools for asynchronous search

### DIFF
--- a/scripts/smoke_test_async_search.py
+++ b/scripts/smoke_test_async_search.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import json
+import sys
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from typing import Any
+
+
+ASYNC_TOOL_NAMES = (
+    'SubmitAsyncSearchTool',
+    'GetAsyncSearchTool',
+    'DeleteAsyncSearchTool',
+)
+GENERIC_TOOL_NAME = 'GenericOpenSearchApiTool'
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the smoke test."""
+    parser = argparse.ArgumentParser(
+        description='Smoke test the Async Search MCP tools against a running local MCP server.'
+    )
+    parser.add_argument(
+        '--server-url',
+        default='http://localhost:9900/mcp',
+        help='Streamable HTTP MCP endpoint. Default: http://localhost:9900/mcp',
+    )
+    parser.add_argument(
+        '--index',
+        help='Target index name or pattern for SubmitAsyncSearchTool.',
+    )
+    parser.add_argument(
+        '--query',
+        default='{"query":{"match_all":{}}}',
+        help='Query DSL as a JSON string. Default: {"query":{"match_all":{}}}',
+    )
+    parser.add_argument(
+        '--cluster-name',
+        default='',
+        help='OpenSearch cluster name to include when the MCP server is running in multi mode.',
+    )
+    parser.add_argument(
+        '--wait-for-completion-timeout',
+        default='1s',
+        help='Value for wait_for_completion_timeout on SubmitAsyncSearchTool.',
+    )
+    parser.add_argument(
+        '--keep-alive',
+        default='5m',
+        help='Value for keep_alive on SubmitAsyncSearchTool.',
+    )
+    parser.add_argument(
+        '--size',
+        type=int,
+        default=10,
+        help='Result size for SubmitAsyncSearchTool. Default: 10',
+    )
+    parser.add_argument(
+        '--skip-delete',
+        action='store_true',
+        help='Do not call DeleteAsyncSearchTool after the smoke test.',
+    )
+    parser.add_argument(
+        '--list-only',
+        action='store_true',
+        help='Only connect and list the available tool names.',
+    )
+    parser.add_argument(
+        '--generic-path',
+        help='If provided, call GenericOpenSearchApiTool with this API path before the async-search flow.',
+    )
+    parser.add_argument(
+        '--generic-method',
+        default='GET',
+        help='HTTP method for GenericOpenSearchApiTool. Default: GET',
+    )
+    parser.add_argument(
+        '--generic-body',
+        help='Optional body for GenericOpenSearchApiTool. Accepts JSON or raw text.',
+    )
+    parser.add_argument(
+        '--generic-query-params',
+        help='Optional query params for GenericOpenSearchApiTool as a JSON object string.',
+    )
+    parser.add_argument(
+        '--generic-headers',
+        help='Optional headers for GenericOpenSearchApiTool as a JSON object string.',
+    )
+    parser.add_argument(
+        '--generic-only',
+        action='store_true',
+        help='Run only GenericOpenSearchApiTool and skip the async-search flow.',
+    )
+    return parser.parse_args()
+
+
+def parse_query(query_text: str) -> dict[str, Any]:
+    """Parse the query JSON string into a dict."""
+    try:
+        query = json.loads(query_text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f'Invalid --query JSON: {exc}') from exc
+    if not isinstance(query, dict):
+        raise SystemExit('--query must decode to a JSON object')
+    return query
+
+
+def parse_optional_json_object(text: str | None, arg_name: str) -> dict[str, Any] | None:
+    """Parse an optional JSON object argument."""
+    if text is None:
+        return None
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f'Invalid {arg_name} JSON: {exc}') from exc
+    if not isinstance(value, dict):
+        raise SystemExit(f'{arg_name} must decode to a JSON object')
+    return value
+
+
+def parse_optional_json_or_text(text: str | None, arg_name: str) -> Any:
+    """Parse JSON when possible, otherwise keep the original text."""
+    if text is None:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def build_tool_args(base_args: dict[str, Any], cluster_name: str) -> dict[str, Any]:
+    """Add cluster_name only when it is needed."""
+    if cluster_name:
+        return {'opensearch_cluster_name': cluster_name, **base_args}
+    return base_args
+
+
+def extract_text_content(result: Any) -> str:
+    """Join all text items from an MCP CallToolResult."""
+    parts: list[str] = []
+    for item in getattr(result, 'content', []):
+        if getattr(item, 'type', None) == 'text':
+            parts.append(getattr(item, 'text', ''))
+    return '\n'.join(part for part in parts if part)
+
+
+def ensure_tool_success(result: Any, tool_name: str) -> str:
+    """Return text content or raise a clean error for tool-level failures."""
+    text = extract_text_content(result)
+    if getattr(result, 'isError', False) or text.startswith('Error '):
+        raise RuntimeError(f'{tool_name} failed: {text}')
+    return text
+
+
+def extract_json_payload(result: Any) -> dict[str, Any]:
+    """Parse the JSON payload embedded in the tool's text response."""
+    text = extract_text_content(result)
+    if not text:
+        raise RuntimeError('Tool returned no text content')
+    _, _, payload = text.partition('\n')
+    json_text = payload or text
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f'Could not parse tool response as JSON: {text}') from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f'Expected JSON object from tool response, got: {type(data).__name__}')
+    return data
+
+
+async def call_generic_api(session: ClientSession, args: argparse.Namespace) -> None:
+    """Call GenericOpenSearchApiTool using CLI arguments."""
+    generic_args = build_tool_args(
+        {
+            'path': args.generic_path,
+            'method': args.generic_method,
+            'query_params': parse_optional_json_object(
+                args.generic_query_params, '--generic-query-params'
+            ),
+            'body': parse_optional_json_or_text(args.generic_body, '--generic-body'),
+            'headers': parse_optional_json_object(args.generic_headers, '--generic-headers'),
+        },
+        args.cluster_name,
+    )
+    print(f'\nCalling {GENERIC_TOOL_NAME}...')
+    generic_result = await session.call_tool(GENERIC_TOOL_NAME, generic_args)
+    print(ensure_tool_success(generic_result, GENERIC_TOOL_NAME))
+
+
+async def main() -> int:
+    """Run the async-search smoke test against the local MCP server."""
+    args = parse_args()
+
+    async with streamablehttp_client(args.server_url) as (
+        read_stream,
+        write_stream,
+        _get_session_id,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            init_result = await session.initialize()
+            print(
+                f'Connected to MCP server: {init_result.serverInfo.name} '
+                f'{init_result.serverInfo.version or ""}'.strip()
+            )
+
+            tools_result = await session.list_tools()
+            tool_names = [tool.name for tool in tools_result.tools]
+            print(f'Available tools ({len(tool_names)}):')
+            for tool_name in tool_names:
+                print(f'  - {tool_name}')
+
+            if args.list_only:
+                return 0
+
+            if args.generic_path:
+                if GENERIC_TOOL_NAME not in tool_names:
+                    raise RuntimeError(f'{GENERIC_TOOL_NAME} is not exposed by the MCP server')
+                await call_generic_api(session, args)
+                if args.generic_only:
+                    return 0
+
+            missing_tools = [name for name in ASYNC_TOOL_NAMES if name not in tool_names]
+            if missing_tools:
+                print('\nMissing async search tools:')
+                for tool_name in missing_tools:
+                    print(f'  - {tool_name}')
+                print(
+                    '\nIf the server is running in single mode, enable them with '
+                    'OPENSEARCH_ENABLED_TOOLS or run the server in multi mode.'
+                )
+                return 2
+
+            if not args.index:
+                raise SystemExit('--index is required unless --list-only is used')
+
+            submit_args = build_tool_args(
+                {
+                    'index': args.index,
+                    'query_dsl': parse_query(args.query),
+                    'wait_for_completion_timeout': args.wait_for_completion_timeout,
+                    'keep_alive': args.keep_alive,
+                    'size': args.size,
+                },
+                args.cluster_name,
+            )
+
+            print('\nSubmitting async search...')
+            submit_result = await session.call_tool('SubmitAsyncSearchTool', submit_args)
+            submit_text = ensure_tool_success(submit_result, 'SubmitAsyncSearchTool')
+            print(submit_text)
+            submit_payload = extract_json_payload(submit_result)
+            if 'error' in submit_payload:
+                raise RuntimeError(
+                    'SubmitAsyncSearchTool returned an async search error: '
+                    f'{json.dumps(submit_payload["error"], separators=(",", ":"))}'
+                )
+            search_id = submit_payload.get('id')
+            if not search_id:
+                print(
+                    '\nSubmitAsyncSearchTool did not return an async search id. '
+                    'This can happen when the query completes immediately.'
+                )
+                return 3
+
+            get_args = build_tool_args({'search_id': search_id}, args.cluster_name)
+            print(f'\nFetching async search status for {search_id}...')
+            get_result = await session.call_tool('GetAsyncSearchTool', get_args)
+            print(ensure_tool_success(get_result, 'GetAsyncSearchTool'))
+
+            if args.skip_delete:
+                print('\nSkipping delete step.')
+                return 0
+
+            print(f'\nDeleting async search {search_id}...')
+            delete_result = await session.call_tool('DeleteAsyncSearchTool', get_args)
+            print(ensure_tool_success(delete_result, 'DeleteAsyncSearchTool'))
+
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        print('\nInterrupted.', file=sys.stderr)
+        raise SystemExit(130)
+    except RuntimeError as exc:
+        print(f'\n{exc}', file=sys.stderr)
+        raise SystemExit(1)

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -962,6 +962,82 @@ async def delete_judgment_list(args: DeleteJudgmentListArgs) -> json:
         return response
 
 
+async def submit_async_search(args) -> json:
+    """Submit an asynchronous search request to OpenSearch.
+
+    Args:
+        args: SubmitAsyncSearchArgs containing index, query_dsl, and async options
+
+    Returns:
+        json: Response containing the async search ID and initial state
+    """
+    from .client import get_opensearch_client
+    from tools.tools import TOOL_REGISTRY
+
+    if isinstance(args.query_dsl, str):
+        validate_json_string(args.query_dsl)
+
+    async with get_opensearch_client(args) as client:
+        query = normalize_scientific_notation(args.query_dsl)
+
+        # Limit size to maximum of 100
+        tool_info = TOOL_REGISTRY.get('SubmitAsyncSearchTool', {})
+        max_size_limit = tool_info.get('max_size_limit', 100)
+        query['size'] = min(args.size, max_size_limit) if args.size else 10
+
+        params = {'wait_for_completion': 'false'}
+        if args.wait_for_completion_timeout:
+            params['wait_for_completion_timeout'] = args.wait_for_completion_timeout
+        if args.keep_alive:
+            params['keep_alive'] = args.keep_alive
+
+        response = await client.transport.perform_request(
+            method='POST',
+            url=f'/{args.index}/_plugins/_asynchronous_search',
+            body=json.dumps(query),
+            params=params,
+        )
+        return response
+
+
+async def get_async_search(args) -> json:
+    """Get the status and results of a previously submitted async search.
+
+    Args:
+        args: GetAsyncSearchArgs containing the search_id
+
+    Returns:
+        json: Response containing the async search state and results (if complete)
+    """
+    from .client import get_opensearch_client
+
+    async with get_opensearch_client(args) as client:
+        response = await client.transport.perform_request(
+            method='GET',
+            url=f'/_plugins/_asynchronous_search/{args.search_id}',
+        )
+        return response
+
+
+async def delete_async_search(args) -> json:
+    """Delete an async search by ID, freeing cluster resources.
+
+    Args:
+        args: DeleteAsyncSearchArgs containing the search_id
+
+    Returns:
+        json: Response confirming deletion
+    """
+    from .client import get_opensearch_client
+
+    async with get_opensearch_client(args) as client:
+        response = await client.transport.perform_request(
+            method='DELETE',
+            url=f'/_plugins/_asynchronous_search/{args.search_id}',
+        )
+        return response
+
+
 def validate_json_string(value: str) -> None:
     """Validate that a string is valid JSON, raising ValueError with a concise message if not.
 

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -985,9 +985,11 @@ async def submit_async_search(args) -> json:
         max_size_limit = tool_info.get('max_size_limit', 100)
         query['size'] = min(args.size, max_size_limit) if args.size else 10
 
-        params = {'wait_for_completion': 'false'}
+        params = {}
         if args.wait_for_completion_timeout:
             params['wait_for_completion_timeout'] = args.wait_for_completion_timeout
+        if args.keep_on_completion is not None:
+            params['keep_on_completion'] = str(args.keep_on_completion).lower()
         if args.keep_alive:
             params['keep_alive'] = args.keep_alive
 

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -1,20 +1,21 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import re
-import os
 import json
 import logging
+import os
+import re
 from .tool_params import baseToolArgs
-from .tools import TOOL_REGISTRY
+from .tools import TOOL_REGISTRY  # noqa: F401
 from .utils import (
     is_tool_compatible,
-    parse_comma_separated,
     load_yaml_config,
+    parse_comma_separated,
     validate_tools,
 )
-from opensearch.helper import get_opensearch_version
 from mcp_server_opensearch.global_state import get_mode
+from opensearch.helper import get_opensearch_version
+
 
 # Global variable to store the resolved allow_write setting
 # This is set during server initialization and used by individual tools
@@ -165,6 +166,9 @@ def process_tool_filter(
             'ListIndexTool',
             'IndexMappingTool',
             'SearchIndexTool',
+            'SubmitAsyncSearchTool',
+            'GetAsyncSearchTool',
+            'DeleteAsyncSearchTool',
             'GetShardsTool',
             'ClusterHealthTool',
             'CountTool',

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -20,6 +20,15 @@ from opensearch.helper import get_opensearch_version
 # Global variable to store the resolved allow_write setting
 # This is set during server initialization and used by individual tools
 _resolved_allow_write_setting = None
+ASYNC_SEARCH_TOOL_NAMES = {
+    'SubmitAsyncSearchTool',
+    'GetAsyncSearchTool',
+    'DeleteAsyncSearchTool',
+}
+ASYNC_SEARCH_PLUGIN_MARKERS = (
+    'asynchronous-search',
+    'asynchronous_search',
+)
 
 
 def process_regex_patterns(regex_list, tool_names):
@@ -30,6 +39,50 @@ def process_regex_patterns(regex_list, tool_names):
             if re.match(regex, tool_name, re.IGNORECASE):
                 matching_tools.append(tool_name)
     return matching_tools
+
+
+async def is_async_search_supported(args: baseToolArgs) -> bool:
+    """Detect whether async search is supported by the connected cluster.
+
+    In single mode, we use this to hide async-search tools when the cluster
+    does not have the async-search plugin/endpoint available.
+
+    The detection intentionally fails open: if plugin discovery is unavailable
+    due to auth or transport issues, this function returns True so we do not
+    accidentally hide tools for a cluster that may support them.
+    """
+    from opensearch.client import get_opensearch_client
+
+    try:
+        async with get_opensearch_client(args) as client:
+            response = await client.transport.perform_request(
+                method='GET',
+                url='/_cat/plugins',
+                params={'format': 'json', 'local': 'true'},
+            )
+    except Exception as exc:
+        logging.debug(f'Could not probe async-search support from plugin list: {exc}')
+        return True
+
+    if isinstance(response, str):
+        try:
+            response = json.loads(response)
+        except json.JSONDecodeError:
+            logging.debug('Unexpected non-JSON response from /_cat/plugins; keeping async tools visible')
+            return True
+
+    if not isinstance(response, list):
+        logging.debug('Unexpected response shape from /_cat/plugins; keeping async tools visible')
+        return True
+
+    for plugin in response:
+        if not isinstance(plugin, dict):
+            continue
+        plugin_text = ' '.join(str(value).lower() for value in plugin.values())
+        if any(marker in plugin_text for marker in ASYNC_SEARCH_PLUGIN_MARKERS):
+            return True
+
+    return False
 
 
 def set_allow_write_setting(allow_write: bool) -> None:
@@ -384,10 +437,24 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
         **{k: v for k, v in env_config.items() if not config_file_path},
     )
 
+    async_search_supported = True
+    if any(tool_name in tool_registry for tool_name in ASYNC_SEARCH_TOOL_NAMES):
+        async_search_supported = await is_async_search_supported(
+            baseToolArgs(opensearch_cluster_name='')
+        )
+        if not async_search_supported:
+            logging.info(
+                'Async search plugin/endpoint not detected on this cluster. '
+                'Hiding async-search tools in single mode.'
+            )
+
     for name, info in tool_registry.items():
         # Create a copy to avoid modifying the original tool info
         tool_info = info.copy()
         tool_name = tool_info['display_name']
+
+        if name in ASYNC_SEARCH_TOOL_NAMES and not async_search_supported:
+            continue
 
         # If tool is not compatible with the current OpenSearch version, skip, don't enable
         if not is_tool_compatible(version, info):

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -641,6 +641,10 @@ class SubmitAsyncSearchArgs(baseToolArgs):
         default='5s',
         description='How long to wait for the search to complete before returning a partial response (e.g., "5s", "1m"). Defaults to "5s".',
     )
+    keep_on_completion: Optional[bool] = Field(
+        default=True,
+        description='Whether to keep the async search result after completion so it can still be retrieved by ID. Defaults to true.',
+    )
     keep_alive: Optional[str] = Field(
         default='5m',
         description='How long to keep the async search context alive for retrieving results later (e.g., "5m", "1h"). Defaults to "5m".',
@@ -661,6 +665,7 @@ class SubmitAsyncSearchArgs(baseToolArgs):
                     'index': 'logs-*',
                     'query_dsl': {'query': {'range': {'timestamp': {'gte': 'now-1h'}}}},
                     'wait_for_completion_timeout': '10s',
+                    'keep_on_completion': True,
                     'keep_alive': '1h',
                     'size': 50,
                 },

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -627,3 +627,68 @@ class SearchExperimentsArgs(baseToolArgs):
 
     class Config:
         json_schema_extra = {'examples': _SRW_SEARCH_QUERY_BODY_EXAMPLES}
+
+
+class SubmitAsyncSearchArgs(baseToolArgs):
+    """Arguments for the SubmitAsyncSearchTool."""
+
+    index: str = Field(description='The name of the index to search in')
+    query_dsl: Any = Field(
+        description='The search query in OpenSearch query DSL format. '
+        'Same syntax as SearchIndexTool.'
+    )
+    wait_for_completion_timeout: Optional[str] = Field(
+        default='5s',
+        description='How long to wait for the search to complete before returning a partial response (e.g., "5s", "1m"). Defaults to "5s".',
+    )
+    keep_alive: Optional[str] = Field(
+        default='5m',
+        description='How long to keep the async search context alive for retrieving results later (e.g., "5m", "1h"). Defaults to "5m".',
+    )
+    size: int = Field(
+        default=10,
+        description='Number of search results to return. The maximum allowed value is 100.',
+    )
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'index': 'my-index',
+                    'query_dsl': {'query': {'match_all': {}}},
+                },
+                {
+                    'index': 'logs-*',
+                    'query_dsl': {'query': {'range': {'timestamp': {'gte': 'now-1h'}}}},
+                    'wait_for_completion_timeout': '10s',
+                    'keep_alive': '1h',
+                    'size': 50,
+                },
+            ]
+        }
+
+
+class GetAsyncSearchArgs(baseToolArgs):
+    """Arguments for the GetAsyncSearchTool."""
+
+    search_id: str = Field(
+        description='The async search ID returned from SubmitAsyncSearchTool'
+    )
+
+    class Config:
+        json_schema_extra = {
+            'examples': [{'search_id': 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc'}]
+        }
+
+
+class DeleteAsyncSearchArgs(baseToolArgs):
+    """Arguments for the DeleteAsyncSearchTool."""
+
+    search_id: str = Field(
+        description='The async search ID to delete and free cluster resources'
+    )
+
+    class Config:
+        json_schema_extra = {
+            'examples': [{'search_id': 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc'}]
+        }

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -36,6 +36,9 @@ from .tool_params import (
     SearchSearchConfigurationsArgs,
     SearchJudgmentsArgs,
     SearchExperimentsArgs,
+    SubmitAsyncSearchArgs,
+    GetAsyncSearchArgs,
+    DeleteAsyncSearchArgs,
     baseToolArgs,
 )
 from .tool_logging import log_tool_error
@@ -77,6 +80,9 @@ from opensearch.helper import (
     search_search_configurations,
     search_judgments,
     search_experiments,
+    submit_async_search,
+    get_async_search,
+    delete_async_search,
 )
 from .skills_tools import SKILLS_TOOLS_REGISTRY
 
@@ -883,6 +889,63 @@ async def search_experiments_tool(args: SearchExperimentsArgs) -> list[dict]:
         return log_tool_error('SearchExperimentsTool', e, 'searching experiments')
 
 
+async def submit_async_search_tool(args: SubmitAsyncSearchArgs) -> list[dict]:
+    """Tool to submit an asynchronous search request to OpenSearch.
+
+    Returns a search ID that can be used to check status and retrieve results later.
+    Useful for long-running or complex queries that may time out with synchronous search.
+
+    Args:
+        args: SubmitAsyncSearchArgs containing index, query_dsl, and async options
+
+    Returns:
+        list[dict]: Async search submission result in MCP format
+    """
+    try:
+        await check_tool_compatibility('SubmitAsyncSearchTool', args)
+        result = await submit_async_search(args)
+        formatted_result = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Async search submitted:\n{formatted_result}'}]
+    except Exception as e:
+        return log_tool_error('SubmitAsyncSearchTool', e, 'submitting async search', index=args.index)
+
+
+async def get_async_search_tool(args: GetAsyncSearchArgs) -> list[dict]:
+    """Tool to get the status and results of a previously submitted async search.
+
+    Args:
+        args: GetAsyncSearchArgs containing the search_id
+
+    Returns:
+        list[dict]: Async search status/results in MCP format
+    """
+    try:
+        await check_tool_compatibility('GetAsyncSearchTool', args)
+        result = await get_async_search(args)
+        formatted_result = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Async search results:\n{formatted_result}'}]
+    except Exception as e:
+        return log_tool_error('GetAsyncSearchTool', e, 'getting async search results')
+
+
+async def delete_async_search_tool(args: DeleteAsyncSearchArgs) -> list[dict]:
+    """Tool to delete an async search by ID, freeing cluster resources.
+
+    Args:
+        args: DeleteAsyncSearchArgs containing the search_id
+
+    Returns:
+        list[dict]: Deletion result in MCP format
+    """
+    try:
+        await check_tool_compatibility('DeleteAsyncSearchTool', args)
+        result = await delete_async_search(args)
+        formatted_result = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Async search {args.search_id} deleted:\n{formatted_result}'}]
+    except Exception as e:
+        return log_tool_error('DeleteAsyncSearchTool', e, 'deleting async search')
+
+
 from .generic_api_tool import GenericOpenSearchApiArgs, generic_opensearch_api_tool
 
 
@@ -1132,6 +1195,42 @@ TOOL_REGISTRY = {
         'args_model': SearchExperimentsArgs,
         'min_version': '3.5.0',
         'http_methods': 'GET, POST',
+    },
+    'SubmitAsyncSearchTool': {
+        'display_name': 'SubmitAsyncSearchTool',
+        'description': (
+            'Submits an asynchronous search request to OpenSearch. Returns a search ID that can be '
+            'used with GetAsyncSearchTool to check status and retrieve results later. Useful for '
+            'long-running or complex queries that may time out with synchronous search. '
+            'PREREQUISITE: You need to know the mappings of the index before constructing queries.'
+        ),
+        'input_schema': SubmitAsyncSearchArgs.model_json_schema(),
+        'function': submit_async_search_tool,
+        'args_model': SubmitAsyncSearchArgs,
+        'min_version': '1.1.0',
+        'http_methods': 'POST',
+    },
+    'GetAsyncSearchTool': {
+        'display_name': 'GetAsyncSearchTool',
+        'description': (
+            'Gets the status and results of a previously submitted async search by its search ID. '
+            'The response includes the search state (RUNNING, SUCCEEDED, FAILED, PERSISTED) and, '
+            'if complete, the search results.'
+        ),
+        'input_schema': GetAsyncSearchArgs.model_json_schema(),
+        'function': get_async_search_tool,
+        'args_model': GetAsyncSearchArgs,
+        'min_version': '1.1.0',
+        'http_methods': 'GET',
+    },
+    'DeleteAsyncSearchTool': {
+        'display_name': 'DeleteAsyncSearchTool',
+        'description': 'Deletes an async search by its search ID, freeing up cluster resources. Use this to clean up completed or no-longer-needed async searches.',
+        'input_schema': DeleteAsyncSearchArgs.model_json_schema(),
+        'function': delete_async_search_tool,
+        'args_model': DeleteAsyncSearchArgs,
+        'min_version': '1.1.0',
+        'http_methods': 'DELETE',
     },
     'GenericOpenSearchApiTool': {
         'display_name': 'GenericOpenSearchApiTool',

--- a/tests/tools/test_async_search_tools.py
+++ b/tests/tools/test_async_search_tools.py
@@ -1,0 +1,245 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+
+
+class TestAsyncSearchTools:
+    def setup_method(self):
+        """Setup that runs before each test method."""
+        self.mock_client = Mock()
+        self.mock_client.transport.perform_request = AsyncMock(return_value={})
+        self.mock_client.info = AsyncMock(return_value={'version': {'number': '2.19.0'}})
+
+        self.init_client_patcher = patch(
+            'opensearch.client.initialize_client', return_value=self.mock_client
+        )
+        self.init_client_patcher.start()
+
+        import sys
+        modules_to_clear = ['tools.tools']
+        for module in modules_to_clear:
+            if module in sys.modules:
+                del sys.modules[module]
+
+        from tools.tools import (
+            submit_async_search_tool,
+            get_async_search_tool,
+            delete_async_search_tool,
+        )
+        from tools.tool_params import (
+            SubmitAsyncSearchArgs,
+            GetAsyncSearchArgs,
+            DeleteAsyncSearchArgs,
+        )
+
+        self._submit_async_search_tool = submit_async_search_tool
+        self._get_async_search_tool = get_async_search_tool
+        self._delete_async_search_tool = delete_async_search_tool
+        self.SubmitAsyncSearchArgs = SubmitAsyncSearchArgs
+        self.GetAsyncSearchArgs = GetAsyncSearchArgs
+        self.DeleteAsyncSearchArgs = DeleteAsyncSearchArgs
+
+    def teardown_method(self):
+        self.init_client_patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_submit_async_search_tool_success(self):
+        """Test submitting an async search returns search ID and state."""
+        mock_response = {
+            'id': 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+            'state': 'RUNNING',
+            'start_time_in_millis': 1234567890000,
+        }
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.SubmitAsyncSearchArgs(
+            index='my-index',
+            query_dsl={'query': {'match_all': {}}},
+            opensearch_cluster_name='',
+        )
+        result = await self._submit_async_search_tool(args)
+
+        assert len(result) == 1
+        assert result[0]['type'] == 'text'
+        assert 'Async search submitted' in result[0]['text']
+        assert 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc' in result[0]['text']
+        assert 'RUNNING' in result[0]['text']
+        self.mock_client.transport.perform_request.assert_called_once()
+        call_args = self.mock_client.transport.perform_request.call_args
+        assert call_args.kwargs['method'] == 'POST'
+        assert '/my-index/_plugins/_asynchronous_search' in call_args.kwargs['url']
+
+    @pytest.mark.asyncio
+    async def test_submit_async_search_tool_with_custom_params(self):
+        """Test that wait_for_completion_timeout and keep_alive are passed correctly."""
+        mock_response = {'id': 'test-id', 'state': 'RUNNING'}
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.SubmitAsyncSearchArgs(
+            index='logs-*',
+            query_dsl={'query': {'range': {'timestamp': {'gte': 'now-1h'}}}},
+            wait_for_completion_timeout='10s',
+            keep_alive='1h',
+            size=50,
+            opensearch_cluster_name='',
+        )
+        result = await self._submit_async_search_tool(args)
+
+        assert 'Async search submitted' in result[0]['text']
+        call_args = self.mock_client.transport.perform_request.call_args
+        params = call_args.kwargs['params']
+        assert params['wait_for_completion_timeout'] == '10s'
+        assert params['keep_alive'] == '1h'
+        assert params['wait_for_completion'] == 'false'
+
+    @pytest.mark.asyncio
+    async def test_submit_async_search_tool_size_capped(self):
+        """Test that size is capped at max_size_limit (100)."""
+        mock_response = {'id': 'test-id', 'state': 'RUNNING'}
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.SubmitAsyncSearchArgs(
+            index='my-index',
+            query_dsl={'query': {'match_all': {}}},
+            size=500,
+            opensearch_cluster_name='',
+        )
+        result = await self._submit_async_search_tool(args)
+
+        assert 'Async search submitted' in result[0]['text']
+        call_args = self.mock_client.transport.perform_request.call_args
+        body = json.loads(call_args.kwargs['body'])
+        assert body['size'] == 100
+
+    @pytest.mark.asyncio
+    async def test_submit_async_search_tool_error(self):
+        """Test error handling when async search submission fails."""
+        self.mock_client.transport.perform_request = AsyncMock(
+            side_effect=Exception('Connection refused')
+        )
+
+        args = self.SubmitAsyncSearchArgs(
+            index='my-index',
+            query_dsl={'query': {'match_all': {}}},
+            opensearch_cluster_name='',
+        )
+        result = await self._submit_async_search_tool(args)
+
+        assert len(result) == 1
+        assert result[0].get('is_error') or 'error' in result[0]['text'].lower()
+
+    @pytest.mark.asyncio
+    async def test_submit_async_search_tool_string_query_dsl(self):
+        """Test that string query_dsl is accepted and parsed."""
+        mock_response = {'id': 'test-id', 'state': 'RUNNING'}
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.SubmitAsyncSearchArgs(
+            index='my-index',
+            query_dsl='{"query": {"match_all": {}}}',
+            opensearch_cluster_name='',
+        )
+        result = await self._submit_async_search_tool(args)
+
+        assert 'Async search submitted' in result[0]['text']
+
+    @pytest.mark.asyncio
+    async def test_get_async_search_tool_running(self):
+        """Test getting status of a running async search."""
+        mock_response = {
+            'id': 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+            'state': 'RUNNING',
+            'start_time_in_millis': 1234567890000,
+        }
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.GetAsyncSearchArgs(
+            search_id='FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+            opensearch_cluster_name='',
+        )
+        result = await self._get_async_search_tool(args)
+
+        assert len(result) == 1
+        assert 'Async search results' in result[0]['text']
+        assert 'RUNNING' in result[0]['text']
+        self.mock_client.transport.perform_request.assert_called_once_with(
+            method='GET',
+            url='/_plugins/_asynchronous_search/FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_async_search_tool_succeeded(self):
+        """Test getting results of a completed async search."""
+        mock_response = {
+            'id': 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+            'state': 'SUCCEEDED',
+            'response': {
+                'hits': {
+                    'total': {'value': 42, 'relation': 'eq'},
+                    'hits': [{'_index': 'my-index', '_id': '1', '_source': {'title': 'test'}}],
+                }
+            },
+        }
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.GetAsyncSearchArgs(
+            search_id='FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+            opensearch_cluster_name='',
+        )
+        result = await self._get_async_search_tool(args)
+
+        assert 'SUCCEEDED' in result[0]['text']
+        assert '"total":{"value":42' in result[0]['text']
+
+    @pytest.mark.asyncio
+    async def test_get_async_search_tool_error(self):
+        """Test error handling when getting async search fails."""
+        self.mock_client.transport.perform_request = AsyncMock(
+            side_effect=Exception('Search ID not found')
+        )
+
+        args = self.GetAsyncSearchArgs(
+            search_id='nonexistent-id',
+            opensearch_cluster_name='',
+        )
+        result = await self._get_async_search_tool(args)
+
+        assert result[0].get('is_error') or 'error' in result[0]['text'].lower()
+
+    @pytest.mark.asyncio
+    async def test_delete_async_search_tool_success(self):
+        """Test deleting an async search successfully."""
+        mock_response = {'acknowledged': True}
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.DeleteAsyncSearchArgs(
+            search_id='FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+            opensearch_cluster_name='',
+        )
+        result = await self._delete_async_search_tool(args)
+
+        assert len(result) == 1
+        assert 'deleted' in result[0]['text'].lower()
+        assert 'FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc' in result[0]['text']
+        self.mock_client.transport.perform_request.assert_called_once_with(
+            method='DELETE',
+            url='/_plugins/_asynchronous_search/FklfVGlYbkpRVl9FbVlVcDJfRTBhQXc',
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_async_search_tool_error(self):
+        """Test error handling when deleting async search fails."""
+        self.mock_client.transport.perform_request = AsyncMock(
+            side_effect=Exception('Search ID not found')
+        )
+
+        args = self.DeleteAsyncSearchArgs(
+            search_id='nonexistent-id',
+            opensearch_cluster_name='',
+        )
+        result = await self._delete_async_search_tool(args)
+
+        assert result[0].get('is_error') or 'error' in result[0]['text'].lower()

--- a/tests/tools/test_async_search_tools.py
+++ b/tests/tools/test_async_search_tools.py
@@ -74,7 +74,7 @@ class TestAsyncSearchTools:
 
     @pytest.mark.asyncio
     async def test_submit_async_search_tool_with_custom_params(self):
-        """Test that wait_for_completion_timeout and keep_alive are passed correctly."""
+        """Test that async search query parameters are passed correctly."""
         mock_response = {'id': 'test-id', 'state': 'RUNNING'}
         self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
 
@@ -82,6 +82,7 @@ class TestAsyncSearchTools:
             index='logs-*',
             query_dsl={'query': {'range': {'timestamp': {'gte': 'now-1h'}}}},
             wait_for_completion_timeout='10s',
+            keep_on_completion=True,
             keep_alive='1h',
             size=50,
             opensearch_cluster_name='',
@@ -92,8 +93,27 @@ class TestAsyncSearchTools:
         call_args = self.mock_client.transport.perform_request.call_args
         params = call_args.kwargs['params']
         assert params['wait_for_completion_timeout'] == '10s'
+        assert params['keep_on_completion'] == 'true'
         assert params['keep_alive'] == '1h'
-        assert params['wait_for_completion'] == 'false'
+
+    @pytest.mark.asyncio
+    async def test_submit_async_search_tool_can_disable_keep_on_completion(self):
+        """Test that keep_on_completion can be explicitly disabled."""
+        mock_response = {'id': 'test-id', 'state': 'RUNNING'}
+        self.mock_client.transport.perform_request = AsyncMock(return_value=mock_response)
+
+        args = self.SubmitAsyncSearchArgs(
+            index='logs-*',
+            query_dsl={'query': {'match_all': {}}},
+            keep_on_completion=False,
+            opensearch_cluster_name='',
+        )
+        result = await self._submit_async_search_tool(args)
+
+        assert 'Async search submitted' in result[0]['text']
+        call_args = self.mock_client.transport.perform_request.call_args
+        params = call_args.kwargs['params']
+        assert params['keep_on_completion'] == 'false'
 
     @pytest.mark.asyncio
     async def test_submit_async_search_tool_size_capped(self):

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -127,8 +127,10 @@ class TestGetTools:
         with (
             patch('tools.tool_filter.get_opensearch_version') as mock_get_version,
             patch('tools.tool_filter.is_tool_compatible') as mock_is_compatible,
+            patch('tools.tool_filter.is_async_search_supported') as mock_async_supported,
         ):
-            yield mock_get_version, mock_is_compatible
+            mock_async_supported.return_value = True
+            yield mock_get_version, mock_is_compatible, mock_async_supported
 
     @pytest.mark.asyncio
     async def test_get_tools_multi_mode_returns_all_tools(self, mock_tool_registry):
@@ -147,7 +149,7 @@ class TestGetTools:
         self, mock_tool_registry, mock_patches
     ):
         """Test that single mode filters by version AND removes base fields."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
 
         # Setup mocks
         mock_get_version.return_value = Version.parse('2.5.0')
@@ -177,7 +179,7 @@ class TestGetTools:
         self, mock_tool_registry, mock_patches
     ):
         """Test that serverless mode passes version compatibility checks."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
 
         # Setup mocks
         mock_get_version.return_value = None
@@ -202,7 +204,7 @@ class TestGetTools:
     @pytest.mark.asyncio
     async def test_get_tools_single_mode_handles_missing_properties(self, mock_patches):
         """Test that single mode handles schemas without properties field."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
 
         # Create tool with missing properties
         tool_without_properties = {
@@ -229,7 +231,7 @@ class TestGetTools:
     @pytest.mark.asyncio
     async def test_get_tools_default_mode_is_single(self, mock_tool_registry, mock_patches):
         """Test that get_tools defaults to single mode."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
 
         mock_get_version.return_value = Version.parse('2.5.0')
         mock_is_compatible.return_value = True
@@ -246,7 +248,7 @@ class TestGetTools:
     @pytest.mark.asyncio
     async def test_get_tools_skills_tools_version_filtering(self, mock_tool_registry, mock_patches):
         """Test that skills tools are filtered based on version compatibility."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
 
         # Setup mocks - simulate OpenSearch 2.5.0 (below skills tools min version 3.3.0)
         mock_get_version.return_value = Version.parse('2.5.0')
@@ -272,7 +274,7 @@ class TestGetTools:
     @pytest.mark.asyncio
     async def test_get_tools_skills_tools_compatible_version(self, mock_tool_registry, mock_patches):
         """Test that skills tools are included when OpenSearch version is compatible."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
 
         # Setup mocks - simulate OpenSearch 3.5.0 (above skills tools min version 3.3.0)
         mock_get_version.return_value = Version.parse('3.5.0')
@@ -291,7 +293,7 @@ class TestGetTools:
     @pytest.mark.asyncio
     async def test_get_tools_logs_version_info(self, mock_tool_registry, mock_patches, caplog):
         """Test that get_tools logs version information in single mode."""
-        mock_get_version, mock_is_compatible = mock_patches
+        mock_get_version, mock_is_compatible, _ = mock_patches
         mock_get_version.return_value = Version.parse('2.5.0')
         mock_is_compatible.return_value = True
 
@@ -301,6 +303,57 @@ class TestGetTools:
             with caplog.at_level('INFO'):
                 await get_tools(mock_tool_registry)
                 assert 'Connected OpenSearch version: 2.5.0' in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_get_tools_hides_async_search_tools_when_plugin_not_detected(self, mock_patches):
+        """Async-search tools are hidden in single mode when the plugin probe fails."""
+        mock_get_version, mock_is_compatible, mock_async_supported = mock_patches
+        mock_get_version.return_value = Version.parse('2.5.0')
+        mock_is_compatible.return_value = True
+        mock_async_supported.return_value = False
+
+        registry = {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.0.0',
+            },
+            'SubmitAsyncSearchTool': {
+                'display_name': 'SubmitAsyncSearchTool',
+                'description': 'Submit async search',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.1.0',
+            },
+            'GetAsyncSearchTool': {
+                'display_name': 'GetAsyncSearchTool',
+                'description': 'Get async search',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.1.0',
+            },
+            'DeleteAsyncSearchTool': {
+                'display_name': 'DeleteAsyncSearchTool',
+                'description': 'Delete async search',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.1.0',
+            },
+        }
+
+        with patch('tools.tool_filter.TOOL_REGISTRY', registry):
+            result = await get_tools(registry)
+
+        assert 'ListIndexTool' in result
+        assert 'SubmitAsyncSearchTool' not in result
+        assert 'GetAsyncSearchTool' not in result
+        assert 'DeleteAsyncSearchTool' not in result
 
 
 class TestProcessToolFilter:

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -1,10 +1,10 @@
+import copy
 import pytest
 from semver import Version
-from unittest.mock import patch, MagicMock
-from tools.utils import is_tool_compatible
 from tools.tool_filter import get_tools, process_tool_filter
-from tools.tool_params import baseToolArgs
-import copy
+from tools.utils import is_tool_compatible
+from unittest.mock import MagicMock, patch
+
 
 # A dictionary for mocking TOOL_REGISTRY
 MOCK_TOOL_REGISTRY = {
@@ -311,6 +311,18 @@ class TestProcessToolFilter:
         self.tool_registry = {
             'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
             'SearchIndexTool': {'display_name': 'SearchIndexTool', 'http_methods': 'GET, POST'},
+            'SubmitAsyncSearchTool': {
+                'display_name': 'SubmitAsyncSearchTool',
+                'http_methods': 'POST',
+            },
+            'GetAsyncSearchTool': {
+                'display_name': 'GetAsyncSearchTool',
+                'http_methods': 'GET',
+            },
+            'DeleteAsyncSearchTool': {
+                'display_name': 'DeleteAsyncSearchTool',
+                'http_methods': 'DELETE',
+            },
             'MsearchTool': {'display_name': 'MsearchTool', 'http_methods': 'GET, POST'},
             'ExplainTool': {'display_name': 'ExplainTool', 'http_methods': 'GET, POST'},
             'ClusterHealthTool': {'display_name': 'ClusterHealthTool', 'http_methods': 'GET'},
@@ -400,6 +412,9 @@ class TestProcessToolFilter:
         # Core tools
         assert 'ListIndexTool' in self.tool_registry
         assert 'ClusterHealthTool' in self.tool_registry
+        assert 'SubmitAsyncSearchTool' in self.tool_registry
+        assert 'GetAsyncSearchTool' in self.tool_registry
+        assert 'DeleteAsyncSearchTool' in self.tool_registry
 
         # Non-core tools
         assert 'IndicesStatsTool' not in self.tool_registry
@@ -580,7 +595,7 @@ class TestAllowWriteSettings:
 
     def test_set_and_get_allow_write_setting(self):
         """Test basic set and get functionality for allow_write setting."""
-        from tools.tool_filter import set_allow_write_setting, get_allow_write_setting
+        from tools.tool_filter import get_allow_write_setting, set_allow_write_setting
 
         # Test setting to False
         set_allow_write_setting(False)


### PR DESCRIPTION
### Description

This PR introduces the following tools:

  - SubmitAsyncSearchTool
  - GetAsyncSearchTool
  - DeleteAsyncSearchTool

For agents to use Async Search (provided from Async Search plugin: https://github.com/opensearch-project/asynchronous-search)

**Testing**

Set following env vars:

```
export OPENSEARCH_URL="https://localhost:9200"
export OPENSEARCH_USERNAME="admin"
export OPENSEARCH_PASSWORD="admin"
export OPENSEARCH_ENABLED_TOOLS=".*"
export OPENSEARCH_SSL_VERIFY="false"
```

Tested with the following script:

<details>

<summary>scripts/smoke_test_async_search.py</summary>

Smoke test script

```
#!/usr/bin/env python3
# Copyright OpenSearch Contributors
# SPDX-License-Identifier: Apache-2.0

import argparse
import asyncio
import json
import sys
from mcp import ClientSession
from mcp.client.streamable_http import streamablehttp_client
from typing import Any


ASYNC_TOOL_NAMES = (
    'SubmitAsyncSearchTool',
    'GetAsyncSearchTool',
    'DeleteAsyncSearchTool',
)
GENERIC_TOOL_NAME = 'GenericOpenSearchApiTool'


def parse_args() -> argparse.Namespace:
    """Parse command-line arguments for the smoke test."""
    parser = argparse.ArgumentParser(
        description='Smoke test the Async Search MCP tools against a running local MCP server.'
    )
    parser.add_argument(
        '--server-url',
        default='http://localhost:9900/mcp',
        help='Streamable HTTP MCP endpoint. Default: http://localhost:9900/mcp',
    )
    parser.add_argument(
        '--index',
        help='Target index name or pattern for SubmitAsyncSearchTool.',
    )
    parser.add_argument(
        '--query',
        default='{"query":{"match_all":{}}}',
        help='Query DSL as a JSON string. Default: {"query":{"match_all":{}}}',
    )
    parser.add_argument(
        '--cluster-name',
        default='',
        help='OpenSearch cluster name to include when the MCP server is running in multi mode.',
    )
    parser.add_argument(
        '--wait-for-completion-timeout',
        default='1s',
        help='Value for wait_for_completion_timeout on SubmitAsyncSearchTool.',
    )
    parser.add_argument(
        '--keep-alive',
        default='5m',
        help='Value for keep_alive on SubmitAsyncSearchTool.',
    )
    parser.add_argument(
        '--size',
        type=int,
        default=10,
        help='Result size for SubmitAsyncSearchTool. Default: 10',
    )
    parser.add_argument(
        '--skip-delete',
        action='store_true',
        help='Do not call DeleteAsyncSearchTool after the smoke test.',
    )
    parser.add_argument(
        '--list-only',
        action='store_true',
        help='Only connect and list the available tool names.',
    )
    parser.add_argument(
        '--generic-path',
        help='If provided, call GenericOpenSearchApiTool with this API path before the async-search flow.',
    )
    parser.add_argument(
        '--generic-method',
        default='GET',
        help='HTTP method for GenericOpenSearchApiTool. Default: GET',
    )
    parser.add_argument(
        '--generic-body',
        help='Optional body for GenericOpenSearchApiTool. Accepts JSON or raw text.',
    )
    parser.add_argument(
        '--generic-query-params',
        help='Optional query params for GenericOpenSearchApiTool as a JSON object string.',
    )
    parser.add_argument(
        '--generic-headers',
        help='Optional headers for GenericOpenSearchApiTool as a JSON object string.',
    )
    parser.add_argument(
        '--generic-only',
        action='store_true',
        help='Run only GenericOpenSearchApiTool and skip the async-search flow.',
    )
    return parser.parse_args()


def parse_query(query_text: str) -> dict[str, Any]:
    """Parse the query JSON string into a dict."""
    try:
        query = json.loads(query_text)
    except json.JSONDecodeError as exc:
        raise SystemExit(f'Invalid --query JSON: {exc}') from exc
    if not isinstance(query, dict):
        raise SystemExit('--query must decode to a JSON object')
    return query


def parse_optional_json_object(text: str | None, arg_name: str) -> dict[str, Any] | None:
    """Parse an optional JSON object argument."""
    if text is None:
        return None
    try:
        value = json.loads(text)
    except json.JSONDecodeError as exc:
        raise SystemExit(f'Invalid {arg_name} JSON: {exc}') from exc
    if not isinstance(value, dict):
        raise SystemExit(f'{arg_name} must decode to a JSON object')
    return value


def parse_optional_json_or_text(text: str | None, arg_name: str) -> Any:
    """Parse JSON when possible, otherwise keep the original text."""
    if text is None:
        return None
    try:
        return json.loads(text)
    except json.JSONDecodeError:
        return text


def build_tool_args(base_args: dict[str, Any], cluster_name: str) -> dict[str, Any]:
    """Add cluster_name only when it is needed."""
    if cluster_name:
        return {'opensearch_cluster_name': cluster_name, **base_args}
    return base_args


def extract_text_content(result: Any) -> str:
    """Join all text items from an MCP CallToolResult."""
    parts: list[str] = []
    for item in getattr(result, 'content', []):
        if getattr(item, 'type', None) == 'text':
            parts.append(getattr(item, 'text', ''))
    return '\n'.join(part for part in parts if part)


def ensure_tool_success(result: Any, tool_name: str) -> str:
    """Return text content or raise a clean error for tool-level failures."""
    text = extract_text_content(result)
    if getattr(result, 'isError', False):
        raise RuntimeError(f'{tool_name} failed: {text}')
    return text


def extract_json_payload(result: Any) -> dict[str, Any]:
    """Parse the JSON payload embedded in the tool's text response."""
    text = extract_text_content(result)
    if not text:
        raise RuntimeError('Tool returned no text content')
    _, _, payload = text.partition('\n')
    json_text = payload or text
    try:
        data = json.loads(json_text)
    except json.JSONDecodeError as exc:
        raise RuntimeError(f'Could not parse tool response as JSON: {text}') from exc
    if not isinstance(data, dict):
        raise RuntimeError(f'Expected JSON object from tool response, got: {type(data).__name__}')
    return data


async def call_generic_api(session: ClientSession, args: argparse.Namespace) -> None:
    """Call GenericOpenSearchApiTool using CLI arguments."""
    generic_args = build_tool_args(
        {
            'path': args.generic_path,
            'method': args.generic_method,
            'query_params': parse_optional_json_object(
                args.generic_query_params, '--generic-query-params'
            ),
            'body': parse_optional_json_or_text(args.generic_body, '--generic-body'),
            'headers': parse_optional_json_object(args.generic_headers, '--generic-headers'),
        },
        args.cluster_name,
    )
    print(f'\nCalling {GENERIC_TOOL_NAME}...')
    generic_result = await session.call_tool(GENERIC_TOOL_NAME, generic_args)
    print(ensure_tool_success(generic_result, GENERIC_TOOL_NAME))


async def main() -> int:
    """Run the async-search smoke test against the local MCP server."""
    args = parse_args()

    async with streamablehttp_client(args.server_url) as (
        read_stream,
        write_stream,
        _get_session_id,
    ):
        async with ClientSession(read_stream, write_stream) as session:
            init_result = await session.initialize()
            print(
                f'Connected to MCP server: {init_result.serverInfo.name} '
                f'{init_result.serverInfo.version or ""}'.strip()
            )

            tools_result = await session.list_tools()
            tool_names = [tool.name for tool in tools_result.tools]
            print(f'Available tools ({len(tool_names)}):')
            for tool_name in tool_names:
                print(f'  - {tool_name}')

            if args.list_only:
                return 0

            if args.generic_path:
                if GENERIC_TOOL_NAME not in tool_names:
                    raise RuntimeError(f'{GENERIC_TOOL_NAME} is not exposed by the MCP server')
                await call_generic_api(session, args)
                if args.generic_only:
                    return 0

            missing_tools = [name for name in ASYNC_TOOL_NAMES if name not in tool_names]
            if missing_tools:
                print('\nMissing async search tools:')
                for tool_name in missing_tools:
                    print(f'  - {tool_name}')
                print(
                    '\nIf the server is running in single mode, enable them with '
                    'OPENSEARCH_ENABLED_TOOLS or run the server in multi mode.'
                )
                return 2

            if not args.index:
                raise SystemExit('--index is required unless --list-only is used')

            submit_args = build_tool_args(
                {
                    'index': args.index,
                    'query_dsl': parse_query(args.query),
                    'wait_for_completion_timeout': args.wait_for_completion_timeout,
                    'keep_alive': args.keep_alive,
                    'size': args.size,
                },
                args.cluster_name,
            )

            print('\nSubmitting async search...')
            submit_result = await session.call_tool('SubmitAsyncSearchTool', submit_args)
            submit_text = ensure_tool_success(submit_result, 'SubmitAsyncSearchTool')
            print(submit_text)
            submit_payload = extract_json_payload(submit_result)
            search_id = submit_payload.get('id')
            if not search_id:
                print(
                    '\nSubmitAsyncSearchTool did not return an async search id. '
                    'This can happen when the query completes immediately.'
                )
                return 3

            get_args = build_tool_args({'search_id': search_id}, args.cluster_name)
            print(f'\nFetching async search status for {search_id}...')
            get_result = await session.call_tool('GetAsyncSearchTool', get_args)
            print(ensure_tool_success(get_result, 'GetAsyncSearchTool'))

            if args.skip_delete:
                print('\nSkipping delete step.')
                return 0

            print(f'\nDeleting async search {search_id}...')
            delete_result = await session.call_tool('DeleteAsyncSearchTool', get_args)
            print(ensure_tool_success(delete_result, 'DeleteAsyncSearchTool'))

    return 0


if __name__ == '__main__':
    try:
        raise SystemExit(asyncio.run(main()))
    except KeyboardInterrupt:
        print('\nInterrupted.', file=sys.stderr)
        raise SystemExit(130)
    except RuntimeError as exc:
        print(f'\n{exc}', file=sys.stderr)
        raise SystemExit(1)

```

</details>

1. Create test index

```
uv run python scripts/smoke_test_async_search.py \
  --cluster-name local-dev \
  --generic-path /my-index \
  --generic-method PUT \
  --generic-body '{"mappings":{"properties":{"title":{"type":"text"},"year":{"type":"integer"}}}}' \
  --generic-only

Connected to MCP server: opensearch-mcp-server 1.23.0
Available tools (14):
  - DataDistributionTool
  - LogPatternAnalysisTool
  - ListIndexTool
  - IndexMappingTool
  - SearchIndexTool
  - GetShardsTool
  - SubmitAsyncSearchTool
  - GetAsyncSearchTool
  - DeleteAsyncSearchTool
  - GenericOpenSearchApiTool
  - ClusterHealthTool
  - CountTool
  - MsearchTool
  - ExplainTool

Calling GenericOpenSearchApiTool...
OpenSearch API Response (PUT /my-index):
{"acknowledged":true,"shards_acknowledged":true,"index":"my-index"}
```

2. Index Document

```
uv run python scripts/smoke_test_async_search.py \
  --cluster-name local-dev \
  --generic-path /my-index/_doc/1 \
  --generic-method PUT \
  --generic-body '{"title":"hello world","year":2025}' \
  --generic-only

Connected to MCP server: opensearch-mcp-server 1.23.0
Available tools (14):
  - DataDistributionTool
  - LogPatternAnalysisTool
  - ListIndexTool
  - IndexMappingTool
  - SearchIndexTool
  - GetShardsTool
  - SubmitAsyncSearchTool
  - GetAsyncSearchTool
  - DeleteAsyncSearchTool
  - GenericOpenSearchApiTool
  - ClusterHealthTool
  - CountTool
  - MsearchTool
  - ExplainTool

Calling GenericOpenSearchApiTool...
OpenSearch API Response (PUT /my-index/_doc/1):
{"_index":"my-index","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":0,"_primary_term":1}
```

3. Refresh index

```
uv run python scripts/smoke_test_async_search.py \
  --cluster-name local-dev \
  --generic-path /my-index/_refresh \
  --generic-method POST \
  --generic-only

Connected to MCP server: opensearch-mcp-server 1.23.0
Available tools (14):
  - DataDistributionTool
  - LogPatternAnalysisTool
  - ListIndexTool
  - IndexMappingTool
  - SearchIndexTool
  - GetShardsTool
  - SubmitAsyncSearchTool
  - GetAsyncSearchTool
  - DeleteAsyncSearchTool
  - GenericOpenSearchApiTool
  - ClusterHealthTool
  - CountTool
  - MsearchTool
  - ExplainTool

Calling GenericOpenSearchApiTool...
OpenSearch API Response (POST /my-index/_refresh):
{"_shards":{"total":2,"successful":2,"failed":0}}
```

4. Run Async Search smoke test

```
uv run python scripts/smoke_test_async_search.py \
  --index my-index \
  --cluster-name local-dev

Connected to MCP server: opensearch-mcp-server 1.23.0
Available tools (14):
  - DataDistributionTool
  - LogPatternAnalysisTool
  - ListIndexTool
  - IndexMappingTool
  - SearchIndexTool
  - GetShardsTool
  - SubmitAsyncSearchTool
  - GetAsyncSearchTool
  - DeleteAsyncSearchTool
  - GenericOpenSearchApiTool
  - ClusterHealthTool
  - CountTool
  - MsearchTool
  - ExplainTool

Submitting async search...
Async search submitted:
{"id":"Fk13Qk55ZVM5VEptX2RUOURGLXpvTXcEMTg4MBRoZmFnWFowQllwX0lMeWxBNnJDQwEz","state":"PERSISTING","start_time_in_millis":1775392320130,"expiration_time_in_millis":1775392620130,"response":{"took":41,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":1.0,"hits":[{"_index":"my-index","_id":"1","_score":1.0,"_source":{"title":"hello world","year":2025}}]}}}

Fetching async search status for Fk13Qk55ZVM5VEptX2RUOURGLXpvTXcEMTg4MBRoZmFnWFowQllwX0lMeWxBNnJDQwEz...
Async search results:
{"id":"Fk13Qk55ZVM5VEptX2RUOURGLXpvTXcEMTg4MBRoZmFnWFowQllwX0lMeWxBNnJDQwEz","state":"PERSISTING","start_time_in_millis":1775392320130,"expiration_time_in_millis":1775392620130,"response":{"took":41,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":1.0,"hits":[{"_index":"my-index","_id":"1","_score":1.0,"_source":{"title":"hello world","year":2025}}]}}}

Deleting async search Fk13Qk55ZVM5VEptX2RUOURGLXpvTXcEMTg4MBRoZmFnWFowQllwX0lMeWxBNnJDQwEz...
Async search Fk13Qk55ZVM5VEptX2RUOURGLXpvTXcEMTg4MBRoZmFnWFowQllwX0lMeWxBNnJDQwEz deleted:
{"acknowledged":true}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).