### PR TITLE
Add agentic memory tools following existing patterns

### DIFF
--- a/src/tools/agentic_memory/__init__.py
+++ b/src/tools/agentic_memory/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from .tools import AGENTIC_MEMORY_TOOLS_REGISTRY
+
+__all__ = ['AGENTIC_MEMORY_TOOLS_REGISTRY']

--- a/src/tools/agentic_memory/params.py
+++ b/src/tools/agentic_memory/params.py
@@ -1,0 +1,403 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set
+
+from pydantic import BaseModel, Field, model_validator
+from pydantic_core import PydanticCustomError
+from typing import Literal
+
+from tools.tool_params import baseToolArgs
+
+
+class MemoryType(str, Enum):
+    """Specifies the different types of agentic memory."""
+
+    sessions = 'sessions'
+    working = 'working'
+    long_term = 'long-term'
+    history = 'history'
+
+
+class PayloadType(str, Enum):
+    """Specifies the type of payload being added to agentic memory."""
+
+    conversational = 'conversational'
+    data = 'data'
+
+
+class MessageContentItem(BaseModel):
+    """Schema for the content part of a message."""
+
+    text: str = Field(..., description='The text content of the message.')
+    content_type: str = Field(
+        ..., description="The type of the content (e.g., 'text').", alias='type'
+    )
+
+
+class MessageItem(BaseModel):
+    """Schema for a single message in the messages field."""
+
+    role: Optional[str] = Field(
+        None, description="The role of the entity (e.g., 'user', 'assistant')."
+    )
+    content: List[MessageContentItem] = Field(
+        ..., description='A list of content items for this message.'
+    )
+
+
+class BaseAgenticMemoryContainerArgs(baseToolArgs):
+    """Base arguments for tools operating on an Agentic Memory Container."""
+
+    memory_container_id: str = Field(..., description='The ID of the memory container.')
+
+
+class CreateAgenticMemorySessionArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for creating a new session in an agentic memory container."""
+
+    session_id: Optional[str] = Field(
+        default=None,
+        description='A custom session ID. If not provided, a random ID is generated.',
+    )
+    summary: Optional[str] = Field(default=None, description='A session summary or description.')
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description='Additional metadata for the session provided as key-value pairs.',
+    )
+    namespace: Optional[Dict[str, str]] = Field(
+        default=None, description='Namespace information for organizing the session.'
+    )
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'SdjmmpgBOh0h20Y9kWuN',
+                    'session_id': 'abc123',
+                    'metadata': {'key1': 'value1'},
+                },
+            ]
+        }
+
+
+_ERR_MESSAGES_REQUIRED = 'messages_required'
+_ERR_FIELD_PROHIBITED = 'field_prohibited'
+_ERR_STRUCTURED_DATA_REQUIRED = 'structured_data_required'
+_ERR_MISSING_CONTENT_FIELD = 'missing_content_field'
+_ERR_FIELD_NOT_ALLOWED = 'field_not_allowed'
+_ERR_MISSING_WORKING_FIELD = 'missing_working_field'
+_ERR_MISSING_LONG_TERM_FIELD = 'missing_long_term_field'
+
+
+class AddAgenticMemoriesArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for adding memories to an agentic memory container."""
+
+    messages: Optional[List[MessageItem]] = Field(
+        default=None, description='A list of messages for a conversational payload.'
+    )
+    structured_data: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description='Structured data content for data memory. Required when payload_type is data.',
+    )
+    binary_data: Optional[str] = Field(
+        default=None,
+        description='Binary data content encoded as a Base64 string for binary payloads.',
+    )
+    payload_type: PayloadType = Field(
+        ..., description='The type of payload. Valid values are conversational or data.'
+    )
+    namespace: Optional[Dict[str, str]] = Field(
+        default=None, description='The namespace context for organizing memories.'
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None, description='Additional metadata for the memory.'
+    )
+    tags: Optional[Dict[str, Any]] = Field(
+        default=None, description='Tags for categorizing and organizing memories.'
+    )
+    infer: Optional[bool] = Field(
+        default=False,
+        description='Whether to use a large language model (LLM) to extract key information.',
+    )
+
+    @model_validator(mode='after')
+    def validate_payload_requirements(self) -> 'AddAgenticMemoriesArgs':
+        """Validate that the correct fields are provided based on payload_type."""
+        set_fields = self.model_fields_set
+
+        if self.payload_type == PayloadType.conversational:
+            if 'messages' not in set_fields:
+                raise PydanticCustomError(
+                    _ERR_MESSAGES_REQUIRED,
+                    "'messages' field is required when payload_type is 'conversational'",
+                )
+            if 'structured_data' in set_fields:
+                raise PydanticCustomError(
+                    _ERR_FIELD_PROHIBITED,
+                    "'structured_data' should not be provided when payload_type is 'conversational'",
+                    {'field_name': 'structured_data'},
+                )
+        elif self.payload_type == PayloadType.data:
+            if 'structured_data' not in set_fields:
+                raise PydanticCustomError(
+                    _ERR_STRUCTURED_DATA_REQUIRED,
+                    "'structured_data' field is required when payload_type is 'data'",
+                )
+            if 'messages' in set_fields:
+                raise PydanticCustomError(
+                    _ERR_FIELD_PROHIBITED,
+                    "'messages' should not be provided when payload_type is 'data'",
+                    {'field_name': 'messages'},
+                )
+
+        content_fields = {'messages', 'structured_data', 'binary_data'}
+        if not any(field in set_fields for field in content_fields):
+            raise PydanticCustomError(
+                _ERR_MISSING_CONTENT_FIELD,
+                'At least one content field (messages, structured_data, or binary_data) must be provided',
+            )
+
+        return self
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'SdjmmpgBOh0h20Y9kWuN',
+                    'messages': [
+                        {
+                            'role': 'user',
+                            'content': [
+                                {'text': "I'm Bob, I really like swimming.", 'type': 'text'}
+                            ],
+                        },
+                        {
+                            'role': 'assistant',
+                            'content': [
+                                {'text': 'Cool, nice. Hope you enjoy your life.', 'type': 'text'}
+                            ],
+                        },
+                    ],
+                    'namespace': {'user_id': 'bob'},
+                    'infer': True,
+                    'payload_type': 'conversational',
+                },
+            ]
+        }
+
+
+class GetAgenticMemoryArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for retrieving a specific agentic memory by its type and ID."""
+
+    memory_type: MemoryType = Field(
+        ...,
+        alias='type',
+        description='The memory type. Valid values are sessions, working, long-term, and history.',
+    )
+    id: str = Field(..., description='The ID of the memory to retrieve.')
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'working',
+                    'id': 'XyEuiJkBeh2gPPwzjYWM',
+                },
+            ]
+        }
+
+
+class UpdateAgenticMemoryArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for updating a specific agentic memory by its type and ID."""
+
+    _SESSION_ONLY_FIELDS: Set[str] = {'summary', 'agents', 'additional_info'}
+    _WORKING_ONLY_FIELDS: Set[str] = {'messages', 'structured_data', 'binary_data'}
+    _LONG_TERM_ONLY_FIELDS: Set[str] = {'memory'}
+    _UPDATABLE_WORKING_FIELDS: Set[str] = {
+        'messages',
+        'structured_data',
+        'binary_data',
+        'tags',
+        'metadata',
+    }
+    _UPDATABLE_LONG_TERM_FIELDS: Set[str] = {'memory', 'tags', 'metadata'}
+
+    memory_type: Literal[MemoryType.sessions, MemoryType.working, MemoryType.long_term] = Field(
+        ...,
+        alias='type',
+        description='The memory type. Valid values are sessions, working, and long-term. History memory cannot be updated.',
+    )
+    id: str = Field(..., description='The ID of the memory to update.')
+    summary: Optional[str] = Field(default=None, description='The summary of the session.')
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description='Additional metadata for the memory.',
+    )
+    agents: Optional[Dict[str, Any]] = Field(
+        default=None, description='Additional information about the agents.'
+    )
+    additional_info: Optional[Dict[str, Any]] = Field(
+        default=None, description='Additional metadata to associate with the session.'
+    )
+    messages: Optional[List[MessageItem]] = Field(
+        default=None,
+        description='Updated conversation messages (for conversation type).',
+    )
+    structured_data: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description='Updated structured data content (for data memory payloads).',
+    )
+    binary_data: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description='Updated binary data content (for data memory payloads).',
+    )
+    tags: Optional[Dict[str, Any]] = Field(
+        default=None, description='Updated tags for categorization.'
+    )
+    memory: Optional[str] = Field(default=None, description='The updated memory content.')
+
+    @model_validator(mode='after')
+    def validate_memory_type_fields(self) -> 'UpdateAgenticMemoryArgs':
+        """Validate that fields match the specified memory_type and minimum requirements."""
+        set_fields = self.model_fields_set
+
+        def _raise_not_allowed_error(field_name: str, memory_type: str):
+            raise PydanticCustomError(
+                _ERR_FIELD_NOT_ALLOWED,
+                "Field '{field_name}' should not be provided when updating {memory_type} memory",
+                {'field_name': field_name, 'memory_type': memory_type},
+            )
+
+        if self.memory_type == MemoryType.sessions:
+            disallowed_fields = self._WORKING_ONLY_FIELDS | self._LONG_TERM_ONLY_FIELDS
+            for field in disallowed_fields:
+                if field in set_fields:
+                    _raise_not_allowed_error(field, MemoryType.sessions)
+
+        elif self.memory_type == MemoryType.working:
+            disallowed_fields = self._SESSION_ONLY_FIELDS | self._LONG_TERM_ONLY_FIELDS
+            for field in disallowed_fields:
+                if field in set_fields:
+                    _raise_not_allowed_error(field, MemoryType.working)
+
+            if not any(field in set_fields for field in self._UPDATABLE_WORKING_FIELDS):
+                raise PydanticCustomError(
+                    _ERR_MISSING_WORKING_FIELD,
+                    'At least one field ({fields}) must be provided for updating working memory',
+                    {'fields': ', '.join(self._UPDATABLE_WORKING_FIELDS)},
+                )
+
+        elif self.memory_type == MemoryType.long_term:
+            disallowed_fields = self._SESSION_ONLY_FIELDS | self._WORKING_ONLY_FIELDS
+            for field in disallowed_fields:
+                if field in set_fields:
+                    _raise_not_allowed_error(field, MemoryType.long_term)
+
+            if not any(field in set_fields for field in self._UPDATABLE_LONG_TERM_FIELDS):
+                raise PydanticCustomError(
+                    _ERR_MISSING_LONG_TERM_FIELD,
+                    'At least one field ({fields}) must be provided for updating long-term memory',
+                    {'fields': ', '.join(self._UPDATABLE_LONG_TERM_FIELDS)},
+                )
+
+        return self
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'sessions',
+                    'id': 'N2CDipkB2Mtr6INFFcX8',
+                    'additional_info': {'key1': 'value1'},
+                },
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'working',
+                    'id': 'XyEuiJkBeh2gPPwzjYWM',
+                    'tags': {'topic': 'updated_topic', 'priority': 'high'},
+                },
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'long-term',
+                    'id': 'DcxjTpkBvwXRq366C1Zz',
+                    'memory': "User's name is Bob Smith",
+                    'tags': {'topic': 'personal info'},
+                },
+            ]
+        }
+
+
+class DeleteAgenticMemoryByIDArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for deleting a specific agentic memory by its type and ID."""
+
+    memory_type: MemoryType = Field(
+        ...,
+        alias='type',
+        description='The type of memory to delete. Valid values are sessions, working, long-term, and history.',
+    )
+    id: str = Field(..., description='The ID of the specific memory to delete.')
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'working',
+                    'id': 'XyEuiJkBeh2gPPwzjYWM',
+                },
+            ]
+        }
+
+
+class DeleteAgenticMemoryByQueryArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for deleting agentic memories by query."""
+
+    memory_type: MemoryType = Field(
+        ...,
+        alias='type',
+        description='The type of memory to delete. Valid values are sessions, working, long-term, and history.',
+    )
+    query: Dict[str, Any] = Field(
+        ...,
+        description='The query to match the memories you want to delete. Must be a valid OpenSearch query DSL object.',
+    )
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'working',
+                    'query': {'match': {'owner_id': 'admin'}},
+                },
+            ]
+        }
+
+
+class SearchAgenticMemoryArgs(BaseAgenticMemoryContainerArgs):
+    """Arguments for searching memories of a specific type within an agentic memory container."""
+
+    memory_type: MemoryType = Field(
+        ...,
+        alias='type',
+        description='The memory type. Valid values are sessions, working, long-term, and history.',
+    )
+    query: Dict[str, Any] = Field(..., description='The search query using OpenSearch query DSL.')
+    sort: Optional[List[Dict[str, Any]]] = Field(
+        default=None, description='Sort specification for the search results.'
+    )
+
+    class Config:
+        json_schema_extra = {
+            'examples': [
+                {
+                    'memory_container_id': 'HudqiJkB1SltqOcZusVU',
+                    'type': 'sessions',
+                    'query': {'match_all': {}},
+                    'sort': [{'created_time': {'order': 'desc'}}],
+                },
+            ]
+        }

