### PR TITLE
Add configurable server-side query timeout via OPENSEARCH_QUERY_TIMEOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Add configurable server-side query timeout via `OPENSEARCH_QUERY_TIMEOUT` environment variable, passed as `cancel_after_time_interval` to OpenSearch search requests ([#228](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/228))
 - Add `User-Agent` header (`opensearch-mcp-server-py/<version>`) to all OpenSearch requests for MCP traffic identification in cluster logs ([#207](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/207))
 - Add `AGENTS.md` and rewrite `DEVELOPER_GUIDE.md` "Adding Custom Tools" section with detailed 4-piece tool anatomy, error handling contracts, and tool category documentation ([#214](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/214))
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -497,6 +497,7 @@ If the port is omitted, this server inserts the usual HTTP(S) default so traffic
 | `OPENSEARCH_NO_AUTH` | No | `''` | Set to `"true"` to connect without authentication |
 | `OPENSEARCH_HEADER_AUTH` | No | `''` | Set to `"true"` to enable header-based authentication (headers take priority over env vars) |
 | `OPENSEARCH_TIMEOUT` | No | `''` | Connection timeout in seconds for OpenSearch operations |
+| `OPENSEARCH_QUERY_TIMEOUT` | No | `''` | Server-side query timeout passed as `cancel_after_time_interval` to search requests (e.g., `"10s"`). Cancels long-running queries after the specified duration. |
 
 ### SSL & Security Variables
 

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -6,8 +6,8 @@ import logging
 import csv
 import io
 import math
+import os
 from decimal import Decimal
-import json
 from semver import Version
 from tools.tool_params import *
 
@@ -68,7 +68,13 @@ async def search_index(args: SearchIndexArgs) -> json:
         effective_size = min(args.size, max_size_limit) if args.size is not None else 10
         query['size'] = effective_size
 
-        response = await client.search(index=args.index, body=query)
+        search_params = {'index': args.index, 'body': query}
+
+        query_timeout = os.getenv('OPENSEARCH_QUERY_TIMEOUT', '').strip() or None
+        if query_timeout:
+            search_params['cancel_after_time_interval'] = query_timeout
+
+        response = await client.search(**search_params)
         return response
 
 

--- a/tests/opensearch/test_helper.py
+++ b/tests/opensearch/test_helper.py
@@ -163,6 +163,66 @@ class TestOpenSearchHelper:
 
     @pytest.mark.asyncio
     @patch('opensearch.client.get_opensearch_client')
+    @patch.dict('os.environ', {'OPENSEARCH_QUERY_TIMEOUT': '10s'})
+    async def test_search_index_with_query_timeout(self, mock_get_client):
+        """Test that OPENSEARCH_QUERY_TIMEOUT is passed as cancel_after_time_interval."""
+        mock_response = {
+            'hits': {
+                'total': {'value': 1},
+                'hits': [{'_index': 'test-index', '_id': '1', '_source': {'field': 'value'}}],
+            }
+        }
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        test_query = {'query': {'match_all': {}}}
+
+        result = await self.search_index(
+            SearchIndexArgs(index='test-index', query_dsl=test_query, opensearch_cluster_name='')
+        )
+
+        assert result == mock_response
+        expected_body = {'query': {'match_all': {}}, 'size': 10}
+        mock_client.search.assert_called_once_with(
+            index='test-index', body=expected_body, cancel_after_time_interval='10s'
+        )
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
+    @patch.dict('os.environ', {}, clear=False)
+    async def test_search_index_without_query_timeout(self, mock_get_client):
+        """Test that cancel_after_time_interval is omitted when OPENSEARCH_QUERY_TIMEOUT is not set."""
+        mock_response = {
+            'hits': {
+                'total': {'value': 1},
+                'hits': [{'_index': 'test-index', '_id': '1', '_source': {'field': 'value'}}],
+            }
+        }
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        test_query = {'query': {'match_all': {}}}
+
+        # Ensure env var is not set
+        import os
+        os.environ.pop('OPENSEARCH_QUERY_TIMEOUT', None)
+
+        result = await self.search_index(
+            SearchIndexArgs(index='test-index', query_dsl=test_query, opensearch_cluster_name='')
+        )
+
+        assert result == mock_response
+        expected_body = {'query': {'match_all': {}}, 'size': 10}
+        mock_client.search.assert_called_once_with(index='test-index', body=expected_body)
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
     async def test_get_shards(self, mock_get_client):
         """Test get_shards function."""
         # Setup mock response


### PR DESCRIPTION
Read the OPENSEARCH_QUERY_TIMEOUT environment variable and pass it as cancel_after_time_interval to OpenSearch search requests. This allows operators to set a server-side timeout that cancels long-running queries after the specified duration (e.g., '10s'), preventing resource exhaustion from expensive AI-generated queries.

Resolves #228

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).