### PR TITLE
Fix multi-mode IT failing for ListClustersTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Switch CI from `pull_request` to `pull_request_target` so integration tests run on fork PRs ([#219](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/219))
+- Fix multi-mode IT failing for `ListClustersTool` which has no `opensearch_cluster_name` parameter ([#220](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/220))
 
 - Fix `SearchIndexTool` ignoring `size=0`, causing aggregation-only queries to always return 10 hits ([#217](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/217))
 

--- a/integration_tests/server_modes/test_multi_mode.py
+++ b/integration_tests/server_modes/test_multi_mode.py
@@ -92,6 +92,8 @@ class TestMultiMode:
         async with mcp_client(multi_mode_setup.url) as session:
             tools = await session.list_tools()
             for tool in tools.tools:
+                if tool.name == 'ListClustersTool':
+                    continue
                 props = tool.inputSchema.get('properties', {})
                 assert 'opensearch_cluster_name' in props, (
                     f'Tool {tool.name} should expose opensearch_cluster_name in multi mode'


### PR DESCRIPTION
## Summary

- Skip `ListClustersTool` in `test_tools_include_cluster_name_param` since it is a meta-tool that lists available clusters and does not take an `opensearch_cluster_name` parameter
- This was introduced when `ListClustersTool` (#210) was merged after the multi-mode IT (#179) without updating the test

## Test plan

- [ ] CI passes with 0 failures (previously 1 failed due to this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)