--- a/src/tools/agentic_memory/tools.py
+++ b/src/tools/agentic_memory/tools.py
@@ -1,0 +1,295 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Dict, Any
+from urllib.parse import quote
+from tools.tool_logging import log_tool_error
+from tools.utils import is_tool_compatible
+from opensearch.client import get_opensearch_client
+from .params import (
+    AddAgenticMemoriesArgs,
+    CreateAgenticMemorySessionArgs,
+    DeleteAgenticMemoryByIDArgs,
+    DeleteAgenticMemoryByQueryArgs,
+    GetAgenticMemoryArgs,
+    SearchAgenticMemoryArgs,
+    UpdateAgenticMemoryArgs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — "dumb pipes" to OpenSearch (no try/except)
+# ---------------------------------------------------------------------------
+
+
+async def create_agentic_memory_session(
+    args: CreateAgenticMemorySessionArgs,
+) -> Dict[str, Any]:
+    """Create a new agentic memory session in the specified memory container."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories/sessions',
+        ])
+        body = args.model_dump(
+            exclude={'memory_container_id', 'opensearch_cluster_name'},
+            exclude_none=True,
+        )
+        return await client.transport.perform_request(method='POST', url=url, body=body)
+
+
+async def add_agentic_memories(args: AddAgenticMemoriesArgs) -> Dict[str, Any]:
+    """Add agentic memories to the specified memory container."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories',
+        ])
+        body = args.model_dump(
+            exclude={'memory_container_id', 'opensearch_cluster_name'},
+            exclude_none=True,
+            by_alias=True,
+        )
+        return await client.transport.perform_request(method='POST', url=url, body=body)
+
+
+async def get_agentic_memory(args: GetAgenticMemoryArgs) -> Dict[str, Any]:
+    """Retrieve a specific agentic memory by its type and ID."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories',
+            quote(args.memory_type, safe=''),
+            quote(args.id, safe=''),
+        ])
+        return await client.transport.perform_request(method='GET', url=url)
+
+
+async def update_agentic_memory(args: UpdateAgenticMemoryArgs) -> Dict[str, Any]:
+    """Update a specific agentic memory by its type and ID."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories',
+            quote(args.memory_type, safe=''),
+            quote(args.id, safe=''),
+        ])
+        body = args.model_dump(
+            exclude={'memory_container_id', 'memory_type', 'id', 'opensearch_cluster_name'},
+            exclude_none=True,
+            by_alias=True,
+        )
+        return await client.transport.perform_request(method='PUT', url=url, body=body)
+
+
+async def delete_agentic_memory_by_id(args: DeleteAgenticMemoryByIDArgs) -> Dict[str, Any]:
+    """Delete a specific agentic memory by its type and ID."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories',
+            quote(args.memory_type, safe=''),
+            quote(args.id, safe=''),
+        ])
+        return await client.transport.perform_request(method='DELETE', url=url)
+
+
+async def delete_agentic_memory_by_query(args: DeleteAgenticMemoryByQueryArgs) -> Dict[str, Any]:
+    """Delete agentic memories matching the provided query."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories',
+            quote(args.memory_type, safe=''),
+            '_delete_by_query',
+        ])
+        body = args.model_dump(
+            exclude={'memory_container_id', 'memory_type', 'opensearch_cluster_name'},
+            exclude_none=True,
+        )
+        return await client.transport.perform_request(method='POST', url=url, body=body)
+
+
+async def search_agentic_memory(args: SearchAgenticMemoryArgs) -> Dict[str, Any]:
+    """Search for agentic memories using OpenSearch query DSL."""
+    async with get_opensearch_client(args) as client:
+        url = '/'.join([
+            '/_plugins/_ml/memory_containers',
+            quote(args.memory_container_id, safe=''),
+            'memories',
+            quote(args.memory_type, safe=''),
+            '_search',
+        ])
+        body = args.model_dump(
+            exclude={'memory_container_id', 'memory_type', 'opensearch_cluster_name'},
+            exclude_none=True,
+        )
+        return await client.transport.perform_request(method='GET', url=url, body=body)
+
+
+# ---------------------------------------------------------------------------
+# Tool functions — try/except + log_tool_error (the one place errors are caught)
+# ---------------------------------------------------------------------------
+
+
+async def check_tool_compatibility(tool_name: str, args):
+    """Check if a tool is compatible with the cluster version."""
+    from tools.tools import TOOL_REGISTRY
+    compatible, message = await is_tool_compatible(tool_name, TOOL_REGISTRY, args)
+    if not compatible:
+        raise Exception(message)
+
+
+async def create_agentic_memory_session_tool(args: CreateAgenticMemorySessionArgs) -> list[dict]:
+    """Tool to create a new session in an agentic memory container."""
+    try:
+        await check_tool_compatibility('CreateAgenticMemorySessionTool', args)
+        result = await create_agentic_memory_session(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Session created:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('CreateAgenticMemorySessionTool', e, 'creating session')
+
+
+async def add_agentic_memories_tool(args: AddAgenticMemoriesArgs) -> list[dict]:
+    """Tool to add memories to an agentic memory container."""
+    try:
+        await check_tool_compatibility('AddAgenticMemoriesTool', args)
+        result = await add_agentic_memories(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Memories added:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('AddAgenticMemoriesTool', e, 'adding memories')
+
+
+async def get_agentic_memory_tool(args: GetAgenticMemoryArgs) -> list[dict]:
+    """Tool to retrieve a specific agentic memory by type and ID."""
+    try:
+        await check_tool_compatibility('GetAgenticMemoryTool', args)
+        result = await get_agentic_memory(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Memory retrieved:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('GetAgenticMemoryTool', e, 'retrieving memory')
+
+
+async def update_agentic_memory_tool(args: UpdateAgenticMemoryArgs) -> list[dict]:
+    """Tool to update a specific agentic memory by type and ID."""
+    try:
+        await check_tool_compatibility('UpdateAgenticMemoryTool', args)
+        result = await update_agentic_memory(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Memory updated:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('UpdateAgenticMemoryTool', e, 'updating memory')
+
+
+async def delete_agentic_memory_by_id_tool(args: DeleteAgenticMemoryByIDArgs) -> list[dict]:
+    """Tool to delete a specific agentic memory by type and ID."""
+    try:
+        await check_tool_compatibility('DeleteAgenticMemoryByIDTool', args)
+        result = await delete_agentic_memory_by_id(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Memory deleted:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('DeleteAgenticMemoryByIDTool', e, 'deleting memory')
+
+
+async def delete_agentic_memory_by_query_tool(args: DeleteAgenticMemoryByQueryArgs) -> list[dict]:
+    """Tool to delete agentic memories by query."""
+    try:
+        await check_tool_compatibility('DeleteAgenticMemoryByQueryTool', args)
+        result = await delete_agentic_memory_by_query(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Memories deleted by query:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('DeleteAgenticMemoryByQueryTool', e, 'deleting memories by query')
+
+
+async def search_agentic_memory_tool(args: SearchAgenticMemoryArgs) -> list[dict]:
+    """Tool to search memories within an agentic memory container."""
+    try:
+        await check_tool_compatibility('SearchAgenticMemoryTool', args)
+        result = await search_agentic_memory(args)
+        formatted = json.dumps(result, separators=(',', ':'))
+        return [{'type': 'text', 'text': f'Memory search results:\n{formatted}'}]
+    except Exception as e:
+        return log_tool_error('SearchAgenticMemoryTool', e, 'searching memories')
+
+
+# ---------------------------------------------------------------------------
+# Registry — spread into TOOL_REGISTRY via **AGENTIC_MEMORY_TOOLS_REGISTRY
+# ---------------------------------------------------------------------------
+
+AGENTIC_MEMORY_TOOLS_REGISTRY = {
+    'CreateAgenticMemorySessionTool': {
+        'display_name': 'CreateAgenticMemorySessionTool',
+        'description': 'Creates a new session in an agentic memory container. Sessions group related memories together and can include metadata and namespace information.',
+        'input_schema': CreateAgenticMemorySessionArgs.model_json_schema(),
+        'function': create_agentic_memory_session_tool,
+        'args_model': CreateAgenticMemorySessionArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'POST',
+    },
+    'AddAgenticMemoriesTool': {
+        'display_name': 'AddAgenticMemoriesTool',
+        'description': 'Adds memories to an agentic memory container. Supports conversational payloads (message lists) and data payloads (structured data). Optionally uses an LLM to extract key information.',
+        'input_schema': AddAgenticMemoriesArgs.model_json_schema(),
+        'function': add_agentic_memories_tool,
+        'args_model': AddAgenticMemoriesArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'POST',
+    },
+    'GetAgenticMemoryTool': {
+        'display_name': 'GetAgenticMemoryTool',
+        'description': 'Retrieves a specific agentic memory by its type and ID from a memory container.',
+        'input_schema': GetAgenticMemoryArgs.model_json_schema(),
+        'function': get_agentic_memory_tool,
+        'args_model': GetAgenticMemoryArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'GET',
+    },
+    'UpdateAgenticMemoryTool': {
+        'display_name': 'UpdateAgenticMemoryTool',
+        'description': 'Updates a specific agentic memory by its type and ID. Supports updating sessions (summary, agents, additional_info), working memories (messages, structured_data, binary_data, tags, metadata), and long-term memories (memory, tags, metadata).',
+        'input_schema': UpdateAgenticMemoryArgs.model_json_schema(),
+        'function': update_agentic_memory_tool,
+        'args_model': UpdateAgenticMemoryArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'PUT',
+    },
+    'DeleteAgenticMemoryByIDTool': {
+        'display_name': 'DeleteAgenticMemoryByIDTool',
+        'description': 'Deletes a specific agentic memory by its type and ID from a memory container.',
+        'input_schema': DeleteAgenticMemoryByIDArgs.model_json_schema(),
+        'function': delete_agentic_memory_by_id_tool,
+        'args_model': DeleteAgenticMemoryByIDArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'DELETE',
+    },
+    'DeleteAgenticMemoryByQueryTool': {
+        'display_name': 'DeleteAgenticMemoryByQueryTool',
+        'description': 'Deletes agentic memories matching a query from a memory container. Uses OpenSearch query DSL to match memories for deletion.',
+        'input_schema': DeleteAgenticMemoryByQueryArgs.model_json_schema(),
+        'function': delete_agentic_memory_by_query_tool,
+        'args_model': DeleteAgenticMemoryByQueryArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'POST',
+    },
+    'SearchAgenticMemoryTool': {
+        'display_name': 'SearchAgenticMemoryTool',
+        'description': 'Searches memories of a specific type within an agentic memory container using OpenSearch query DSL. Supports sorting of results.',
+        'input_schema': SearchAgenticMemoryArgs.model_json_schema(),
+        'function': search_agentic_memory_tool,
+        'args_model': SearchAgenticMemoryArgs,
+        'min_version': '3.3.0',
+        'http_methods': 'GET',
+    },
+}

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -99,6 +99,57 @@ def _resolve_allow_write_setting(config_file_path: str = None) -> bool:
     return allow_write
 
 
+
+def _resolve_memory_container_id(config_file_path: str = None) -> str:
+    """Resolve memory_container_id from config file or environment variable.
+
+    Args:
+        config_file_path: Optional path to config file
+
+    Returns:
+        str: The memory container ID, or empty string if not configured
+    """
+    if config_file_path and os.path.exists(config_file_path):
+        try:
+            config = load_yaml_config(config_file_path)
+            if config:
+                agentic_memory = config.get('agentic_memory', {})
+                if isinstance(agentic_memory, dict):
+                    container_id = agentic_memory.get('memory_container_id', '')
+                    if container_id:
+                        return container_id
+        except Exception as e:
+            logging.debug(f'Could not load memory_container_id from config: {e}')
+
+    return os.getenv('OPENSEARCH_MEMORY_CONTAINER_ID', '')
+
+
+def _set_memory_container_default(tool_registry: dict, container_id: str) -> None:
+    """Set memory_container_id default on Pydantic models for agentic memory tools.
+
+    This runs once at startup so Pydantic auto-fills the field when clients omit it.
+
+    Args:
+        tool_registry: The tool registry dict
+        container_id: The memory container ID to set as default
+    """
+    for name, info in tool_registry.items():
+        args_model = info.get('args_model')
+        if args_model and hasattr(args_model, 'model_fields'):
+            field = args_model.model_fields.get('memory_container_id')
+            if field is not None:
+                field.default = container_id
+                # Also update the JSON schema so MCP clients see the default
+                schema = info.get('input_schema', {})
+                props = schema.get('properties', {})
+                if 'memory_container_id' in props:
+                    props['memory_container_id']['default'] = container_id
+                # Remove from required in schema
+                if 'required' in schema and 'memory_container_id' in schema['required']:
+                    schema['required'].remove('memory_container_id')
+                logging.debug(f'Set memory_container_id default for {name}: {container_id}')
+
+
 def apply_write_filter(registry):
     """Apply allow_write filters to the registry."""
     for tool_name in list(registry.keys()):
@@ -217,6 +268,31 @@ def process_tool_filter(
         # Add search_relevance as a built-in category (not enabled by default)
         category_to_tools['search_relevance'] = search_relevance_display_names
 
+        # Initialize agentic_memory tool names
+        agentic_memory_tools = [
+            'CreateAgenticMemorySessionTool',
+            'AddAgenticMemoriesTool',
+            'GetAgenticMemoryTool',
+            'UpdateAgenticMemoryTool',
+            'DeleteAgenticMemoryByIDTool',
+            'DeleteAgenticMemoryByQueryTool',
+            'SearchAgenticMemoryTool',
+        ]
+
+        # Build agentic_memory tools list using display names
+        agentic_memory_display_names = []
+        for tool_name in agentic_memory_tools:
+            if tool_name in tool_registry:
+                tool_display_name = tool_registry[tool_name].get('display_name', tool_name)
+                agentic_memory_display_names.append(tool_display_name)
+
+        # Add agentic_memory as a built-in category (not enabled by default)
+        category_to_tools['agentic_memory'] = agentic_memory_display_names
+
+        # Auto-enable agentic_memory category when memory_container_id is configured
+        if os.getenv('OPENSEARCH_MEMORY_CONTAINER_ID', ''):
+            enabled_category_list.append('agentic_memory')
+
         # Process YAML config file if provided
         config = load_yaml_config(filter_path)
         if config:
@@ -236,6 +312,12 @@ def process_tool_filter(
             settings = tool_filters.get('settings', {})
             if settings:
                 allow_write = settings.get('allow_write', True)
+
+            # Auto-enable agentic_memory from YAML config
+            agentic_memory = config.get('agentic_memory', {})
+            if isinstance(agentic_memory, dict) and agentic_memory.get('memory_container_id'):
+                if 'agentic_memory' not in enabled_category_list:
+                    enabled_category_list.append('agentic_memory')
 
         # Process environment variables
         if tool_categories:
@@ -347,6 +429,12 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
     # This needs to be done in both single and multi mode
     resolved_allow_write = _resolve_allow_write_setting(config_file_path)
     set_allow_write_setting(resolved_allow_write)
+
+    # Set memory_container_id Pydantic default on agentic memory tools if configured.
+    # This allows Pydantic to auto-fill the field when clients omit it.
+    memory_container_id = _resolve_memory_container_id(config_file_path)
+    if memory_container_id:
+        _set_memory_container_default(tool_registry, memory_container_id)
 
     # In multi mode, return all tools without any filtering
     if mode == 'multi':

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -289,10 +289,6 @@ def process_tool_filter(
         # Add agentic_memory as a built-in category (not enabled by default)
         category_to_tools['agentic_memory'] = agentic_memory_display_names
 
-        # Auto-enable agentic_memory category when memory_container_id is configured
-        if os.getenv('OPENSEARCH_MEMORY_CONTAINER_ID', ''):
-            enabled_category_list.append('agentic_memory')
-
         # Process YAML config file if provided
         config = load_yaml_config(filter_path)
         if config:
@@ -312,12 +308,6 @@ def process_tool_filter(
             settings = tool_filters.get('settings', {})
             if settings:
                 allow_write = settings.get('allow_write', True)
-
-            # Auto-enable agentic_memory from YAML config
-            agentic_memory = config.get('agentic_memory', {})
-            if isinstance(agentic_memory, dict) and agentic_memory.get('memory_container_id'):
-                if 'agentic_memory' not in enabled_category_list:
-                    enabled_category_list.append('agentic_memory')
 
         # Process environment variables
         if tool_categories:

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -80,6 +80,7 @@ from opensearch.helper import (
     search_experiments,
 )
 from .skills_tools import SKILLS_TOOLS_REGISTRY
+from .agentic_memory import AGENTIC_MEMORY_TOOLS_REGISTRY
 from mcp_server_opensearch.clusters_information import cluster_registry
 
 
@@ -900,6 +901,7 @@ from .generic_api_tool import GenericOpenSearchApiArgs, generic_opensearch_api_t
 # Registry of available OpenSearch tools with their metadata
 TOOL_REGISTRY = {
     **SKILLS_TOOLS_REGISTRY,
+    **AGENTIC_MEMORY_TOOLS_REGISTRY,
     'ListIndexTool': {
         'display_name': 'ListIndexTool',
         'description': 'Lists indices in the OpenSearch cluster. If an index name or pattern is specified, return only information about the provided index or index pattern. The include_detail flag controls output: if False, returns only index name(s); if True (default), returns full metadata.',


### PR DESCRIPTION
## Summary

Reference implementation of 7 agentic memory tools following existing codebase patterns.
This branch demonstrates how the tools from #138 can be structured to align with the
repo's tool anatomy and conventions.

### Key design choices
- **Self-contained `agentic_memory/` module** — follows `skills_tools.py` spread pattern (`**AGENTIC_MEMORY_TOOLS_REGISTRY`)
- **`log_tool_error()`** for all error handling — preserves `is_error: True` for metrics
- **Helpers are dumb pipes** — no try/except, exceptions propagate to tool functions
- **`agentic_memory` category in `tool_filter.py`** — auto-enables from env var or YAML config
- **`_set_memory_container_default()`** — sets Pydantic field default once at startup, no `validate_args_for_mode()` changes

### Diff on existing files
- `tools.py` — **+2 lines** (import + registry spread)
- `tool_filter.py` — **+88 lines** (category + default injection)
- `tool_params.py` — **0 lines changed**
- `helper.py` — **0 lines changed**

## Test plan
- [x] All 337 existing tests pass
- [ ] Manual verification with MCP client (tools listed, defaults applied)