### PR TITLE
[Fix/Enhancement] Use HTTP(S) default ports when OpenSearch URL omits port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix multi-mode IT failing for `ListClustersTool` which has no `opensearch_cluster_name` parameter ([#220](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/220))
 
 - Fix `SearchIndexTool` ignoring `size=0`, causing aggregation-only queries to always return 10 hits ([#217](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/217))
+- Infer default TCP port from URL scheme (`http` → 80, `https` → 443) when no port is specified, instead of relying on implicit 9200 behavior ([#170](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/170))
 
 ### Removed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -470,6 +470,18 @@ python -m mcp_server_opensearch --mode multi
 
 ### Connection & Authentication Variables
 
+`OPENSEARCH_URL` (and each cluster’s `opensearch_url` in multi-cluster YAML) must include a scheme (`http://` or `https://`). The TCP port used is determined as follows:
+
+| Example URL | Port in the URL? | TCP port used |
+|---------------|------------------|---------------|
+| `https://cluster.example.com` | Omitted | **443** (HTTPS default) |
+| `http://cluster.example.com` | Omitted | **80** (HTTP default) |
+| `https://cluster.example.com:9200` | Set to `9200` | **9200** |
+| `http://localhost:9200` | Set to `9200` | **9200** |
+| `https://cluster.example.com:9443` | Set to `9443` (or any other value) | **Same as in the URL** |
+
+If the port is omitted, this server inserts the usual HTTP(S) default so traffic does not fall back to the OpenSearch Python client’s implicit **9200** (Elasticsearch-style default when no port appears in the string). For a typical local OpenSearch process listening on 9200, set the URL to `http://localhost:9200` (or another host) **with `:9200` explicitly**.
+
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `OPENSEARCH_URL` | Yes* | `''` | OpenSearch cluster endpoint URL |

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -13,8 +13,9 @@ import importlib.metadata
 import logging
 import os
 from contextlib import asynccontextmanager
+from http.client import HTTP_PORT, HTTPS_PORT
 from typing import Any, AsyncIterator, Dict, Optional
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from mcp.server.lowlevel.server import request_ctx
 from starlette.requests import Request
@@ -38,6 +39,8 @@ try:
 except importlib.metadata.PackageNotFoundError:
     _VERSION = 'unknown'
 USER_AGENT = f'opensearch-mcp-server-py/{_VERSION}'
+# opensearch-py uses 9200 when the URL has no port; http/https must use RFC defaults.
+_DEFAULT_PORTS_BY_SCHEME: dict[str, int] = {'http': HTTP_PORT, 'https': HTTPS_PORT}
 
 
 # Import custom connection classes and exceptions
@@ -58,30 +61,6 @@ class ConfigurationError(OpenSearchClientError):
     """Exception raised when configuration is invalid."""
 
     pass
-
-
-def _log_connection_event(
-    auth_method: str,
-    datasource_type: str,
-    opensearch_url: str,
-    error: str,
-) -> None:
-    """Emit a structured error log event for failed datasource connections.
-
-    Only logs failures because AsyncOpenSearch() construction does not
-    actually connect — a "success" event would be misleading.
-    """
-    logger.error(
-        f'Datasource connection failed: {auth_method} ({datasource_type})',
-        extra={
-            'event_type': 'datasource_connection',
-            'auth_method': auth_method,
-            'datasource_type': datasource_type,
-            'status': 'error',
-            'opensearch_url': opensearch_url,
-            'error': error,
-        },
-    )
 
 
 # Public API Functions
@@ -169,6 +148,55 @@ async def get_opensearch_client(args: baseToolArgs) -> AsyncIterator[AsyncOpenSe
 
 
 # Private Implementation Functions
+def _netloc_with_explicit_port(parsed: ParseResult, port: int) -> str:
+    host = parsed.hostname
+    if not host:
+        return parsed.netloc
+    host_literal = f'[{host}]' if ':' in host and not host.startswith('[') else host
+    if parsed.username is not None:
+        userinfo = parsed.username
+        if parsed.password is not None:
+            userinfo = f'{userinfo}:{parsed.password}'
+        return f'{userinfo}@{host_literal}:{port}'
+    return f'{host_literal}:{port}'
+
+
+def _parsed_with_default_ports(parsed: ParseResult) -> tuple[str, ParseResult]:
+    """Return ``(url, parsed)`` with :80/:443 in netloc when http(s) omits a port."""
+    if parsed.port is not None:
+        return urlunparse(parsed), parsed
+    port = _DEFAULT_PORTS_BY_SCHEME.get(parsed.scheme)
+    if port is None or not parsed.hostname:
+        return urlunparse(parsed), parsed
+    new_netloc = _netloc_with_explicit_port(parsed, port)
+    new_parsed = parsed._replace(netloc=new_netloc)
+    return urlunparse(new_parsed), new_parsed
+
+
+def _log_connection_event(
+    auth_method: str,
+    datasource_type: str,
+    opensearch_url: str,
+    error: str,
+) -> None:
+    """Emit a structured error log event for failed datasource connections.
+
+    Only logs failures because AsyncOpenSearch() construction does not
+    actually connect — a "success" event would be misleading.
+    """
+    logger.error(
+        f'Datasource connection failed: {auth_method} ({datasource_type})',
+        extra={
+            'event_type': 'datasource_connection',
+            'auth_method': auth_method,
+            'datasource_type': datasource_type,
+            'status': 'error',
+            'opensearch_url': opensearch_url,
+            'error': error,
+        },
+    )
+
+
 def _initialize_client_single_mode() -> AsyncOpenSearch:
     """Initialize OpenSearch client for single mode using environment variables.
 
@@ -486,11 +514,12 @@ def _create_opensearch_client(
 
     opensearch_url = opensearch_url.strip()
 
-    # Validate URL format
+    # Parse and validate; only when scheme is http/https and no port is given, append port.
     try:
         parsed_url = urlparse(opensearch_url)
         if not parsed_url.scheme or not parsed_url.netloc:
             raise ValueError('Invalid URL format')
+        opensearch_url, parsed_url = _parsed_with_default_ports(parsed_url)
     except Exception as e:
         raise ConfigurationError(f'Invalid OpenSearch URL format: {opensearch_url}. Error: {e}')
 
@@ -529,7 +558,7 @@ def _create_opensearch_client(
         'headers': {'user-agent': USER_AGENT},
     }
     client_kwargs.update(tls_config)
-    
+
     if response_size_limit is not None:
         logger.info(
             f'Configuring OpenSearch client with max_response_size={response_size_limit} bytes'
@@ -562,7 +591,9 @@ def _create_opensearch_client(
                 client_kwargs['headers'] = {'Authorization': bearer_auth_header}
                 return AsyncOpenSearch(**client_kwargs)
             except Exception as e:
-                _log_connection_event('header_auth_bearer', datasource_type, opensearch_url, str(e))
+                _log_connection_event(
+                    'header_auth_bearer', datasource_type, opensearch_url, str(e)
+                )
                 raise AuthenticationError(
                     f'Failed to authenticate with Authorization Bearer header: {e}'
                 )
@@ -860,7 +891,7 @@ def _get_auth_from_headers() -> Dict[str, Optional[str]]:
                 )
                 result['aws_session_token'] = headers.get('aws-session-token', '').strip() or None
                 result['aws_service_name'] = headers.get('aws-service-name', '').strip() or None
-                
+
                 # Extract auth from Authorization header
                 auth_header = headers.get('authorization', '').strip()
                 if auth_header:
@@ -871,11 +902,12 @@ def _get_auth_from_headers() -> Dict[str, Optional[str]]:
                             result['bearer_auth_header'] = f'Bearer {token}'
                     elif auth_header_lower.startswith('basic '):
                         import base64
+
                         # Extract the base64 encoded credentials
                         encoded_credentials = auth_header[6:]  # Skip 'Basic '
                         decoded_bytes = base64.b64decode(encoded_credentials)
                         decoded_credentials = decoded_bytes.decode('utf-8')
-                        
+
                         # Split into username and password
                         if ':' in decoded_credentials:
                             username, password = decoded_credentials.split(':', 1)

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -1,8 +1,7 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-OpenSearch client initialization module.
+"""OpenSearch client initialization module.
 
 This module provides functions to initialize OpenSearch clients with different
 authentication methods and connection modes (single vs multi-cluster).
@@ -12,19 +11,23 @@ import boto3
 import importlib.metadata
 import logging
 import os
+from .connection import (
+    DEFAULT_MAX_RESPONSE_SIZE,
+    BufferedAsyncHttpConnection,
+    OpenSearchClientError,
+)
+from botocore.credentials import Credentials
 from contextlib import asynccontextmanager
 from http.client import HTTP_PORT, HTTPS_PORT
-from typing import Any, AsyncIterator, Dict, Optional
-from urllib.parse import ParseResult, urlparse, urlunparse
-
 from mcp.server.lowlevel.server import request_ctx
-from starlette.requests import Request
-
 from mcp_server_opensearch.clusters_information import ClusterInfo, get_cluster
 from mcp_server_opensearch.global_state import get_mode, get_profile
 from opensearchpy import AsyncOpenSearch, AWSV4SignerAsyncAuth
+from starlette.requests import Request
 from tools.tool_params import baseToolArgs
-from botocore.credentials import Credentials
+from typing import Any, AsyncIterator, Dict, Optional
+from urllib.parse import ParseResult, urlparse, urlunparse
+
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -41,14 +44,6 @@ except importlib.metadata.PackageNotFoundError:
 USER_AGENT = f'opensearch-mcp-server-py/{_VERSION}'
 # opensearch-py uses 9200 when the URL has no port; http/https must use RFC defaults.
 _DEFAULT_PORTS_BY_SCHEME: dict[str, int] = {'http': HTTP_PORT, 'https': HTTPS_PORT}
-
-
-# Import custom connection classes and exceptions
-from .connection import (
-    BufferedAsyncHttpConnection,
-    OpenSearchClientError,
-    DEFAULT_MAX_RESPONSE_SIZE,
-)
 
 
 class AuthenticationError(OpenSearchClientError):
@@ -819,7 +814,6 @@ def get_aws_region_multi_mode(cluster_info: ClusterInfo) -> Optional[str]:
         Optional[str]: AWS region, or None if not available (acceptable for basic auth/no auth)
 
     """
-
     try:
         # Try cluster-specific region first
         if cluster_info.aws_region and cluster_info.aws_region.strip():

--- a/tests/opensearch/test_client.py
+++ b/tests/opensearch/test_client.py
@@ -3,27 +3,26 @@
 
 import boto3
 import os
-import tempfile
-
 import pytest
-from urllib.parse import urlparse
-
+import tempfile
 from opensearch.client import (
-    initialize_client,
-    ConfigurationError,
     AuthenticationError,
     BufferedAsyncHttpConnection,
+    ConfigurationError,
     _parsed_with_default_ports,
+    initialize_client,
 )
-from opensearchpy import AsyncOpenSearch, AsyncHttpConnection, AWSV4SignerAsyncAuth
+from opensearchpy import AWSV4SignerAsyncAuth
 from tools.tool_params import baseToolArgs
 from unittest.mock import Mock, patch
+from urllib.parse import urlparse
 
 
 class TestOpenSearchClient:
+    """Tests for OpenSearch client initialization."""
+
     def setup_method(self):
-        """Setup that runs before each test method."""
-        # Clear any existing environment variables
+        """Clear env vars and set single-cluster mode before each test."""
         self.original_env = {}
         for key in [
             'OPENSEARCH_USERNAME',
@@ -45,7 +44,6 @@ class TestOpenSearchClient:
                 self.original_env[key] = os.environ[key]
                 del os.environ[key]
 
-        # Set global mode for tests
         from mcp_server_opensearch.global_state import set_mode
 
         set_mode('single')
@@ -910,21 +908,26 @@ class TestParsedWithDefaultPorts:
         return _parsed_with_default_ports(urlparse(url))[0]
 
     def test_https_adds_443(self):
+        """HTTPS without a port uses TCP 443."""
         assert self._norm('https://my-cluster.example.com') == 'https://my-cluster.example.com:443'
 
     def test_http_adds_80(self):
+        """HTTP without a port uses TCP 80."""
         assert self._norm('http://my-cluster.example.com') == 'http://my-cluster.example.com:80'
 
     def test_explicit_port_unchanged(self):
+        """Explicit port in the URL is preserved."""
         assert (
             self._norm('https://my-cluster.example.com:9200')
             == 'https://my-cluster.example.com:9200'
         )
 
     def test_https_ipv6_adds_443(self):
+        """HTTPS IPv6 literal without a port gets :443."""
         assert self._norm('https://[::1]/') == 'https://[::1]:443/'
 
     def test_basic_auth_netloc(self):
+        """Userinfo in netloc is kept when inserting the default port."""
         assert (
             self._norm('https://user:secret@my-cluster.example.com/path')
             == 'https://user:secret@my-cluster.example.com:443/path'

--- a/tests/opensearch/test_client.py
+++ b/tests/opensearch/test_client.py
@@ -6,7 +6,15 @@ import os
 import tempfile
 
 import pytest
-from opensearch.client import initialize_client, ConfigurationError, AuthenticationError, BufferedAsyncHttpConnection
+from urllib.parse import urlparse
+
+from opensearch.client import (
+    initialize_client,
+    ConfigurationError,
+    AuthenticationError,
+    BufferedAsyncHttpConnection,
+    _parsed_with_default_ports,
+)
 from opensearchpy import AsyncOpenSearch, AsyncHttpConnection, AWSV4SignerAsyncAuth
 from tools.tool_params import baseToolArgs
 from unittest.mock import Mock, patch
@@ -79,7 +87,7 @@ class TestOpenSearchClient:
         assert client == mock_client
         mock_opensearch.assert_called_once()
         call_kwargs = mock_opensearch.call_args[1]
-        assert call_kwargs['hosts'] == ['https://test-opensearch-domain.com']
+        assert call_kwargs['hosts'] == ['https://test-opensearch-domain.com:443']
         assert call_kwargs['use_ssl'] is True
         assert call_kwargs['verify_certs'] is True
         assert call_kwargs['connection_class'] == BufferedAsyncHttpConnection
@@ -122,7 +130,7 @@ class TestOpenSearchClient:
         assert client == mock_client
         mock_opensearch.assert_called_once()
         call_kwargs = mock_opensearch.call_args[1]
-        assert call_kwargs['hosts'] == ['https://test-opensearch-domain.com']
+        assert call_kwargs['hosts'] == ['https://test-opensearch-domain.com:443']
         assert call_kwargs['use_ssl'] is True
         assert call_kwargs['verify_certs'] is True
         assert call_kwargs['connection_class'] == BufferedAsyncHttpConnection
@@ -188,7 +196,7 @@ class TestOpenSearchClient:
         assert client == mock_client
         mock_opensearch.assert_called_once()
         call_kwargs = mock_opensearch.call_args[1]
-        assert call_kwargs['hosts'] == ['https://test-opensearch-domain.com']
+        assert call_kwargs['hosts'] == ['https://test-opensearch-domain.com:443']
         assert call_kwargs['use_ssl'] is True
         assert call_kwargs['verify_certs'] is True
         assert call_kwargs['connection_class'] == BufferedAsyncHttpConnection
@@ -606,6 +614,7 @@ class TestOpenSearchClientContextManager:
         # Verify all three clients were created
         assert mock_opensearch.call_count == 3
 
+
 class TestHeaderBasedBasicAuth:
     """Tests for Basic authentication via Authorization header."""
 
@@ -652,7 +661,7 @@ class TestHeaderBasedBasicAuth:
         password = 'header-password'
         credentials = f'{username}:{password}'
         encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
-        
+
         mock_request = Mock(spec=Request)
         mock_request.headers = {'authorization': f'Basic {encoded_credentials}'}
 
@@ -700,7 +709,7 @@ class TestHeaderBasedBasicAuth:
         header_password = 'header-password'
         credentials = f'{header_username}:{header_password}'
         encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
-        
+
         mock_request = Mock(spec=Request)
         mock_request.headers = {'authorization': f'Basic {encoded_credentials}'}
 
@@ -783,9 +792,7 @@ class TestHeaderBasedBearerAuth:
 
     @patch('opensearch.client.request_ctx')
     @patch('opensearch.client.AsyncOpenSearch')
-    def test_bearer_auth_from_authorization_header(
-        self, mock_opensearch, mock_request_ctx
-    ):
+    def test_bearer_auth_from_authorization_header(self, mock_opensearch, mock_request_ctx):
         """Test Bearer auth passthrough from Authorization header."""
         from starlette.requests import Request
 
@@ -893,3 +900,32 @@ class TestHeaderBasedBearerAuth:
         assert client == mock_client
         call_kwargs = mock_opensearch.call_args[1]
         assert call_kwargs['http_auth'] == ('env-user', 'env-password')
+
+
+class TestParsedWithDefaultPorts:
+    """URL normalization used by ``_create_opensearch_client`` (same path as production)."""
+
+    @staticmethod
+    def _norm(url: str) -> str:
+        return _parsed_with_default_ports(urlparse(url))[0]
+
+    def test_https_adds_443(self):
+        assert self._norm('https://my-cluster.example.com') == 'https://my-cluster.example.com:443'
+
+    def test_http_adds_80(self):
+        assert self._norm('http://my-cluster.example.com') == 'http://my-cluster.example.com:80'
+
+    def test_explicit_port_unchanged(self):
+        assert (
+            self._norm('https://my-cluster.example.com:9200')
+            == 'https://my-cluster.example.com:9200'
+        )
+
+    def test_https_ipv6_adds_443(self):
+        assert self._norm('https://[::1]/') == 'https://[::1]:443/'
+
+    def test_basic_auth_netloc(self):
+        assert (
+            self._norm('https://user:secret@my-cluster.example.com/path')
+            == 'https://user:secret@my-cluster.example.com:443/path'
+        )


### PR DESCRIPTION
### Description
When configuring the OpenSearch endpoint as a URL (e.g. `https://my-cluster.example.com`), the MCP server could effectively behave as if port **9200** were used when no port was explicitly specified. That can cause failures such as **TimeoutError** when the cluster is actually served on standard HTTPS (**443**) or HTTP (**80**).
The server should infer the default port from the URL scheme (**443** for `https://`, **80** for `http://`) when no port is specified, consistent with usual HTTP conventions.

This PR implements that normalization in the client creation path, documents it in the user guide, adds tests, and records the change in `CHANGELOG.md`.

Also covering minor Ruff related clean-ups.

### Changes Made
- **`src/opensearch/client.py`** — Default missing ports on scheme based (http/https) URLs to 80 / 443 (RFC-style) instead of implicit 9200.
- **`tests/opensearch/test_client.py`** — Tests for URL normalization; Ruff-related cleanups.
- **`USER_GUIDE.md`** — Document endpoint URL / default port behavior.
- **`CHANGELOG.md`** — `[Unreleased]` Added entry linked to the issue.

### Lint/Tests
| Check | Result |
| --- | --- |
| `uv run ruff check src/opensearch/client.py tests/opensearch/test_client.py` | All checks passed |
| `uv run pytest tests/opensearch/test_client.py -q` | 27 passed |


### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-mcp-server-py/issues/170

Related cleanup: Ruff/pydocstyle issues in `src/opensearch/client.py` and `tests/opensearch/test_client.py` addressed as part of the same PR (no separate GitHub issue).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).