### PR TITLE
fix: treat size=0 as valid in search_index, not as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Switch CI from `pull_request` to `pull_request_target` so integration tests run on fork PRs ([#219](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/219))
 
+- Fix `SearchIndexTool` ignoring `size=0`, causing aggregation-only queries to always return 10 hits ([#217](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/217))
+
 ### Removed
 
 ## [Released 0.9.0]

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -65,7 +65,7 @@ async def search_index(args: SearchIndexArgs) -> json:
         tool_info = TOOL_REGISTRY.get('SearchIndexTool', {})
         max_size_limit = tool_info.get('max_size_limit', 100)  # Default to 100 if not configured
 
-        effective_size = min(args.size, max_size_limit) if args.size else 10
+        effective_size = min(args.size, max_size_limit) if args.size is not None else 10
         query['size'] = effective_size
 
         response = await client.search(index=args.index, body=query)

--- a/tests/opensearch/test_helper.py
+++ b/tests/opensearch/test_helper.py
@@ -124,6 +124,45 @@ class TestOpenSearchHelper:
 
     @pytest.mark.asyncio
     @patch('opensearch.client.get_opensearch_client')
+    async def test_search_index_size_zero(self, mock_get_client):
+        """Test that size=0 is respected for aggregation-only queries.
+
+        size=0 is falsy in Python, so `if args.size else 10` would incorrectly
+        fall back to 10. The fix uses `if args.size is not None else 10`.
+        """
+        mock_response = {
+            'hits': {'total': {'value': 100}, 'hits': []},
+            'aggregations': {'by_status': {'buckets': [{'key': 'opened', 'doc_count': 80}]}},
+        }
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        test_query = {
+            'size': 0,
+            'query': {'match_all': {}},
+            'aggs': {'by_status': {'terms': {'field': 'status.keyword'}}},
+        }
+
+        result = await self.search_index(
+            SearchIndexArgs(
+                index='test-index', query_dsl=test_query, size=0, opensearch_cluster_name=''
+            )
+        )
+
+        assert result == mock_response
+        # size=0 must be passed through, not replaced with the default of 10
+        expected_body = {
+            'size': 0,
+            'query': {'match_all': {}},
+            'aggs': {'by_status': {'terms': {'field': 'status.keyword'}}},
+        }
+        mock_client.search.assert_called_once_with(index='test-index', body=expected_body)
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
     async def test_get_shards(self, mock_get_client):
         """Test get_shards function."""
         # Setup mock response


### PR DESCRIPTION
## Summary

Fixes #216.

`if args.size else 10` evaluates `0` as falsy in Python, so passing `size=0` to `SearchIndexTool` always falls back to a default of 10 hits. The tool then overwrites any `"size": 0` in the DSL body, making aggregation-only queries impossible — they always return 10 full document hits alongside (or instead of) the aggregation results.

**One-line fix** in `src/opensearch/helper.py`:

```python
# Before
effective_size = min(args.size, max_size_limit) if args.size else 10

# After
effective_size = min(args.size, max_size_limit) if args.size is not None else 10
```

## Changes

- `src/opensearch/helper.py`: fix falsy check for `size=0`
- `tests/opensearch/test_helper.py`: add `test_search_index_size_zero` to assert that `size=0` is passed through to OpenSearch unchanged

## Test plan

- [x] Existing `test_search_index` still passes (default size=10 behaviour unchanged)
- [x] New `test_search_index_size_zero` passes (size=0 is respected)