### PR TITLE
Add requires_ml_tool marker to skip skills tests on unsupported clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings
 
 ### Fixed
+- Add `requires_version` pytest marker to skip skills integration tests (DataDistributionTool, LogPatternAnalysisTool) on clusters below OpenSearch 3.3.0
 - Switch CI from `pull_request` to `pull_request_target` so integration tests run on fork PRs ([#219](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/219))
 - Fix multi-mode IT failing for `ListClustersTool` which has no `opensearch_cluster_name` parameter ([#220](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/220))
 - Fix non-ASCII characters (e.g. Chinese, Japanese, accented characters) being escaped to Unicode sequences in all tool JSON responses ([#164](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/164))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings
 
 ### Fixed
-- Add `requires_version` pytest marker to skip skills integration tests (DataDistributionTool, LogPatternAnalysisTool) on clusters below OpenSearch 3.3.0
+- Add `requires_ml_tool` pytest marker to skip skills integration tests when ML tools are not registered on the cluster
 - Switch CI from `pull_request` to `pull_request_target` so integration tests run on fork PRs ([#219](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/219))
 - Fix multi-mode IT failing for `ListClustersTool` which has no `opensearch_cluster_name` parameter ([#220](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/220))
 - Fix non-ASCII characters (e.g. Chinese, Japanese, accented characters) being escaped to Unicode sequences in all tool JSON responses ([#164](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/164))

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pytest
 import pytest_asyncio
-from packaging.version import Version
 from integration_tests.framework.aws_helpers import (
     AWSProfileManager,
     build_header_auth_headers,
@@ -132,31 +131,50 @@ async def seed_test_index():
 
 
 # ---------------------------------------------------------------------------
-# Cluster version detection & requires_version marker
+# ML tool availability detection & requires_ml_tool marker
 # ---------------------------------------------------------------------------
+
+_ml_tool_availability_cache: dict = {}
 
 
 @pytest.fixture(scope='session')
-def cluster_version():
-    """Detect the OpenSearch cluster version (session-scoped, runs once)."""
+def ml_tool_availability():
+    """Probe cluster to detect which ML tools are registered (session-scoped)."""
+    if _ml_tool_availability_cache:
+        return _ml_tool_availability_cache
+
     client = _create_os_client()
     try:
-        info = client.info()
-        version_str = info['version']['number']
-        return Version(version_str)
+        for tool_name in ('DataDistributionTool', 'LogPatternAnalysisTool'):
+            try:
+                client.transport.perform_request(
+                    'POST',
+                    f'/_plugins/_ml/tools/_execute/{tool_name}',
+                    body={'parameters': {}},
+                )
+                _ml_tool_availability_cache[tool_name] = True
+            except Exception as e:
+                error_str = str(e)
+                if 'Tool not found' in error_str:
+                    _ml_tool_availability_cache[tool_name] = False
+                else:
+                    # Tool exists but request failed for other reasons (e.g. bad params)
+                    _ml_tool_availability_cache[tool_name] = True
     finally:
         client.close()
 
+    return _ml_tool_availability_cache
+
 
 @pytest.fixture(autouse=True)
-def _check_requires_version(request, cluster_version):
-    """Skip tests marked with @pytest.mark.requires_version if cluster is too old."""
-    marker = request.node.get_closest_marker('requires_version')
+def _check_requires_ml_tool(request, ml_tool_availability):
+    """Skip tests marked with @pytest.mark.requires_ml_tool if tool is not available."""
+    marker = request.node.get_closest_marker('requires_ml_tool')
     if marker is None:
         return
-    required = Version(marker.args[0])
-    if cluster_version < required:
-        pytest.skip(f'Requires OpenSearch {required}+, cluster is {cluster_version}')
+    tool_name = marker.args[0]
+    if not ml_tool_availability.get(tool_name, False):
+        pytest.skip(f'ML tool {tool_name} not registered on this cluster')
 
 
 # ---------------------------------------------------------------------------

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pytest
 import pytest_asyncio
+from packaging.version import Version
 from integration_tests.framework.aws_helpers import (
     AWSProfileManager,
     build_header_auth_headers,
@@ -128,6 +129,34 @@ async def seed_test_index():
         logger.info(f'Deleted test index: {TEST_INDEX}')
     except Exception as e:
         logger.warning(f'Failed to delete test index {TEST_INDEX}: {e}')
+
+
+# ---------------------------------------------------------------------------
+# Cluster version detection & requires_version marker
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='session')
+def cluster_version():
+    """Detect the OpenSearch cluster version (session-scoped, runs once)."""
+    client = _create_os_client()
+    try:
+        info = client.info()
+        version_str = info['version']['number']
+        return Version(version_str)
+    finally:
+        client.close()
+
+
+@pytest.fixture(autouse=True)
+def _check_requires_version(request, cluster_version):
+    """Skip tests marked with @pytest.mark.requires_version if cluster is too old."""
+    marker = request.node.get_closest_marker('requires_version')
+    if marker is None:
+        return
+    required = Version(marker.args[0])
+    if cluster_version < required:
+        pytest.skip(f'Requires OpenSearch {required}+, cluster is {cluster_version}')
 
 
 # ---------------------------------------------------------------------------

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -154,8 +154,8 @@ def ml_tool_availability():
                 )
                 _ml_tool_availability_cache[tool_name] = True
             except Exception as e:
-                error_str = str(e)
-                if 'Tool not found' in error_str:
+                error_repr = repr(e)
+                if 'Tool not found' in error_repr or 'Tool not found' in str(getattr(e, 'info', '')):
                     _ml_tool_availability_cache[tool_name] = False
                 else:
                     # Tool exists but request failed for other reasons (e.g. bad params)

--- a/integration_tests/tools/test_data_distribution_tool.py
+++ b/integration_tests/tools/test_data_distribution_tool.py
@@ -7,6 +7,7 @@ from integration_tests.framework.constants import TEST_INDEX
 
 
 @pytest.mark.tools
+@pytest.mark.requires_version('3.3.0')
 class TestDataDistributionTool:
     """Tests for DataDistributionTool (ML skills, requires OpenSearch 3.3+)."""
 

--- a/integration_tests/tools/test_data_distribution_tool.py
+++ b/integration_tests/tools/test_data_distribution_tool.py
@@ -7,7 +7,7 @@ from integration_tests.framework.constants import TEST_INDEX
 
 
 @pytest.mark.tools
-@pytest.mark.requires_version('3.3.0')
+@pytest.mark.requires_ml_tool('DataDistributionTool')
 class TestDataDistributionTool:
     """Tests for DataDistributionTool (ML skills, requires OpenSearch 3.3+)."""
 

--- a/integration_tests/tools/test_log_pattern_analysis_tool.py
+++ b/integration_tests/tools/test_log_pattern_analysis_tool.py
@@ -7,7 +7,7 @@ from integration_tests.framework.constants import TEST_INDEX
 
 
 @pytest.mark.tools
-@pytest.mark.requires_version('3.3.0')
+@pytest.mark.requires_ml_tool('LogPatternAnalysisTool')
 class TestLogPatternAnalysisTool:
     """Tests for LogPatternAnalysisTool (ML skills, requires OpenSearch 3.3+)."""
 

--- a/integration_tests/tools/test_log_pattern_analysis_tool.py
+++ b/integration_tests/tools/test_log_pattern_analysis_tool.py
@@ -7,6 +7,7 @@ from integration_tests.framework.constants import TEST_INDEX
 
 
 @pytest.mark.tools
+@pytest.mark.requires_version('3.3.0')
 class TestLogPatternAnalysisTool:
     """Tests for LogPatternAnalysisTool (ML skills, requires OpenSearch 3.3+)."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ markers = [
     "no_auth: Requires no-auth cluster access",
     "server_modes: Server mode tests (single and multi-cluster)",
     "dynamic_connection: Dynamic per-call connection parameter tests",
+    "requires_version: Skip test when cluster version is below the specified minimum (e.g. @pytest.mark.requires_version('3.3.0'))",
 ]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ markers = [
     "no_auth: Requires no-auth cluster access",
     "server_modes: Server mode tests (single and multi-cluster)",
     "dynamic_connection: Dynamic per-call connection parameter tests",
-    "requires_version: Skip test when cluster version is below the specified minimum (e.g. @pytest.mark.requires_version('3.3.0'))",
+    "requires_ml_tool: Skip test when the specified ML tool is not registered on the cluster",
 ]
 testpaths = ["tests"]
 asyncio_mode = "auto"


### PR DESCRIPTION
### Description

DataDistributionTool and LogPatternAnalysisTool may not be registered on AOS clusters even at version 3.3+. Instead of checking version, this PR adds a `requires_ml_tool` pytest marker that probes the `/_plugins/_ml/tools/_execute/{tool_name}` endpoint at session startup and skips tests when the tool returns "Tool not found".

This is more robust than version-based skipping since tool availability depends on cluster configuration, not just version.

### Issues Resolved

Fixes integration test failures for skills tools on clusters where ML tools are not registered.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented in the CHANGELOG
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).