### PR TITLE
Fix non-ASCII characters escaped in tool JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Switch CI from `pull_request` to `pull_request_target` so integration tests run on fork PRs ([#219](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/219))
 - Fix multi-mode IT failing for `ListClustersTool` which has no `opensearch_cluster_name` parameter ([#220](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/220))
+- Fix non-ASCII characters (e.g. Chinese, Japanese, accented characters) being escaped to Unicode sequences in all tool JSON responses ([#164](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/164))
 
 - Fix `SearchIndexTool` ignoring `size=0`, causing aggregation-only queries to always return 10 hits ([#217](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/217))
 - Infer default TCP port from URL scheme (`http` → 80, `https` → 443) when no port is specified, instead of relying on implicit 9200 behavior ([#170](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/170))

--- a/src/tools/generic_api_tool.py
+++ b/src/tools/generic_api_tool.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlencode
 
 from .tool_logging import log_tool_error
+from .utils import format_json
 from .tool_params import baseToolArgs
 from pydantic import BaseModel, Field
 
@@ -90,7 +91,9 @@ async def generic_opensearch_api_tool(args: GenericOpenSearchApiArgs) -> list[di
         if method not in valid_methods:
             return log_tool_error(
                 'GenericOpenSearchApiTool',
-                ValueError(f'Invalid HTTP method "{args.method}". Valid methods are: {", ".join(valid_methods)}'),
+                ValueError(
+                    f'Invalid HTTP method "{args.method}". Valid methods are: {", ".join(valid_methods)}'
+                ),
                 'validating request',
             )
 
@@ -104,7 +107,9 @@ async def generic_opensearch_api_tool(args: GenericOpenSearchApiArgs) -> list[di
         if method in write_methods and not allow_write:
             return log_tool_error(
                 'GenericOpenSearchApiTool',
-                PermissionError(f'Write operations are disabled. Method "{method}" is not allowed.'),
+                PermissionError(
+                    f'Write operations are disabled. Method "{method}" is not allowed.'
+                ),
                 'validating request',
             )
 
@@ -151,7 +156,7 @@ async def generic_opensearch_api_tool(args: GenericOpenSearchApiArgs) -> list[di
                 formatted_response = response
             else:
                 # Most APIs return JSON
-                formatted_response = json.dumps(response, separators=(',', ':'))
+                formatted_response = format_json(response)
 
             # Create descriptive message
             message = f'OpenSearch API Response ({method} {args.path})'
@@ -162,7 +167,9 @@ async def generic_opensearch_api_tool(args: GenericOpenSearchApiArgs) -> list[di
 
     except Exception as e:
         return log_tool_error(
-            'GenericOpenSearchApiTool', e,
+            'GenericOpenSearchApiTool',
+            e,
             f'calling OpenSearch API ({args.method} {args.path})',
-            method=args.method, path=args.path,
+            method=args.method,
+            path=args.path,
         )

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -5,32 +5,48 @@ import json
 import logging
 from typing import Dict, Any
 from .tool_logging import log_tool_error
+from .utils import format_json
 from .tool_params import baseToolArgs
 from pydantic import Field
 from opensearch.client import get_opensearch_client
 
 logger = logging.getLogger(__name__)
 
+
 class DataDistributionToolArgs(baseToolArgs):
-    index: str = Field(description="Target OpenSearch index name")
-    selectionTimeRangeStart: str = Field(description="Start time for analysis period")
-    selectionTimeRangeEnd: str = Field(description="End time for analysis period")
-    timeField: str = Field(description="Date/time field for filtering(requied)")
-    baselineTimeRangeStart: str = Field(default="", description="Start time for baseline period (optional)")
-    baselineTimeRangeEnd: str = Field(default="", description="End time for baseline period (optional)")
-    size: int = Field(default=1000, description="Maximum number of documents to analyze")
+    index: str = Field(description='Target OpenSearch index name')
+    selectionTimeRangeStart: str = Field(description='Start time for analysis period')
+    selectionTimeRangeEnd: str = Field(description='End time for analysis period')
+    timeField: str = Field(description='Date/time field for filtering(requied)')
+    baselineTimeRangeStart: str = Field(
+        default='', description='Start time for baseline period (optional)'
+    )
+    baselineTimeRangeEnd: str = Field(
+        default='', description='End time for baseline period (optional)'
+    )
+    size: int = Field(default=1000, description='Maximum number of documents to analyze')
+
 
 class LogPatternAnalysisToolArgs(baseToolArgs):
-    index: str = Field(description="Target OpenSearch index name containing log data")
-    logFieldName: str = Field(description="Field containing raw log messages to analyze")
-    selectionTimeRangeStart: str = Field(description="Start time for analysis target period")
-    selectionTimeRangeEnd: str = Field(description="End time for analysis target period")
-    timeField: str = Field(description="Date/time field for time-based filtering(requied)")
-    traceFieldName: str = Field(default="", description="Field for trace/correlation ID (optional)")
-    baseTimeRangeStart: str = Field(default="", description="Start time for baseline comparison period (optional)")
-    baseTimeRangeEnd: str = Field(default="", description="End time for baseline comparison period (optional)")
+    index: str = Field(description='Target OpenSearch index name containing log data')
+    logFieldName: str = Field(description='Field containing raw log messages to analyze')
+    selectionTimeRangeStart: str = Field(description='Start time for analysis target period')
+    selectionTimeRangeEnd: str = Field(description='End time for analysis target period')
+    timeField: str = Field(description='Date/time field for time-based filtering(requied)')
+    traceFieldName: str = Field(
+        default='', description='Field for trace/correlation ID (optional)'
+    )
+    baseTimeRangeStart: str = Field(
+        default='', description='Start time for baseline comparison period (optional)'
+    )
+    baseTimeRangeEnd: str = Field(
+        default='', description='End time for baseline comparison period (optional)'
+    )
 
-async def call_opensearch_tool(tool_name: str, parameters: Dict[str, Any], args: baseToolArgs) -> list[dict]:
+
+async def call_opensearch_tool(
+    tool_name: str, parameters: Dict[str, Any], args: baseToolArgs
+) -> list[dict]:
     """Call OpenSearch ML tools API"""
     try:
         async with get_opensearch_client(args) as client:
@@ -38,15 +54,16 @@ async def call_opensearch_tool(tool_name: str, parameters: Dict[str, Any], args:
             response = await client.transport.perform_request(
                 'POST',
                 f'/_plugins/_ml/tools/_execute/{tool_name}',
-                body={'parameters': parameters}
+                body={'parameters': parameters},
             )
 
-        logger.info(f"Tool {tool_name} result: {json.dumps(response, separators=(',', ':'))}")
-        formatted_result = json.dumps(response, separators=(',', ':'))
+        logger.info(f'Tool {tool_name} result: {format_json(response)}')
+        formatted_result = format_json(response)
         return [{'type': 'text', 'text': f'{tool_name} result:\n{formatted_result}'}]
 
     except Exception as e:
         return log_tool_error(tool_name, e, f'executing {tool_name}')
+
 
 async def data_distribution_tool(args: DataDistributionToolArgs) -> list[dict]:
     params = {
@@ -54,7 +71,7 @@ async def data_distribution_tool(args: DataDistributionToolArgs) -> list[dict]:
         'timeField': args.timeField,
         'selectionTimeRangeStart': args.selectionTimeRangeStart,
         'selectionTimeRangeEnd': args.selectionTimeRangeEnd,
-        'size': args.size
+        'size': args.size,
     }
     if args.baselineTimeRangeStart:
         params['baselineTimeRangeStart'] = args.baselineTimeRangeStart
@@ -64,13 +81,14 @@ async def data_distribution_tool(args: DataDistributionToolArgs) -> list[dict]:
     result = await call_opensearch_tool('DataDistributionTool', params, args)
     return result
 
+
 async def log_pattern_analysis_tool(args: LogPatternAnalysisToolArgs) -> list[dict]:
     params = {
         'index': args.index,
         'timeField': args.timeField,
         'logFieldName': args.logFieldName,
         'selectionTimeRangeStart': args.selectionTimeRangeStart,
-        'selectionTimeRangeEnd': args.selectionTimeRangeEnd
+        'selectionTimeRangeEnd': args.selectionTimeRangeEnd,
     }
     if args.traceFieldName:
         params['traceFieldName'] = args.traceFieldName
@@ -81,6 +99,7 @@ async def log_pattern_analysis_tool(args: LogPatternAnalysisToolArgs) -> list[di
 
     result = await call_opensearch_tool('LogPatternAnalysisTool', params, args)
     return result
+
 
 SKILLS_TOOLS_REGISTRY = {
     'DataDistributionTool': {

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -40,7 +40,7 @@ from .tool_params import (
     baseToolArgs,
 )
 from .tool_logging import log_tool_error
-from .utils import is_tool_compatible
+from .utils import format_json, is_tool_compatible
 from opensearch.helper import (
     convert_search_results_to_csv,
     create_judgment_list,
@@ -125,14 +125,17 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
             if args.index:
                 # Return detailed information for specific index or pattern
                 index_info = await get_index(args)
-                formatted_info = json.dumps(index_info, separators=(',', ':'))
+                formatted_info = format_json(index_info)
                 return [
-                    {'type': 'text', 'text': f'Index information for {args.index}:\n{formatted_info}'}
+                    {
+                        'type': 'text',
+                        'text': f'Index information for {args.index}:\n{formatted_info}',
+                    }
                 ]
             else:
                 # Return full metadata for all indices
                 indices = await list_indices(args)
-                formatted_indices = json.dumps(indices, separators=(',', ':'))
+                formatted_indices = format_json(indices)
                 return [{'type': 'text', 'text': f'All indices information:\n{formatted_indices}'}]
         else:
             # Return minimal information (names only)
@@ -140,17 +143,19 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
             index_names = [
                 item.get('index') for item in indices if isinstance(item, dict) and 'index' in item
             ]
-            formatted_names = json.dumps(index_names, separators=(',', ':'))
+            formatted_names = format_json(index_names)
             return [{'type': 'text', 'text': f'Indices:\n{formatted_names}'}]
     except Exception as e:
-        return log_tool_error('ListIndexTool', e, 'listing indices', index=getattr(args, 'index', None))
+        return log_tool_error(
+            'ListIndexTool', e, 'listing indices', index=getattr(args, 'index', None)
+        )
 
 
 async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
     try:
         await check_tool_compatibility('IndexMappingTool', args)
         mapping = await get_index_mapping(args)
-        formatted_mapping = json.dumps(mapping, separators=(',', ':'))
+        formatted_mapping = format_json(mapping)
 
         return [{'type': 'text', 'text': f'Mapping for {args.index}:\n{formatted_mapping}'}]
     except Exception as e:
@@ -171,7 +176,7 @@ async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
                 }
             ]
         else:
-            formatted_result = json.dumps(result, separators=(',', ':'))
+            formatted_result = format_json(result)
             return [
                 {
                     'type': 'text',
@@ -188,7 +193,12 @@ async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
         result = await get_shards(args)
 
         if isinstance(result, dict) and 'error' in result:
-            return log_tool_error('GetShardsTool', Exception(result['error']), 'getting shards', index=getattr(args, 'index', None))
+            return log_tool_error(
+                'GetShardsTool',
+                Exception(result['error']),
+                'getting shards',
+                index=getattr(args, 'index', None),
+            )
         formatted_text = 'index | shard | prirep | state | docs | store | ip | node\n'
 
         # Format each shard row
@@ -204,7 +214,9 @@ async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
 
         return [{'type': 'text', 'text': formatted_text}]
     except Exception as e:
-        return log_tool_error('GetShardsTool', e, 'getting shards information', index=getattr(args, 'index', None))
+        return log_tool_error(
+            'GetShardsTool', e, 'getting shards information', index=getattr(args, 'index', None)
+        )
 
 
 async def get_cluster_state_tool(args: GetClusterStateArgs) -> list[dict]:
@@ -221,7 +233,7 @@ async def get_cluster_state_tool(args: GetClusterStateArgs) -> list[dict]:
         result = await get_cluster_state(args)
 
         # Format the response for better readability
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
 
         # Create response message based on what was requested
         message = 'Cluster state information'
@@ -249,7 +261,12 @@ async def get_segments_tool(args: GetSegmentsArgs) -> list[dict]:
         result = await get_segments(args)
 
         if isinstance(result, dict) and 'error' in result:
-            return log_tool_error('GetSegmentsTool', Exception(result['error']), 'getting segments', index=getattr(args, 'index', None))
+            return log_tool_error(
+                'GetSegmentsTool',
+                Exception(result['error']),
+                'getting segments',
+                index=getattr(args, 'index', None),
+            )
 
         # Create a formatted table for better readability
         formatted_text = 'index | shard | prirep | segment | generation | docs.count | docs.deleted | size | memory.bookkeeping | memory.vectors | memory.docvalues | memory.terms | version\n'
@@ -279,7 +296,9 @@ async def get_segments_tool(args: GetSegmentsArgs) -> list[dict]:
 
         return [{'type': 'text', 'text': f'{message}:\n{formatted_text}'}]
     except Exception as e:
-        return log_tool_error('GetSegmentsTool', e, 'getting segment information', index=getattr(args, 'index', None))
+        return log_tool_error(
+            'GetSegmentsTool', e, 'getting segment information', index=getattr(args, 'index', None)
+        )
 
 
 async def cat_nodes_tool(args: CatNodesArgs) -> list[dict]:
@@ -296,7 +315,9 @@ async def cat_nodes_tool(args: CatNodesArgs) -> list[dict]:
         result = await get_nodes(args)
 
         if isinstance(result, dict) and 'error' in result:
-            return log_tool_error('CatNodesTool', Exception(result['error']), 'getting node information')
+            return log_tool_error(
+                'CatNodesTool', Exception(result['error']), 'getting node information'
+            )
 
         # If no nodes found
         if not result:
@@ -339,7 +360,7 @@ async def get_index_info_tool(args: GetIndexInfoArgs) -> list[dict]:
         result = await get_index_info(args)
 
         # Format the response for better readability
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
 
         # Create response message
         message = f'Detailed information for index: {args.index}'
@@ -363,7 +384,7 @@ async def get_index_stats_tool(args: GetIndexStatsArgs) -> list[dict]:
         result = await get_index_stats(args)
 
         # Format the response for better readability
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
 
         # Create response message based on what was requested
         message = f'Statistics for index: {args.index}'
@@ -389,7 +410,7 @@ async def get_query_insights_tool(args: GetQueryInsightsArgs) -> list[dict]:
         result = await get_query_insights(args)
 
         # Format the response for better readability
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
 
         # Create simple response message
         message = 'Query insights from /_insights/top_queries endpoint'
@@ -435,7 +456,9 @@ async def get_allocation_tool(args: GetAllocationArgs) -> list[dict]:
         result = await get_allocation(args)
 
         if isinstance(result, dict) and 'error' in result:
-            return log_tool_error('GetAllocationTool', Exception(result['error']), 'getting allocation information')
+            return log_tool_error(
+                'GetAllocationTool', Exception(result['error']), 'getting allocation information'
+            )
 
         # If no allocation information found
         if not result:
@@ -476,10 +499,12 @@ async def get_nodes_tool(args: GetNodesArgs) -> list[dict]:
         result = await get_nodes_info(args)
 
         if isinstance(result, dict) and 'error' in result:
-            return log_tool_error('GetNodesTool', Exception(result['error']), 'getting nodes information')
+            return log_tool_error(
+                'GetNodesTool', Exception(result['error']), 'getting nodes information'
+            )
 
         # Format the response for better readability
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
 
         # Create response message based on what was requested
         message = 'Detailed node information'
@@ -510,7 +535,9 @@ async def get_long_running_tasks_tool(args: GetLongRunningTasksArgs) -> list[dic
         result = await get_long_running_tasks(args)
 
         if isinstance(result, dict) and 'error' in result:
-            return log_tool_error('GetLongRunningTasksTool', Exception(result['error']), 'getting long-running tasks')
+            return log_tool_error(
+                'GetLongRunningTasksTool', Exception(result['error']), 'getting long-running tasks'
+            )
 
         # If no tasks found
         if not result:
@@ -534,7 +561,9 @@ async def get_long_running_tasks_tool(args: GetLongRunningTasksArgs) -> list[dic
 
         return [{'type': 'text', 'text': f'{message}:\n{formatted_text}'}]
     except Exception as e:
-        return log_tool_error('GetLongRunningTasksTool', e, 'getting long-running tasks information')
+        return log_tool_error(
+            'GetLongRunningTasksTool', e, 'getting long-running tasks information'
+        )
 
 
 async def create_search_configuration_tool(args: CreateSearchConfigurationArgs) -> list[dict]:
@@ -549,7 +578,7 @@ async def create_search_configuration_tool(args: CreateSearchConfigurationArgs) 
     try:
         await check_tool_compatibility('CreateSearchConfigurationTool', args)
         result = await create_search_configuration(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Search configuration created:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('CreateSearchConfigurationTool', e, 'creating search configuration')
@@ -567,7 +596,7 @@ async def get_search_configuration_tool(args: GetSearchConfigurationArgs) -> lis
     try:
         await check_tool_compatibility('GetSearchConfigurationTool', args)
         result = await get_search_configuration(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [
             {
                 'type': 'text',
@@ -590,7 +619,7 @@ async def delete_search_configuration_tool(args: DeleteSearchConfigurationArgs) 
     try:
         await check_tool_compatibility('DeleteSearchConfigurationTool', args)
         result = await delete_search_configuration(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [
             {
                 'type': 'text',
@@ -613,7 +642,7 @@ async def get_query_set_tool(args: GetQuerySetArgs) -> list[dict]:
     try:
         await check_tool_compatibility('GetQuerySetTool', args)
         result = await get_query_set(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Query set {args.query_set_id}:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('GetQuerySetTool', e, 'retrieving query set')
@@ -631,7 +660,7 @@ async def create_query_set_tool(args: CreateQuerySetArgs) -> list[dict]:
     try:
         await check_tool_compatibility('CreateQuerySetTool', args)
         result = await create_query_set(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Query set created:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('CreateQuerySetTool', e, 'creating query set')
@@ -649,7 +678,7 @@ async def sample_query_set_tool(args: SampleQuerySetArgs) -> list[dict]:
     try:
         await check_tool_compatibility('SampleQuerySetTool', args)
         result = await sample_query_set(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Query set sampled:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('SampleQuerySetTool', e, 'sampling query set')
@@ -667,8 +696,10 @@ async def delete_query_set_tool(args: DeleteQuerySetArgs) -> list[dict]:
     try:
         await check_tool_compatibility('DeleteQuerySetTool', args)
         result = await delete_query_set(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Query set {args.query_set_id} deleted:\n{formatted_result}'}]
+        formatted_result = format_json(result)
+        return [
+            {'type': 'text', 'text': f'Query set {args.query_set_id} deleted:\n{formatted_result}'}
+        ]
     except Exception as e:
         return log_tool_error('DeleteQuerySetTool', e, 'deleting query set')
 
@@ -685,8 +716,10 @@ async def get_judgment_list_tool(args: GetJudgmentListArgs) -> list[dict]:
     try:
         await check_tool_compatibility('GetJudgmentListTool', args)
         result = await get_judgment_list(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Judgment list: {args.judgment_id}:\n{formatted_result}'}]
+        formatted_result = format_json(result)
+        return [
+            {'type': 'text', 'text': f'Judgment list: {args.judgment_id}:\n{formatted_result}'}
+        ]
     except Exception as e:
         return log_tool_error('GetJudgmentListTool', e, 'retrieving judgment list')
 
@@ -703,7 +736,7 @@ async def create_judgment_list_tool(args: CreateJudgmentListArgs) -> list[dict]:
     try:
         await check_tool_compatibility('CreateJudgmentListTool', args)
         result = await create_judgment_list(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Judgment created:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('CreateJudgmentListTool', e, 'creating judgment list')
@@ -721,7 +754,7 @@ async def create_ubi_judgment_list_tool(args: CreateUBIJudgmentListArgs) -> list
     try:
         await check_tool_compatibility('CreateUBIJudgmentListTool', args)
         result = await create_ubi_judgment_list(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'UBI judgment created:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('CreateUBIJudgmentListTool', e, 'creating UBI judgment')
@@ -739,8 +772,13 @@ async def delete_judgment_list_tool(args: DeleteJudgmentListArgs) -> list[dict]:
     try:
         await check_tool_compatibility('DeleteJudgmentListTool', args)
         result = await delete_judgment_list(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Judgment list {args.judgment_id} deleted:\n{formatted_result}'}]
+        formatted_result = format_json(result)
+        return [
+            {
+                'type': 'text',
+                'text': f'Judgment list {args.judgment_id} deleted:\n{formatted_result}',
+            }
+        ]
     except Exception as e:
         return log_tool_error('DeleteJudgmentListTool', e, 'deleting judgment list')
 
@@ -761,7 +799,7 @@ async def create_llm_judgment_list_tool(args: CreateLLMJudgmentListArgs) -> list
     try:
         await check_tool_compatibility('CreateLLMJudgmentListTool', args)
         result = await create_llm_judgment_list(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'LLM judgment list created:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('CreateLLMJudgmentListTool', e, 'creating LLM judgment list')
@@ -779,7 +817,7 @@ async def get_experiment_tool(args: GetExperimentArgs) -> list[dict]:
     try:
         await check_tool_compatibility('GetExperimentTool', args)
         result = await get_experiment(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Experiment {args.experiment_id}:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('GetExperimentTool', e, 'retrieving experiment')
@@ -798,7 +836,7 @@ async def create_experiment_tool(args: CreateExperimentArgs) -> list[dict]:
     try:
         await check_tool_compatibility('CreateExperimentTool', args)
         result = await create_experiment(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Experiment created:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('CreateExperimentTool', e, 'creating experiment')
@@ -816,8 +854,13 @@ async def delete_experiment_tool(args: DeleteExperimentArgs) -> list[dict]:
     try:
         await check_tool_compatibility('DeleteExperimentTool', args)
         result = await delete_experiment(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Experiment {args.experiment_id} deleted:\n{formatted_result}'}]
+        formatted_result = format_json(result)
+        return [
+            {
+                'type': 'text',
+                'text': f'Experiment {args.experiment_id} deleted:\n{formatted_result}',
+            }
+        ]
     except Exception as e:
         return log_tool_error('DeleteExperimentTool', e, 'deleting experiment')
 
@@ -834,7 +877,7 @@ async def search_query_sets_tool(args: SearchQuerySetsArgs) -> list[dict]:
     try:
         await check_tool_compatibility('SearchQuerySetsTool', args)
         result = await search_query_sets(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Query set search results:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('SearchQuerySetsTool', e, 'searching query sets')
@@ -852,10 +895,14 @@ async def search_search_configurations_tool(args: SearchSearchConfigurationsArgs
     try:
         await check_tool_compatibility('SearchSearchConfigurationsTool', args)
         result = await search_search_configurations(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Search configuration search results:\n{formatted_result}'}]
+        formatted_result = format_json(result)
+        return [
+            {'type': 'text', 'text': f'Search configuration search results:\n{formatted_result}'}
+        ]
     except Exception as e:
-        return log_tool_error('SearchSearchConfigurationsTool', e, 'searching search configurations')
+        return log_tool_error(
+            'SearchSearchConfigurationsTool', e, 'searching search configurations'
+        )
 
 
 async def search_judgments_tool(args: SearchJudgmentsArgs) -> list[dict]:
@@ -870,7 +917,7 @@ async def search_judgments_tool(args: SearchJudgmentsArgs) -> list[dict]:
     try:
         await check_tool_compatibility('SearchJudgmentsTool', args)
         result = await search_judgments(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Judgment search results:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('SearchJudgmentsTool', e, 'searching judgments')
@@ -888,7 +935,7 @@ async def search_experiments_tool(args: SearchExperimentsArgs) -> list[dict]:
     try:
         await check_tool_compatibility('SearchExperimentsTool', args)
         result = await search_experiments(args)
-        formatted_result = json.dumps(result, separators=(',', ':'))
+        formatted_result = format_json(result)
         return [{'type': 'text', 'text': f'Experiment search results:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('SearchExperimentsTool', e, 'searching experiments')

--- a/src/tools/utils.py
+++ b/src/tools/utils.py
@@ -1,9 +1,19 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import yaml
 from semver import Version
+
+
+def format_json(data) -> str:
+    """Format data as compact JSON with non-ASCII character preservation.
+
+    All tool responses should use this function instead of calling json.dumps
+    directly to ensure consistent formatting across the codebase.
+    """
+    return json.dumps(data, separators=(',', ':'), ensure_ascii=False)
 
 
 def is_tool_compatible(current_version: Version | None, tool_info: dict = {}):


### PR DESCRIPTION
## Summary
- Add `format_json()` helper in `utils.py` that wraps `json.dumps` with `ensure_ascii=False` and compact separators
- Replace all 28 `json.dumps` call sites across `tools.py`, `generic_api_tool.py`, and `skills_tools.py` with the shared helper
- Ensures non-ASCII characters (e.g. Chinese, Japanese, accented characters) are preserved in all tool outputs instead of being escaped to `\uXXXX` sequences

## Issues Resolved
Supersedes #164

## Testing
- All 329 existing unit tests pass (`uv run pytest`)
- No new dependencies added

## Credits
Based on the original fix by @Yuxin-Yu in #164. This PR extends the fix to all tool response formatting across the codebase and centralizes it in a shared helper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).