### PR TITLE
Fix ruff linting issues and add code quality CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,36 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    if: github.repository == 'opensearch-project/opensearch-mcp-server-py'
+    name: Code Quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv sync
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Check code quality
+        run: uv run ruff check .
+
   test:
     if: github.repository == 'opensearch-project/opensearch-mcp-server-py'
     name: Test on ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings
 
+### Infrastructure
+- Add code quality CI job running `ruff format --check` and `ruff check` on every PR ([#241](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/241))
+- Fix all ruff linting issues: replace star imports with explicit imports, add missing docstrings, fix docstring formatting ([#241](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/241))
+
 ### Fixed
 - Fix SigV4 auth callable invoked with wrong positional arguments in `BufferedAsyncHttpConnection`, causing 403 signature mismatch on every GET request with query parameters and silent fallback on every POST/PUT/DELETE ([#237](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/237))
 - Add `requires_ml_tool` pytest marker to skip skills integration tests when ML tools are not registered on the cluster

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -406,4 +406,13 @@ uv run ruff check .
 uv run mypy src/
 ```
 
+#### Pre-commit Hooks
+
+Install [pre-commit](https://pre-commit.com/) to automatically run ruff format and lint on staged files before each commit:
+
+```bash
+uv tool install pre-commit
+pre-commit install
+```
+
 > **Note**: Make sure to run tests and code quality checks before submitting your changes.

--- a/integration_tests/concurrency/conftest.py
+++ b/integration_tests/concurrency/conftest.py
@@ -1,8 +1,8 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import time
 import pytest_asyncio
+import time
 from integration_tests.framework.assertions import assert_tool_success
 from integration_tests.framework.aws_helpers import build_header_auth_headers
 from integration_tests.framework.client import mcp_client

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -155,7 +155,9 @@ def ml_tool_availability():
                 _ml_tool_availability_cache[tool_name] = True
             except Exception as e:
                 error_repr = repr(e)
-                if 'Tool not found' in error_repr or 'Tool not found' in str(getattr(e, 'info', '')):
+                if 'Tool not found' in error_repr or 'Tool not found' in str(
+                    getattr(e, 'info', '')
+                ):
                     _ml_tool_availability_cache[tool_name] = False
                 else:
                     # Tool exists but request failed for other reasons (e.g. bad params)

--- a/integration_tests/framework/constants.py
+++ b/integration_tests/framework/constants.py
@@ -3,4 +3,5 @@
 
 import os
 
+
 TEST_INDEX = os.environ.get('IT_TEST_INDEX', 'mcp-integration-test')

--- a/integration_tests/framework/server.py
+++ b/integration_tests/framework/server.py
@@ -104,9 +104,7 @@ class MCPServerProcess:
         while asyncio.get_event_loop().time() < deadline:
             # Check if process died
             if self._process and self._process.poll() is not None:
-                raise RuntimeError(
-                    f'MCP server exited with code {self._process.returncode}'
-                )
+                raise RuntimeError(f'MCP server exited with code {self._process.returncode}')
 
             try:
                 async with aiohttp.ClientSession() as session:

--- a/integration_tests/tools/test_dynamic_connection.py
+++ b/integration_tests/tools/test_dynamic_connection.py
@@ -84,9 +84,7 @@ async def wrong_url_server(seed_test_index):
     No auth is configured on the server — auth comes entirely from the
     inline call params, which also proves per-call auth overrides work.
     """
-    server = MCPServerProcess(
-        env={'OPENSEARCH_URL': 'http://does-not-exist.invalid:9200'}
-    )
+    server = MCPServerProcess(env={'OPENSEARCH_URL': 'http://does-not-exist.invalid:9200'})
     await server.start()
     yield server
     await server.stop()
@@ -179,6 +177,5 @@ class TestPreconfiguredMode:
             for tool in tools.tools:
                 props = tool.inputSchema.get('properties', {})
                 assert 'opensearch_cluster_name' not in props, (
-                    f'Tool {tool.name!r} should not expose opensearch_cluster_name '
-                    f'in single mode'
+                    f'Tool {tool.name!r} should not expose opensearch_cluster_name in single mode'
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ no-sections = true
 [tool.ruff.lint.per-file-ignores]
 "**/*.ipynb" = ["F704"]
 "integration_tests/**" = ["D101", "D102", "D103", "D107"]
-"tests/**" = ["D101", "D102", "D103", "D107"]
+"tests/**" = ["D101", "D102", "D103", "D105", "D107"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ no-sections = true
 [tool.ruff.lint.per-file-ignores]
 "**/*.ipynb" = ["F704"]
 "integration_tests/**" = ["D101", "D102", "D103", "D107"]
+"tests/**" = ["D101", "D102", "D103", "D107"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/mcp_server_opensearch/__main__.py
+++ b/src/mcp_server_opensearch/__main__.py
@@ -3,4 +3,5 @@
 
 from . import main
 
+
 main()

--- a/src/mcp_server_opensearch/global_state.py
+++ b/src/mcp_server_opensearch/global_state.py
@@ -1,8 +1,7 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Global state management for the OpenSearch MCP Server.
+"""Global state management for the OpenSearch MCP Server.
 
 This module provides a centralized way to store and access the current server mode,
 profile, and config file path that need to be available throughout the application.
@@ -10,6 +9,7 @@ profile, and config file path that need to be available throughout the applicati
 
 import logging
 from typing import Optional
+
 
 # Global variables
 _current_mode: Optional[str] = None

--- a/src/mcp_server_opensearch/install_hooks.py
+++ b/src/mcp_server_opensearch/install_hooks.py
@@ -19,6 +19,7 @@ Usage:
     opensearch-mcp-server-py install-hooks --client kiro --scope user
 """
 
+import base64 as _base64
 import json
 import logging
 from pathlib import Path
@@ -102,16 +103,16 @@ CLAUDE_CODE_SEARCH_COMMAND = f"echo '{SEARCH_PROMPT}'"
 # Stop hook script: reads stop_hook_active from stdin, only blocks on first stop.
 # Uses python3 -c to parse stdin JSON — no external dependencies needed.
 # The payload is base64-encoded to avoid quoting issues with the JSON content.
-import base64 as _base64
+
 _stop_payload = json.dumps({'decision': 'block', 'reason': SAVE_PROMPT})
 _stop_payload_b64 = _base64.b64encode(_stop_payload.encode()).decode()
 CLAUDE_CODE_STOP_COMMAND = (
-    f"python3 -c \""
-    f"import json,sys,base64; "
-    f"data=json.load(sys.stdin); "
+    f'python3 -c "'
+    f'import json,sys,base64; '
+    f'data=json.load(sys.stdin); '
     f"sys.stdout.write('' if data.get('stop_hook_active') "
     f"else base64.b64decode('{_stop_payload_b64}').decode())"
-    f"\""
+    f'"'
 )
 
 # Claude Code settings.json hook map (nested map keyed by event name).
@@ -254,6 +255,7 @@ def _claude_hooks_already_installed(hooks_map: dict) -> bool:
                     try:
                         import base64
                         import re
+
                         match = re.search(r"b64decode\('([A-Za-z0-9+/=]+)'\)", command)
                         if match:
                             decoded = base64.b64decode(match.group(1)).decode()
@@ -328,6 +330,7 @@ def _cursor_hooks_already_installed(hooks_config: dict) -> bool:
                 try:
                     import base64
                     import re
+
                     match = re.search(r"b64decode\('([A-Za-z0-9+/=]+)'\)", command)
                     if match:
                         decoded = base64.b64decode(match.group(1)).decode()

--- a/src/mcp_server_opensearch/installer.py
+++ b/src/mcp_server_opensearch/installer.py
@@ -64,8 +64,11 @@ def _detect_ides() -> list[str]:
 
 
 def _build_mcp_server_config(
-    opensearch_url: str, aws_region: str, aws_profile: str,
-    from_git: str = '', from_local: str = ''
+    opensearch_url: str,
+    aws_region: str,
+    aws_profile: str,
+    from_git: str = '',
+    from_local: str = '',
 ) -> dict:
     """Build the MCP server configuration block.
 
@@ -330,7 +333,9 @@ def run_install(from_git: str = '', from_local: str = '') -> None:
     print('Step 3: Configuration')
     print('-' * 30)
 
-    mcp_config = _build_mcp_server_config(opensearch_url, aws_region, aws_profile, from_git, from_local)
+    mcp_config = _build_mcp_server_config(
+        opensearch_url, aws_region, aws_profile, from_git, from_local
+    )
     actions = []
 
     for ide_id in detected:
@@ -349,8 +354,13 @@ def run_install(from_git: str = '', from_local: str = '') -> None:
             actions.append(_configure_cursor_mcp(mcp_config))
             # Install Cursor hooks for memory search/save
             from .install_hooks import _install_cursor_hooks
+
             cursor_hook_actions = _install_cursor_hooks('user')
-            actions.extend(cursor_hook_actions if cursor_hook_actions else ['  Cursor hooks already installed.'])
+            actions.extend(
+                cursor_hook_actions
+                if cursor_hook_actions
+                else ['  Cursor hooks already installed.']
+            )
 
     print()
     print('Done!')

--- a/src/mcp_server_opensearch/logging_config.py
+++ b/src/mcp_server_opensearch/logging_config.py
@@ -1,8 +1,7 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Structured logging configuration for metric extraction.
+"""Structured logging configuration for metric extraction.
 
 Provides a JSON formatter that outputs one JSON object per log line, making
 log events directly targetable by metric filters. Extra fields passed via
@@ -33,6 +32,7 @@ class JsonFormatter(logging.Formatter):
     """
 
     def format(self, record: logging.LogRecord) -> str:
+        """Format a log record as a JSON string."""
         log_entry = {
             'timestamp': datetime.fromtimestamp(record.created, tz=timezone.utc).strftime(
                 '%Y-%m-%dT%H:%M:%S.%f'

--- a/src/mcp_server_opensearch/stdio_server.py
+++ b/src/mcp_server_opensearch/stdio_server.py
@@ -22,6 +22,7 @@ async def serve(
     config_file_path: str = '',
     cli_tool_overrides: dict | None = None,
 ) -> None:
+    """Start the MCP server in stdio mode."""
     # Set the global mode
     set_mode(mode)
 

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -30,6 +30,7 @@ async def create_mcp_server(
     config_file_path: str = '',
     cli_tool_overrides: dict | None = None,
 ) -> Server:
+    """Create and configure the MCP server instance."""
     # Set the global mode
     set_mode(mode)
 
@@ -82,7 +83,10 @@ async def create_mcp_server(
 
 
 class MCPStarletteApp:
+    """Starlette application wrapper for the MCP server."""
+
     def __init__(self, mcp_server: Server, stateless: bool = True):
+        """Initialize the MCP Starlette application."""
         self.mcp_server = mcp_server
         self.sse = SseServerTransport('/messages/')
         self.session_manager = StreamableHTTPSessionManager(
@@ -93,6 +97,7 @@ class MCPStarletteApp:
         )
 
     async def handle_sse(self, request: Request) -> Response:
+        """Handle SSE connection requests."""
         async with self.sse.connect_sse(
             request.scope,
             request.receive,
@@ -108,12 +113,13 @@ class MCPStarletteApp:
         return Response()
 
     async def handle_health(self, request: Request) -> Response:
+        """Handle health check requests."""
         return Response('OK', status_code=200)
 
     @contextlib.asynccontextmanager
     async def lifespan(self, app: Starlette) -> AsyncIterator[None]:
-        """
-        Context manager for session manager lifecycle.
+        """Context manager for session manager lifecycle.
+
         Ensures proper startup and shutdown of the session manager.
         """
         from mcp_server_opensearch.logging_config import start_memory_monitor
@@ -136,6 +142,7 @@ class MCPStarletteApp:
         await self.session_manager.handle_request(scope, receive, send)
 
     def create_app(self) -> Starlette:
+        """Create the Starlette application with routes."""
         return Starlette(
             routes=[
                 Route('/sse', endpoint=self.handle_sse, methods=['GET']),
@@ -157,6 +164,7 @@ async def serve(
     cli_tool_overrides: dict | None = None,
     stateless: bool = True,
 ) -> None:
+    """Start the MCP server in streaming HTTP mode."""
     mcp_server = await create_mcp_server(mode, profile, config_file_path, cli_tool_overrides)
     app_handler = MCPStarletteApp(mcp_server, stateless=stateless)
     app = app_handler.create_app()

--- a/src/mcp_server_opensearch/tool_executor.py
+++ b/src/mcp_server_opensearch/tool_executor.py
@@ -1,8 +1,7 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Shared tool execution with structured logging for metrics.
+"""Shared tool execution with structured logging for metrics.
 
 Extracts the duplicated call_tool() logic from stdio_server.py and
 streaming_server.py into a single function that wraps tool invocation
@@ -18,8 +17,8 @@ tool invocation, enabling metric filters for:
 
 import logging
 import time
-
 from mcp.types import TextContent
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -397,9 +397,7 @@ def _initialize_client_multi_mode(cluster_info: ClusterInfo) -> AsyncOpenSearch:
         opensearch_client_cert_path = _normalize_path_value(
             cluster_info.opensearch_client_cert_path
         )
-        opensearch_client_key_path = _normalize_path_value(
-            cluster_info.opensearch_client_key_path
-        )
+        opensearch_client_key_path = _normalize_path_value(cluster_info.opensearch_client_key_path)
 
         # Get max response size from cluster config, fallback to environment variable
         max_response_size = cluster_info.max_response_size

--- a/src/opensearch/connection.py
+++ b/src/opensearch/connection.py
@@ -1,8 +1,7 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Custom OpenSearch connection classes with enhanced functionality.
+"""Custom OpenSearch connection classes with enhanced functionality.
 
 This module provides custom connection classes that extend the standard
 OpenSearch connection classes with additional features like response size limiting.
@@ -10,8 +9,8 @@ OpenSearch connection classes with additional features like response size limiti
 
 import logging
 import time
-
 from opensearchpy import AsyncHttpConnection
+
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -23,11 +22,13 @@ DEFAULT_MAX_RESPONSE_SIZE = None  # No limit by default - only enforce when expl
 # Base exception class (to avoid circular imports)
 class OpenSearchClientError(Exception):
     """Base exception for OpenSearch client errors."""
+
     pass
 
 
 class ResponseSizeExceededError(OpenSearchClientError):
     """Exception raised when response size exceeds the configured limit."""
+
     pass
 
 
@@ -68,8 +69,7 @@ def _log_request_event(
 
 
 class BufferedAsyncHttpConnection(AsyncHttpConnection):
-    """
-    Async HTTP connection that buffers responses with size limiting.
+    """Async HTTP connection that buffers responses with size limiting.
 
     This connection class prevents large responses from being loaded into memory
     by streaming the response and checking size limits during processing. If the
@@ -78,12 +78,12 @@ class BufferedAsyncHttpConnection(AsyncHttpConnection):
     """
 
     def __init__(self, *args, max_response_size=DEFAULT_MAX_RESPONSE_SIZE, **kwargs):
-        """
-        Initialize buffered connection with response size limit.
+        """Initialize buffered connection with response size limit.
 
         Args:
-            max_response_size: Maximum allowed response size in bytes (default: None - no limit)
-            *args, **kwargs: Arguments passed to parent AsyncHttpConnection
+            *args: Arguments passed to parent AsyncHttpConnection.
+            max_response_size: Maximum allowed response size in bytes (default: None - no limit).
+            **kwargs: Keyword arguments passed to parent AsyncHttpConnection.
         """
         super().__init__(*args, **kwargs)
         self.max_response_size = max_response_size
@@ -97,8 +97,7 @@ class BufferedAsyncHttpConnection(AsyncHttpConnection):
     async def perform_request(
         self, method, url, params=None, body=None, timeout=None, ignore=(), headers=None
     ):
-        """
-        Perform HTTP request with response size limiting.
+        """Perform HTTP request with response size limiting.
 
         This implementation leverages the parent class for authentication and session management
         but implements streaming response size checking to prevent memory exhaustion from large responses.
@@ -125,8 +124,8 @@ class BufferedAsyncHttpConnection(AsyncHttpConnection):
         try:
             # Import required modules
             import aiohttp
-            from urllib.parse import urlencode
             import yarl
+            from urllib.parse import urlencode
 
             # Ensure session is created (from parent class)
             if self.session is None:
@@ -278,8 +277,7 @@ class BufferedAsyncHttpConnection(AsyncHttpConnection):
     async def _fallback_perform_request(
         self, method, url, params=None, body=None, timeout=None, ignore=(), headers=None
     ):
-        """
-        Fallback to parent implementation with post-download size checking.
+        """Fallback to parent implementation with post-download size checking.
 
         This is used when streaming is not available or fails.
         """

--- a/src/opensearch/connection.py
+++ b/src/opensearch/connection.py
@@ -163,9 +163,7 @@ class BufferedAsyncHttpConnection(AsyncHttpConnection):
             if callable(self._http_auth):
                 req_headers = {
                     **req_headers,
-                    **self._http_auth(
-                        method=method, url=url, body=body, headers=req_headers
-                    ),
+                    **self._http_auth(method=method, url=url, body=body, headers=req_headers),
                 }
 
             start = self.loop.time()

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -1,15 +1,14 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-import logging
 import csv
 import io
+import json
+import logging
 import math
 import os
 from decimal import Decimal
 from semver import Version
-from tools.tool_params import *
 from tools.agentic_memory.params import (
     AddAgenticMemoriesArgs,
     CreateAgenticMemorySessionArgs,
@@ -19,6 +18,43 @@ from tools.agentic_memory.params import (
     SearchAgenticMemoryArgs,
     UpdateAgenticMemoryArgs,
 )
+from tools.tool_params import (
+    CatNodesArgs,
+    CreateExperimentArgs,
+    CreateJudgmentListArgs,
+    CreateLLMJudgmentListArgs,
+    CreateQuerySetArgs,
+    CreateSearchConfigurationArgs,
+    CreateUBIJudgmentListArgs,
+    DeleteExperimentArgs,
+    DeleteJudgmentListArgs,
+    DeleteQuerySetArgs,
+    DeleteSearchConfigurationArgs,
+    GetAllocationArgs,
+    GetClusterStateArgs,
+    GetExperimentArgs,
+    GetIndexInfoArgs,
+    GetIndexMappingArgs,
+    GetIndexStatsArgs,
+    GetJudgmentListArgs,
+    GetLongRunningTasksArgs,
+    GetNodesArgs,
+    GetNodesHotThreadsArgs,
+    GetQueryInsightsArgs,
+    GetQuerySetArgs,
+    GetSearchConfigurationArgs,
+    GetSegmentsArgs,
+    GetShardsArgs,
+    ListIndicesArgs,
+    SampleQuerySetArgs,
+    SearchExperimentsArgs,
+    SearchIndexArgs,
+    SearchJudgmentsArgs,
+    SearchQuerySetsArgs,
+    SearchSearchConfigurationsArgs,
+    baseToolArgs,
+)
+from typing import Any, Dict
 from urllib.parse import quote
 
 
@@ -29,6 +65,7 @@ logger = logging.getLogger(__name__)
 # List all the helper functions, these functions perform a single rest call to opensearch
 # these functions will be used in tools folder to eventually write more complex tools
 async def list_indices(args: ListIndicesArgs) -> json:
+    """List indices matching the given pattern."""
     from .client import get_opensearch_client
 
     async with get_opensearch_client(args) as client:
@@ -55,6 +92,7 @@ async def get_index(args: ListIndicesArgs) -> json:
 
 
 async def get_index_mapping(args: GetIndexMappingArgs) -> json:
+    """Get the mapping for a specific index."""
     from .client import get_opensearch_client
 
     async with get_opensearch_client(args) as client:
@@ -63,6 +101,7 @@ async def get_index_mapping(args: GetIndexMappingArgs) -> json:
 
 
 async def search_index(args: SearchIndexArgs) -> json:
+    """Execute a search query against an index."""
     from .client import get_opensearch_client
     from tools.tools import TOOL_REGISTRY
 
@@ -90,6 +129,7 @@ async def search_index(args: SearchIndexArgs) -> json:
 
 
 async def get_shards(args: GetShardsArgs) -> json:
+    """Get shard information for an index."""
     from .client import get_opensearch_client
 
     async with get_opensearch_client(args) as client:
@@ -342,7 +382,6 @@ async def create_query_set(args: CreateQuerySetArgs) -> json:
         json: Result of the creation operation with query set ID
     """
     import json as _json
-
     from .client import get_opensearch_client
 
     queries = _json.loads(args.queries) if isinstance(args.queries, str) else args.queries
@@ -385,7 +424,8 @@ async def sample_query_set(args: SampleQuerySetArgs) -> json:
 
     body = {
         'name': args.name,
-        'description': args.description or f'Query set: {args.name} ({args.sampling}, size={args.query_set_size})',
+        'description': args.description
+        or f'Query set: {args.name} ({args.sampling}, size={args.query_set_size})',
         'sampling': args.sampling,
         'querySetSize': args.query_set_size,
     }
@@ -481,11 +521,16 @@ async def create_experiment(args: CreateExperimentArgs) -> json:
         else args.search_configuration_ids
     )
     if not isinstance(search_configuration_ids, list):
-        raise ValueError('search_configuration_ids must be a JSON array of configuration ID strings')
+        raise ValueError(
+            'search_configuration_ids must be a JSON array of configuration ID strings'
+        )
 
     if args.experiment_type == 'PAIRWISE_COMPARISON' and len(search_configuration_ids) != 2:
         raise ValueError('PAIRWISE_COMPARISON requires exactly 2 search configuration IDs')
-    if args.experiment_type in ('POINTWISE_EVALUATION', 'HYBRID_OPTIMIZER') and len(search_configuration_ids) != 1:
+    if (
+        args.experiment_type in ('POINTWISE_EVALUATION', 'HYBRID_OPTIMIZER')
+        and len(search_configuration_ids) != 1
+    ):
         raise ValueError(f'{args.experiment_type} requires exactly 1 search configuration ID')
 
     body: dict = {
@@ -508,7 +553,9 @@ async def create_experiment(args: CreateExperimentArgs) -> json:
             else args.judgment_list_ids
         )
         if not isinstance(judgment_list_ids, list) or len(judgment_list_ids) == 0:
-            raise ValueError('judgment_list_ids must be a non-empty JSON array of judgment list ID strings')
+            raise ValueError(
+                'judgment_list_ids must be a non-empty JSON array of judgment list ID strings'
+            )
         body['judgmentList'] = judgment_list_ids
 
     async with get_opensearch_client(args) as client:
@@ -592,7 +639,7 @@ def convert_search_results_to_csv(search_results: dict) -> str:
         str: CSV formatted string of the search results
     """
     if not search_results:
-        return "No search results to convert"
+        return 'No search results to convert'
 
     has_hits = 'hits' in search_results and search_results['hits']['hits']
     has_aggregations = 'aggregations' in search_results
@@ -609,9 +656,9 @@ def convert_search_results_to_csv(search_results: dict) -> str:
     if has_hits and has_aggregations:
         hits_csv = _convert_hits_to_csv(search_results['hits']['hits'])
         aggregations_json = json.dumps(search_results['aggregations'], separators=(',', ':'))
-        return f"SEARCH HITS:\n{hits_csv}\n\nAGGREGATIONS:\n{aggregations_json}"
+        return f'SEARCH HITS:\n{hits_csv}\n\nAGGREGATIONS:\n{aggregations_json}'
 
-    return "No search results to convert"
+    return 'No search results to convert'
 
 
 def _convert_hits_to_csv(hits: list) -> str:
@@ -624,7 +671,7 @@ def _convert_hits_to_csv(hits: list) -> str:
         str: CSV formatted string
     """
     if not hits:
-        return "No documents found in search results"
+        return 'No documents found in search results'
 
     # Extract all unique field names from all documents (flattened)
     all_fields = set()
@@ -635,7 +682,7 @@ def _convert_hits_to_csv(hits: list) -> str:
         all_fields.update(['_index', '_id', '_score'])
 
     # Convert to sorted list for consistent column order
-    fieldnames = sorted(list(all_fields))
+    fieldnames = sorted(all_fields)
 
     # Create CSV in memory
     output = io.StringIO()
@@ -947,13 +994,13 @@ def plain_float(value):
         return None
 
     d = Decimal(str(value)).normalize()
-    s = format(d, "f")
-    if "." in s:
-        s = s.rstrip("0").rstrip(".")
-    if s == "" or s == "-":
-        s = "0"
+    s = format(d, 'f')
+    if '.' in s:
+        s = s.rstrip('0').rstrip('.')
+    if s == '' or s == '-':
+        s = '0'
 
-    if "." not in s:
+    if '.' not in s:
         return int(s)
     else:
         return float(s)
@@ -1147,7 +1194,9 @@ async def create_llm_judgment_list(args: CreateLLMJudgmentListArgs) -> json:
         else args.context_fields
     )
     if not isinstance(context_fields, list):
-        raise ValueError('context_fields must be a JSON array of field name strings, e.g. ["title", "description"]')
+        raise ValueError(
+            'context_fields must be a JSON array of field name strings, e.g. ["title", "description"]'
+        )
 
     body = {
         'name': args.name,
@@ -1199,7 +1248,7 @@ def validate_json_string(value: str) -> None:
         json.loads(value)
     except json.JSONDecodeError as e:
         raise ValueError(
-            f"query is not valid JSON: {e.msg} (line {e.lineno}, col {e.colno})"
+            f'query is not valid JSON: {e.msg} (line {e.lineno}, col {e.colno})'
         ) from e
 
 

--- a/src/tools/agentic_memory/actions.py
+++ b/src/tools/agentic_memory/actions.py
@@ -59,7 +59,9 @@ async def get_agentic_memory_tool(args: GetAgenticMemoryArgs) -> list[dict]:
         await check_tool_compatibility('GetAgenticMemoryTool', args)
         result = await get_agentic_memory(args)
         formatted = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Memory {args.id} ({args.memory_type.value}):\n{formatted}'}]
+        return [
+            {'type': 'text', 'text': f'Memory {args.id} ({args.memory_type.value}):\n{formatted}'}
+        ]
     except Exception as e:
         return log_tool_error('GetAgenticMemoryTool', e, 'retrieving memory')
 
@@ -115,7 +117,9 @@ async def search_agentic_memory_tool(args: SearchAgenticMemoryArgs) -> list[dict
         await check_tool_compatibility('SearchAgenticMemoryTool', args)
         result = await search_agentic_memory(args)
         formatted = json.dumps(result, separators=(',', ':'))
-        return [{'type': 'text', 'text': f'Search results ({args.memory_type.value}):\n{formatted}'}]
+        return [
+            {'type': 'text', 'text': f'Search results ({args.memory_type.value}):\n{formatted}'}
+        ]
     except Exception as e:
         return log_tool_error('SearchAgenticMemoryTool', e, 'searching memory')
 

--- a/src/tools/agentic_memory/params.py
+++ b/src/tools/agentic_memory/params.py
@@ -36,6 +36,7 @@ ERR_EMBEDDING_DIMENSION_REQUIRED = 'embedding_dimension_required'
 
 class MessageContentItem(BaseModel):
     """Schema for the content part of a message.
+
     Used for strong typing in 'messages' fields.
     """
 
@@ -47,6 +48,7 @@ class MessageContentItem(BaseModel):
 
 class MessageItem(BaseModel):
     """Schema for a single message in 'messages' field.
+
     Used for strong typing.
     """
 

--- a/src/tools/config.py
+++ b/src/tools/config.py
@@ -6,8 +6,9 @@ import logging
 import os
 import re
 import yaml
-from typing import Dict, Any
 from tools.tools import TOOL_REGISTRY as default_tool_registry
+from typing import Any, Dict
+
 
 # Constants for field names
 DISPLAY_NAME_STRING = 'display_name'
@@ -20,8 +21,7 @@ DISPLAY_NAME_PATTERN = r'^[a-zA-Z0-9_-]+$'
 
 
 def is_valid_display_name_pattern(name: str) -> bool:
-    """
-    Check if a display name follows the required pattern.
+    """Check if a display name follows the required pattern.
 
     :param name: The name to validate
     :return: True if valid, False otherwise
@@ -89,8 +89,7 @@ def _put_nested_dict(nested: dict, keys: list[str], value: Any) -> dict:
 
 
 def parse_cli_to_nested_config(cli_tool_overrides: Dict[str, str]) -> Dict[str, Dict[str, Any]]:
-    """
-    Parse generic CLI overrides of the form 'tool.<ToolName>.<path>=<value>' into a nested dict.
+    """Parse generic CLI overrides of the form 'tool.<ToolName>.<path>=<value>' into a nested dict.
 
     Examples:
     - tool.ListIndexTool.http_methods=POST
@@ -122,8 +121,7 @@ def parse_cli_to_nested_config(cli_tool_overrides: Dict[str, str]) -> Dict[str, 
 def _validate_config(
     config: Dict[str, Dict[str, Any]], reference_registry: Dict[str, Any]
 ) -> None:
-    """
-    Validate the configuration.
+    """Validate the configuration.
 
     Checks:
     1. All tool names exist in the default registry
@@ -194,8 +192,7 @@ def _validate_config(
 def _apply_validated_configs(
     custom_registry: Dict[str, Any], configs: Dict[str, Dict[str, Any]]
 ) -> None:
-    """
-    Apply validated configurations to the registry.
+    """Apply validated configurations to the registry.
 
     :param custom_registry: The registry to modify
     :param configs: Dictionary of tool names and their custom configurations
@@ -237,11 +234,8 @@ def _apply_validated_configs(
                 tool_info[field_name] = field_value
 
 
-def _apply_memory_container_defaults(
-    custom_registry: Dict[str, Any], container_id: str
-) -> None:
-    """
-    Set memory_container_id as a default in the input_schema of all agentic memory tools.
+def _apply_memory_container_defaults(custom_registry: Dict[str, Any], container_id: str) -> None:
+    """Set memory_container_id as a default in the input_schema of all agentic memory tools.
 
     This modifies the JSON schema so that:
     1. MCP clients see the default value (and the field is no longer required)
@@ -282,8 +276,7 @@ def apply_custom_tool_config(
     config_file_path: str,
     cli_tool_overrides: Dict[str, str],
 ) -> Dict[str, Any]:
-    """
-    Apply custom configurations to the tool registry from YAML file and command-line arguments.
+    """Apply custom configurations to the tool registry from YAML file and command-line arguments.
 
     Priority order:
     1. Config file settings (if config file is provided, CLI is completely ignored)
@@ -356,10 +349,14 @@ def get_memory_container_id_from_config(config_file_path: str = '') -> str:
                     if isinstance(agentic_memory_config, dict):
                         container_id = agentic_memory_config.get('memory_container_id', '')
                         if container_id:
-                            logging.info(f'Using memory_container_id from config file: {container_id}')
+                            logging.info(
+                                f'Using memory_container_id from config file: {container_id}'
+                            )
                             return container_id
         except Exception as e:
-            logging.debug(f'Could not load memory_container_id from config file {config_file_path}: {e}')
+            logging.debug(
+                f'Could not load memory_container_id from config file {config_file_path}: {e}'
+            )
 
     container_id = os.getenv('OPENSEARCH_MEMORY_CONTAINER_ID', '')
     if container_id:

--- a/src/tools/generic_api_tool.py
+++ b/src/tools/generic_api_tool.py
@@ -3,14 +3,13 @@
 
 import json
 import logging
-import os
+from .tool_logging import log_tool_error
+from .tool_params import baseToolArgs
+from .utils import format_json
+from pydantic import Field
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode
 
-from .tool_logging import log_tool_error
-from .utils import format_json
-from .tool_params import baseToolArgs
-from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/src/tools/memory_tools.py
+++ b/src/tools/memory_tools.py
@@ -94,11 +94,7 @@ def _get_boto3_session(profile_override: Optional[str] = None):
     import boto3
     from mcp_server_opensearch.global_state import get_profile
 
-    profile = (
-        profile_override
-        or get_profile()
-        or os.getenv('AWS_PROFILE', '').strip()
-    )
+    profile = profile_override or get_profile() or os.getenv('AWS_PROFILE', '').strip()
     try:
         return boto3.Session(profile_name=profile) if profile else boto3.Session()
     except Exception:
@@ -128,7 +124,7 @@ def _get_domain_name_from_url(opensearch_url: str) -> Optional[str]:
         # hostname = search-my-domain-abc123.us-east-1.es.amazonaws.com
         prefix = hostname.split('.')[0]  # search-my-domain-abc123
         if prefix.startswith('search-'):
-            prefix = prefix[len('search-'):]
+            prefix = prefix[len('search-') :]
         # Remove the trailing hash (last segment after the last hyphen that looks like a hash)
         parts = prefix.rsplit('-', 1)
         if len(parts) == 2 and len(parts[1]) >= 10:
@@ -202,7 +198,9 @@ def _get_collection_name(aoss_client, collection_id: str) -> str:
     return details[0]['name']
 
 
-def _ensure_aoss_data_access_policy(session, aoss_client, collection_id: str, region: str, index_name: str) -> None:
+def _ensure_aoss_data_access_policy(
+    session, aoss_client, collection_id: str, region: str, index_name: str
+) -> None:
     """Create or update an AOSS data access policy for the memory index.
 
     Grants the current caller's IAM role access to the specific memory index
@@ -229,9 +227,7 @@ def _ensure_aoss_data_access_policy(session, aoss_client, collection_id: str, re
                 existing_principals.add(p)
 
         if principal_arn in existing_principals:
-            logger.debug(
-                f'AOSS data access policy "{policy_name}" already covers {principal_arn}'
-            )
+            logger.debug(f'AOSS data access policy "{policy_name}" already covers {principal_arn}')
             return
 
         # Principal not covered — add it to the existing policy
@@ -342,8 +338,7 @@ async def _ensure_memory_index(args: baseToolArgs) -> None:
     # getattr with default handles the case where PR #231 is not yet merged and
     # the override fields don't exist on baseToolArgs yet.
     opensearch_url = (
-        getattr(args, 'opensearch_url', None)
-        or os.getenv('OPENSEARCH_URL', '')
+        getattr(args, 'opensearch_url', None) or os.getenv('OPENSEARCH_URL', '')
     ).strip()
 
     # Resolve is_serverless from args or env
@@ -389,7 +384,10 @@ async def _ensure_memory_index(args: baseToolArgs) -> None:
             logger.debug(f'Memory index "{index_name}" already exists (AOSS)')
         except Exception as e:
             error_str = str(e)
-            if 'already exists' in error_str.lower() or 'ResourceAlreadyExistsException' in error_str:
+            if (
+                'already exists' in error_str.lower()
+                or 'ResourceAlreadyExistsException' in error_str
+            ):
                 logger.debug(f'Memory index "{index_name}" already exists (AOSS)')
             else:
                 raise
@@ -412,7 +410,10 @@ async def _ensure_memory_index(args: baseToolArgs) -> None:
             logger.debug(f'Memory index "{index_name}" already exists')
         except Exception as e:
             error_str = str(e)
-            if 'already exists' in error_str.lower() or 'ResourceAlreadyExistsException' in error_str:
+            if (
+                'already exists' in error_str.lower()
+                or 'ResourceAlreadyExistsException' in error_str
+            ):
                 logger.debug(f'Memory index "{index_name}" already exists')
             else:
                 raise
@@ -525,9 +526,7 @@ class SearchMemoryArgs(baseToolArgs):
 class DeleteMemoryArgs(baseToolArgs):
     """Arguments for deleting a memory."""
 
-    memory_id: str = Field(
-        description='The ID of the memory document to delete.'
-    )
+    memory_id: str = Field(description='The ID of the memory document to delete.')
 
     class Config:
         json_schema_extra = {
@@ -640,19 +639,15 @@ async def search_memory_tool(args: SearchMemoryArgs) -> list[dict]:
         if not is_list_all:
             now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
             offset_hours = (
-                args.recency_offset_hours
-                if args.recency_offset_hours is not None
-                else 24.0
+                args.recency_offset_hours if args.recency_offset_hours is not None else 24.0
             )
             half_life_hours = (
-                args.recency_half_life_hours
-                if args.recency_half_life_hours is not None
-                else 168.0
+                args.recency_half_life_hours if args.recency_half_life_hours is not None else 168.0
             )
             recency_script = (
                 'double relevance = _score;'
                 'long now = params.now_ms;'
-                'long created = doc[\'created_at\'].value.toInstant().toEpochMilli();'
+                "long created = doc['created_at'].value.toInstant().toEpochMilli();"
                 'double ageHours = (now - created) / 3600000.0;'
                 'double decay = Math.exp(-0.693 * Math.max(0, ageHours - params.offset_hours) / params.half_life_hours);'
                 'return relevance * decay;'
@@ -769,7 +764,7 @@ MEMORY_TOOLS_REGISTRY: dict[str, dict[str, Any]] = (
                 'enriched for semantic search. Scope memories using user_id, agent_id, '
                 'and session_id. Add tags for categorization. '
                 'IMPORTANT: Save important facts, decisions, user preferences, and insights '
-                'immediately as they arise during the conversation — don\'t wait until the '
+                "immediately as they arise during the conversation — don't wait until the "
                 'end. Also do a final check before finishing to capture anything missed.'
             ),
             'input_schema': SaveMemoryArgs.model_json_schema(),
@@ -791,7 +786,7 @@ MEMORY_TOOLS_REGISTRY: dict[str, dict[str, Any]] = (
                 'IMPORTANT: Always call this tool at the start of a conversation to check '
                 'for relevant context. Also search memory whenever the user asks about '
                 'bugs, decisions, features, configurations, or any topic that may have '
-                'been previously discussed or worked on — even if they don\'t explicitly '
+                "been previously discussed or worked on — even if they don't explicitly "
                 'reference a prior conversation.'
             ),
             'input_schema': SearchMemoryArgs.model_json_schema(),

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -1,19 +1,21 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import logging
-from typing import Dict, Any
 from .tool_logging import log_tool_error
-from .utils import format_json
 from .tool_params import baseToolArgs
-from pydantic import Field
+from .utils import format_json
 from opensearch.client import get_opensearch_client
+from pydantic import Field
+from typing import Any, Dict
+
 
 logger = logging.getLogger(__name__)
 
 
 class DataDistributionToolArgs(baseToolArgs):
+    """Arguments for the DataDistributionTool."""
+
     index: str = Field(description='Target OpenSearch index name')
     selectionTimeRangeStart: str = Field(description='Start time for analysis period')
     selectionTimeRangeEnd: str = Field(description='End time for analysis period')
@@ -28,6 +30,8 @@ class DataDistributionToolArgs(baseToolArgs):
 
 
 class LogPatternAnalysisToolArgs(baseToolArgs):
+    """Arguments for the LogPatternAnalysisTool."""
+
     index: str = Field(description='Target OpenSearch index name containing log data')
     logFieldName: str = Field(description='Field containing raw log messages to analyze')
     selectionTimeRangeStart: str = Field(description='Start time for analysis target period')
@@ -47,7 +51,7 @@ class LogPatternAnalysisToolArgs(baseToolArgs):
 async def call_opensearch_tool(
     tool_name: str, parameters: Dict[str, Any], args: baseToolArgs
 ) -> list[dict]:
-    """Call OpenSearch ML tools API"""
+    """Call OpenSearch ML tools API."""
     try:
         async with get_opensearch_client(args) as client:
             # Call OpenSearch ML tools execute API
@@ -66,6 +70,7 @@ async def call_opensearch_tool(
 
 
 async def data_distribution_tool(args: DataDistributionToolArgs) -> list[dict]:
+    """Analyze data distribution over time ranges."""
     params = {
         'index': args.index,
         'timeField': args.timeField,
@@ -83,6 +88,7 @@ async def data_distribution_tool(args: DataDistributionToolArgs) -> list[dict]:
 
 
 async def log_pattern_analysis_tool(args: LogPatternAnalysisToolArgs) -> list[dict]:
+    """Analyze log patterns in the specified index."""
     params = {
         'index': args.index,
         'timeField': args.timeField,

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -413,9 +413,7 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
     # connection setup, and are not supported in multi mode.
     if mode == 'multi':
         filtered_registry = {
-            name: info
-            for name, info in tool_registry.items()
-            if not info.get('memory_tool')
+            name: info for name, info in tool_registry.items() if not info.get('memory_tool')
         }
         for name, info in filtered_registry.items():
             schema = info['input_schema']

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -393,7 +393,10 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
     """
     # Inline import to avoid circular dependency at module load time
     # (server_instructions imports clusters_information which is loaded after tools)
-    from mcp_server_opensearch.server_instructions import CONNECTION_OVERRIDE_FIELDS, is_dynamic_mode_enabled
+    from mcp_server_opensearch.server_instructions import (
+        CONNECTION_OVERRIDE_FIELDS,
+        is_dynamic_mode_enabled,
+    )
 
     # Get the current mode from global state
     mode = get_mode()
@@ -475,9 +478,7 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
         if 'properties' in schema:
             dynamic = is_dynamic_mode_enabled()
             _always_hidden = {'opensearch_cluster_name'}
-            fields_to_strip = _always_hidden | (
-                set() if dynamic else CONNECTION_OVERRIDE_FIELDS
-            )
+            fields_to_strip = _always_hidden | (set() if dynamic else CONNECTION_OVERRIDE_FIELDS)
             for field in fields_to_strip:
                 schema['properties'].pop(field, None)
                 if 'required' in schema and field in schema['required']:

--- a/src/tools/tool_generator.py
+++ b/src/tools/tool_generator.py
@@ -3,9 +3,9 @@
 
 import aiohttp
 import json
-import yaml
-import ssl
 import os
+import ssl
+import yaml
 from .tool_logging import log_tool_error
 from .tool_params import baseToolArgs
 from .tools import TOOL_REGISTRY, check_tool_compatibility
@@ -212,7 +212,7 @@ def generate_tool_from_group(base_name: str, endpoints: List[Dict]) -> Dict[str,
     max_version = details.get('x-version-deprecated', '99.99.99')
 
     # Get the HTTP method(s) used by the endpoints
-    methods = set(endpoint['method'].upper() for endpoint in endpoints)
+    methods = {endpoint['method'].upper() for endpoint in endpoints}
     http_methods = ', '.join(sorted(methods))
 
     all_parameters, path_parameters, required_parameters = extract_parameters(endpoints)
@@ -228,6 +228,7 @@ def generate_tool_from_group(base_name: str, endpoints: List[Dict]) -> Dict[str,
         tool_name = f'{base_name.replace("_", "")}Tool'
         try:
             from opensearch.client import get_opensearch_client
+
             params_dict = params.model_dump() if hasattr(params, 'model_dump') else {}
 
             try:

--- a/src/tools/tool_logging.py
+++ b/src/tools/tool_logging.py
@@ -1,8 +1,7 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Structured error logging for tool functions.
+"""Structured error logging for tool functions.
 
 Provides a helper that extracts structured data from exceptions
 (status codes, error types, root causes) before they are stringified,
@@ -11,6 +10,7 @@ and emits a structured log event for metric extraction.
 
 import json
 import logging
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/tools/tool_params.py
+++ b/src/tools/tool_params.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 from typing import Any, Dict, Literal, Optional, Type, TypeVar
 
 
-
 T = TypeVar('T', bound=BaseModel)
 
 
@@ -115,6 +114,8 @@ class ListClustersArgs(BaseModel):
 
 
 class ListIndicesArgs(baseToolArgs):
+    """Arguments for the ListIndicesTool."""
+
     index: str = Field(
         default='',
         description='The name of the index or index pattern to get information for.',
@@ -126,17 +127,28 @@ class ListIndicesArgs(baseToolArgs):
 
 
 class GetIndexMappingArgs(baseToolArgs):
+    """Arguments for the GetIndexMappingTool."""
+
     index: str = Field(description='The name of the index to get mapping information for')
 
 
 class SearchIndexArgs(baseToolArgs):
+    """Arguments for the SearchIndexTool."""
+
     index: str = Field(description='The name of the index to search in')
-    query_dsl: Any = Field(description='The search query in OpenSearch query DSL format. For keyword-type fields (mapping shows "type": "keyword"), use field name DIRECTLY - do NOT add .keyword suffix. For text-type fields with .keyword subfields, use the .keyword suffix for exact matches. For date/time range queries, MUST include "format" parameter (commonly "format": "strict_date_optional_time||epoch_millis"), e.g. {"range": {"timestamp": {"gte": "2025-12-29T17:15:12Z", "lte": "2025-12-30T08:15:12Z", "format": "strict_date_optional_time||epoch_millis"}}}; if using non-ISO formats, adjust "format" accordingly.')
+    query_dsl: Any = Field(
+        description='The search query in OpenSearch query DSL format. For keyword-type fields (mapping shows "type": "keyword"), use field name DIRECTLY - do NOT add .keyword suffix. For text-type fields with .keyword subfields, use the .keyword suffix for exact matches. For date/time range queries, MUST include "format" parameter (commonly "format": "strict_date_optional_time||epoch_millis"), e.g. {"range": {"timestamp": {"gte": "2025-12-29T17:15:12Z", "lte": "2025-12-30T08:15:12Z", "format": "strict_date_optional_time||epoch_millis"}}}; if using non-ISO formats, adjust "format" accordingly.'
+    )
     format: str = Field(default='json', description='Output format: "json" or "csv"')
-    size: int = Field(default=10, description='Number of search results to return. The maximum allowed value is 100, unless overridden by configuration.')
+    size: int = Field(
+        default=10,
+        description='Number of search results to return. The maximum allowed value is 100, unless overridden by configuration.',
+    )
 
 
 class GetShardsArgs(baseToolArgs):
+    """Arguments for the GetShardsTool."""
+
     index: str = Field(description='The name of the index to get shard information for')
 
 
@@ -577,12 +589,14 @@ class CreateExperimentArgs(baseToolArgs):
         'POINTWISE_EVALUATION and HYBRID_OPTIMIZER require exactly 1. '
         'Example: ["config-id-1", "config-id-2"]'
     )
-    experiment_type: Literal['PAIRWISE_COMPARISON', 'POINTWISE_EVALUATION', 'HYBRID_OPTIMIZER'] = Field(
-        description=(
-            'Type of experiment: '
-            '"PAIRWISE_COMPARISON" (compares 2 search configurations, no judgment lists required), '
-            '"POINTWISE_EVALUATION" (evaluates 1 configuration against judgment lists), '
-            '"HYBRID_OPTIMIZER" (optimizes 1 configuration using judgment lists)'
+    experiment_type: Literal['PAIRWISE_COMPARISON', 'POINTWISE_EVALUATION', 'HYBRID_OPTIMIZER'] = (
+        Field(
+            description=(
+                'Type of experiment: '
+                '"PAIRWISE_COMPARISON" (compares 2 search configurations, no judgment lists required), '
+                '"POINTWISE_EVALUATION" (evaluates 1 configuration against judgment lists), '
+                '"HYBRID_OPTIMIZER" (optimizes 1 configuration using judgment lists)'
+            )
         )
     )
     size: int = Field(
@@ -640,9 +654,7 @@ _SRW_SEARCH_QUERY_BODY_EXAMPLES = [
 class SearchQuerySetsArgs(baseToolArgs):
     """Arguments for the SearchQuerySetsTool."""
 
-    query_body: Optional[Any] = Field(
-        default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION
-    )
+    query_body: Optional[Any] = Field(default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION)
 
     class Config:
         json_schema_extra = {'examples': _SRW_SEARCH_QUERY_BODY_EXAMPLES}
@@ -651,9 +663,7 @@ class SearchQuerySetsArgs(baseToolArgs):
 class SearchSearchConfigurationsArgs(baseToolArgs):
     """Arguments for the SearchSearchConfigurationsTool."""
 
-    query_body: Optional[Any] = Field(
-        default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION
-    )
+    query_body: Optional[Any] = Field(default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION)
 
     class Config:
         json_schema_extra = {'examples': _SRW_SEARCH_QUERY_BODY_EXAMPLES}
@@ -662,9 +672,7 @@ class SearchSearchConfigurationsArgs(baseToolArgs):
 class SearchJudgmentsArgs(baseToolArgs):
     """Arguments for the SearchJudgmentsTool."""
 
-    query_body: Optional[Any] = Field(
-        default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION
-    )
+    query_body: Optional[Any] = Field(default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION)
 
     class Config:
         json_schema_extra = {'examples': _SRW_SEARCH_QUERY_BODY_EXAMPLES}
@@ -673,9 +681,7 @@ class SearchJudgmentsArgs(baseToolArgs):
 class SearchExperimentsArgs(baseToolArgs):
     """Arguments for the SearchExperimentsTool."""
 
-    query_body: Optional[Any] = Field(
-        default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION
-    )
+    query_body: Optional[Any] = Field(default=None, description=_SRW_SEARCH_QUERY_BODY_DESCRIPTION)
 
     class Config:
         json_schema_extra = {'examples': _SRW_SEARCH_QUERY_BODY_EXAMPLES}

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -2,55 +2,64 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from .agentic_memory.actions import AGENTIC_MEMORY_TOOLS_REGISTRY
+from .generic_api_tool import GenericOpenSearchApiArgs, generic_opensearch_api_tool
+from .skills_tools import SKILLS_TOOLS_REGISTRY
+from .tool_logging import log_tool_error
 from .tool_params import (
+    CatNodesArgs,
+    CreateExperimentArgs,
     CreateJudgmentListArgs,
     CreateLLMJudgmentListArgs,
+    CreateQuerySetArgs,
     CreateSearchConfigurationArgs,
     CreateUBIJudgmentListArgs,
+    DeleteExperimentArgs,
     DeleteJudgmentListArgs,
+    DeleteQuerySetArgs,
     DeleteSearchConfigurationArgs,
     GetAllocationArgs,
     GetClusterStateArgs,
+    GetExperimentArgs,
     GetIndexInfoArgs,
     GetIndexMappingArgs,
     GetIndexStatsArgs,
     GetJudgmentListArgs,
     GetLongRunningTasksArgs,
-    CatNodesArgs,
     GetNodesArgs,
     GetNodesHotThreadsArgs,
     GetQueryInsightsArgs,
+    GetQuerySetArgs,
     GetSearchConfigurationArgs,
     GetSegmentsArgs,
     GetShardsArgs,
     ListClustersArgs,
     ListIndicesArgs,
-    SearchIndexArgs,
-    GetQuerySetArgs,
-    CreateQuerySetArgs,
     SampleQuerySetArgs,
-    DeleteQuerySetArgs,
-    GetExperimentArgs,
-    CreateExperimentArgs,
-    DeleteExperimentArgs,
+    SearchExperimentsArgs,
+    SearchIndexArgs,
+    SearchJudgmentsArgs,
     SearchQuerySetsArgs,
     SearchSearchConfigurationsArgs,
-    SearchJudgmentsArgs,
-    SearchExperimentsArgs,
     baseToolArgs,
 )
-from .tool_logging import log_tool_error
 from .utils import format_json, is_tool_compatible
+from mcp_server_opensearch.clusters_information import cluster_registry
 from opensearch.helper import (
     convert_search_results_to_csv,
+    create_experiment,
     create_judgment_list,
     create_llm_judgment_list,
+    create_query_set,
     create_search_configuration,
     create_ubi_judgment_list,
+    delete_experiment,
     delete_judgment_list,
+    delete_query_set,
     delete_search_configuration,
     get_allocation,
     get_cluster_state,
+    get_experiment,
     get_index,
     get_index_info,
     get_index_mapping,
@@ -62,22 +71,17 @@ from opensearch.helper import (
     get_nodes_info,
     get_opensearch_version,
     get_query_insights,
+    get_query_set,
     get_search_configuration,
     get_segments,
     get_shards,
     list_indices,
-    search_index,
-    get_query_set,
-    create_query_set,
     sample_query_set,
-    delete_query_set,
-    get_experiment,
-    create_experiment,
-    delete_experiment,
+    search_experiments,
+    search_index,
+    search_judgments,
     search_query_sets,
     search_search_configurations,
-    search_judgments,
-    search_experiments,
 )
 from .agentic_memory.actions import AGENTIC_MEMORY_TOOLS_REGISTRY
 from .skills_tools import SKILLS_TOOLS_REGISTRY
@@ -86,6 +90,7 @@ from mcp_server_opensearch.clusters_information import cluster_registry
 
 
 async def list_clusters_tool(args: ListClustersArgs) -> list[dict]:
+    """List all available OpenSearch clusters."""
     try:
         cluster_names = list(cluster_registry.keys())
         formatted_names = json.dumps(cluster_names, separators=(',', ':'))
@@ -95,6 +100,7 @@ async def list_clusters_tool(args: ListClustersArgs) -> list[dict]:
 
 
 async def check_tool_compatibility(tool_name: str, args: baseToolArgs = None):
+    """Check if a tool is compatible with the current OpenSearch version."""
     opensearch_version = await get_opensearch_version(args)
     if not is_tool_compatible(opensearch_version, TOOL_REGISTRY[tool_name]):
         tool_display_name = TOOL_REGISTRY[tool_name].get('display_name', tool_name)
@@ -119,6 +125,7 @@ async def check_tool_compatibility(tool_name: str, args: baseToolArgs = None):
 
 
 async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
+    """List indices with optional detailed information."""
     try:
         await check_tool_compatibility('ListIndexTool', args)
 
@@ -154,6 +161,7 @@ async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
 
 
 async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
+    """Get the mapping for a specific index."""
     try:
         await check_tool_compatibility('IndexMappingTool', args)
         mapping = await get_index_mapping(args)
@@ -165,6 +173,7 @@ async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
 
 
 async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
+    """Search an index using query DSL."""
     try:
         await check_tool_compatibility('SearchIndexTool', args)
         result = await search_index(args)
@@ -190,6 +199,7 @@ async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
 
 
 async def get_shards_tool(args: GetShardsArgs) -> list[dict]:
+    """Get shard information for an index."""
     try:
         await check_tool_compatibility('GetShardsTool', args)
         result = await get_shards(args)
@@ -941,8 +951,6 @@ async def search_experiments_tool(args: SearchExperimentsArgs) -> list[dict]:
         return [{'type': 'text', 'text': f'Experiment search results:\n{formatted_result}'}]
     except Exception as e:
         return log_tool_error('SearchExperimentsTool', e, 'searching experiments')
-
-from .generic_api_tool import GenericOpenSearchApiArgs, generic_opensearch_api_tool
 
 
 # Registry of available OpenSearch tools with their metadata

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -4,6 +4,7 @@
 import json
 from .agentic_memory.actions import AGENTIC_MEMORY_TOOLS_REGISTRY
 from .generic_api_tool import GenericOpenSearchApiArgs, generic_opensearch_api_tool
+from .memory_tools import MEMORY_TOOLS_REGISTRY
 from .skills_tools import SKILLS_TOOLS_REGISTRY
 from .tool_logging import log_tool_error
 from .tool_params import (
@@ -83,10 +84,6 @@ from opensearch.helper import (
     search_query_sets,
     search_search_configurations,
 )
-from .agentic_memory.actions import AGENTIC_MEMORY_TOOLS_REGISTRY
-from .skills_tools import SKILLS_TOOLS_REGISTRY
-from .memory_tools import MEMORY_TOOLS_REGISTRY
-from mcp_server_opensearch.clusters_information import cluster_registry
 
 
 async def list_clusters_tool(args: ListClustersArgs) -> list[dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,9 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption('--run-evals'):
-        skip = pytest.mark.skip(reason='LLM eval tests are skipped by default; pass --run-evals to run them')
+        skip = pytest.mark.skip(
+            reason='LLM eval tests are skipped by default; pass --run-evals to run them'
+        )
         for item in items:
             if item.get_closest_marker('eval'):
                 item.add_marker(skip)

--- a/tests/mcp_server_opensearch/test_clusters_information.py
+++ b/tests/mcp_server_opensearch/test_clusters_information.py
@@ -1,15 +1,14 @@
+import os
+import platform
 import pytest
 import tempfile
-import os
 import yaml
-import platform
-from unittest.mock import patch, MagicMock, AsyncMock
 from mcp_server_opensearch.clusters_information import (
     ClusterInfo,
     add_cluster,
+    cluster_registry,
     get_cluster,
     load_clusters_from_yaml,
-    cluster_registry,
 )
 
 

--- a/tests/mcp_server_opensearch/test_install_hooks.py
+++ b/tests/mcp_server_opensearch/test_install_hooks.py
@@ -6,7 +6,6 @@ import pytest
 from mcp_server_opensearch.install_hooks import (
     KIRO_SAVE_HOOK,
     KIRO_SEARCH_HOOK,
-    CURSOR_HOOKS_CONFIG,
     install_hooks,
 )
 from unittest.mock import patch
@@ -140,10 +139,14 @@ class TestInstallClaudeCodeHooks:
                 {'matcher': 'Write', 'hooks': [{'type': 'command', 'command': 'echo ok'}]}
             ]
         }
-        settings_path.write_text(json.dumps({
-            'model': 'claude-sonnet-4-20250514',
-            'hooks': existing_hooks,
-        }))
+        settings_path.write_text(
+            json.dumps(
+                {
+                    'model': 'claude-sonnet-4-20250514',
+                    'hooks': existing_hooks,
+                }
+            )
+        )
 
         with patch(
             'mcp_server_opensearch.install_hooks._get_claude_settings_path',
@@ -176,11 +179,20 @@ class TestInstallClaudeCodeHooks:
         settings_path = tmp_workspace / '.claude' / 'settings.json'
         settings_path.parent.mkdir(parents=True)
         # Old (incorrect) flat-list format
-        settings_path.write_text(json.dumps({
-            'hooks': [
-                {'event': 'UserPromptSubmit', 'matcher': '', 'type': 'command', 'command': 'echo old'}
-            ]
-        }))
+        settings_path.write_text(
+            json.dumps(
+                {
+                    'hooks': [
+                        {
+                            'event': 'UserPromptSubmit',
+                            'matcher': '',
+                            'type': 'command',
+                            'command': 'echo old',
+                        }
+                    ]
+                }
+            )
+        )
 
         with patch(
             'mcp_server_opensearch.install_hooks._get_claude_settings_path',
@@ -250,12 +262,16 @@ class TestInstallCursorHooks:
         """Install merges into existing hooks.json without overwriting."""
         hooks_path = tmp_workspace / '.cursor' / 'hooks.json'
         hooks_path.parent.mkdir(parents=True)
-        hooks_path.write_text(json.dumps({
-            'version': 1,
-            'hooks': {
-                'afterFileEdit': [{'command': 'echo formatted'}],
-            },
-        }))
+        hooks_path.write_text(
+            json.dumps(
+                {
+                    'version': 1,
+                    'hooks': {
+                        'afterFileEdit': [{'command': 'echo formatted'}],
+                    },
+                }
+            )
+        )
 
         with patch(
             'mcp_server_opensearch.install_hooks._get_cursor_hooks_path',

--- a/tests/mcp_server_opensearch/test_logging_config.py
+++ b/tests/mcp_server_opensearch/test_logging_config.py
@@ -5,10 +5,7 @@ import asyncio
 import io
 import json
 import logging
-from unittest.mock import patch
-
 import pytest
-
 from mcp_server_opensearch.logging_config import (
     JsonFormatter,
     _get_rss_mb,
@@ -17,6 +14,7 @@ from mcp_server_opensearch.logging_config import (
     memory_monitor,
     start_memory_monitor,
 )
+from unittest.mock import patch
 
 
 class TestJsonFormatter:

--- a/tests/mcp_server_opensearch/test_server_instructions.py
+++ b/tests/mcp_server_opensearch/test_server_instructions.py
@@ -383,8 +383,10 @@ class TestConditionalSchemaStripping:
 
     @pytest.mark.asyncio
     async def test_dynamic_mode_with_url_env_var_does_not_mark_required(self):
-        """When OPENSEARCH_DYNAMIC_CONNECTION=true but OPENSEARCH_URL is set,
-        opensearch_url is exposed in schema but NOT required (server has a fallback)."""
+        """When OPENSEARCH_DYNAMIC_CONNECTION=true but OPENSEARCH_URL is set.
+
+        opensearch_url is exposed in schema but NOT required (server has a fallback).
+        """
         os.environ['OPENSEARCH_URL'] = 'https://cluster.example.com'
         os.environ['OPENSEARCH_DYNAMIC_CONNECTION'] = 'true'
         from tools.tool_filter import get_tools

--- a/tests/mcp_server_opensearch/test_streaming_server.py
+++ b/tests/mcp_server_opensearch/test_streaming_server.py
@@ -4,14 +4,14 @@
 import pytest
 import pytest_asyncio
 from mcp.types import TextContent
-from unittest.mock import AsyncMock, Mock, patch, MagicMock, ANY
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 
 @pytest.fixture(autouse=True)
 def patch_opensearch_version():
     """Mock OpenSearch client and version check."""
-    from unittest.mock import AsyncMock
     from semver import Version
+    from unittest.mock import AsyncMock
 
     mock_client = Mock()
     mock_client.info = AsyncMock(return_value={'version': {'number': '3.0.0'}})
@@ -89,10 +89,10 @@ class TestMCPServer:
         mock_load_clusters.return_value = None
 
         # Create server
-        from mcp_server_opensearch.streaming_server import create_mcp_server
         from mcp.types import Tool
+        from mcp_server_opensearch.streaming_server import create_mcp_server
 
-        server = await create_mcp_server()
+        await create_mcp_server()
 
         # Get the tools by calling the decorated function
         tools = []

--- a/tests/mcp_server_opensearch/test_tool_executor.py
+++ b/tests/mcp_server_opensearch/test_tool_executor.py
@@ -3,9 +3,8 @@
 
 import logging
 import pytest
-from unittest.mock import AsyncMock, Mock, patch
-
 from mcp_server_opensearch.tool_executor import execute_tool
+from unittest.mock import AsyncMock, Mock, patch
 
 
 def make_enabled_tools(tool_key='TestTool', display_name=None, return_value=None):
@@ -37,7 +36,11 @@ class TestExecuteTool:
         # Check structured log was emitted
         assert any('Tool executed: TestTool' in r.message for r in caplog.records)
         # Check extra fields
-        success_records = [r for r in caplog.records if hasattr(r, 'event_type') and r.event_type == 'tool_execution']
+        success_records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
         assert len(success_records) == 1
         assert success_records[0].status == 'success'
         assert hasattr(success_records[0], 'duration_ms')
@@ -47,14 +50,24 @@ class TestExecuteTool:
     async def test_soft_error_detected_via_is_error_flag(self, mock_validate, caplog):
         mock_validate.return_value = Mock()
         enabled_tools = make_enabled_tools(
-            return_value=[{'type': 'text', 'text': 'Error searching index: connection refused', 'is_error': True}]
+            return_value=[
+                {
+                    'type': 'text',
+                    'text': 'Error searching index: connection refused',
+                    'is_error': True,
+                }
+            ]
         )
 
         with caplog.at_level(logging.ERROR):
             result = await execute_tool('TestTool', {}, enabled_tools)
 
         assert result[0]['is_error'] is True
-        error_records = [r for r in caplog.records if hasattr(r, 'event_type') and r.event_type == 'tool_execution']
+        error_records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
         assert len(error_records) == 1
         assert error_records[0].status == 'error'
 
@@ -68,9 +81,13 @@ class TestExecuteTool:
         )
 
         with caplog.at_level(logging.INFO):
-            result = await execute_tool('TestTool', {}, enabled_tools)
+            await execute_tool('TestTool', {}, enabled_tools)
 
-        records = [r for r in caplog.records if hasattr(r, 'event_type') and r.event_type == 'tool_execution']
+        records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
         assert len(records) == 1
         assert records[0].status == 'success'
 
@@ -80,7 +97,11 @@ class TestExecuteTool:
             with pytest.raises(ValueError, match='Unknown or disabled tool'):
                 await execute_tool('NonExistentTool', {}, {})
 
-        error_records = [r for r in caplog.records if hasattr(r, 'event_type') and r.event_type == 'tool_execution']
+        error_records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
         assert len(error_records) == 1
         assert error_records[0].status == 'error'
         assert error_records[0].error_type == 'UnknownToolError'
@@ -96,7 +117,11 @@ class TestExecuteTool:
             with pytest.raises(RuntimeError, match='boom'):
                 await execute_tool('TestTool', {}, enabled_tools)
 
-        error_records = [r for r in caplog.records if hasattr(r, 'event_type') and r.event_type == 'tool_execution']
+        error_records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
         assert len(error_records) == 1
         assert error_records[0].status == 'error'
         assert error_records[0].error_type == 'RuntimeError'
@@ -112,7 +137,11 @@ class TestExecuteTool:
             with pytest.raises(ValueError, match='Missing required field'):
                 await execute_tool('TestTool', {}, enabled_tools)
 
-        error_records = [r for r in caplog.records if hasattr(r, 'event_type') and r.event_type == 'tool_execution']
+        error_records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
         assert len(error_records) == 1
         assert error_records[0].status == 'error'
         assert error_records[0].error_type == 'ValidationError'
@@ -134,7 +163,9 @@ class TestExecuteTool:
     @patch('tools.tool_params.validate_args_for_mode')
     async def test_tool_key_logged(self, mock_validate, caplog):
         mock_validate.return_value = Mock()
-        enabled_tools = make_enabled_tools(tool_key='SearchIndexTool', display_name='SearchIndexTool')
+        enabled_tools = make_enabled_tools(
+            tool_key='SearchIndexTool', display_name='SearchIndexTool'
+        )
 
         with caplog.at_level(logging.INFO):
             await execute_tool('SearchIndexTool', {}, enabled_tools)

--- a/tests/opensearch/test_helper.py
+++ b/tests/opensearch/test_helper.py
@@ -1,8 +1,8 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import json
+import pytest
 from tools.tool_params import (
     GetIndexMappingArgs,
     GetShardsArgs,
@@ -10,7 +10,7 @@ from tools.tool_params import (
     SearchIndexArgs,
     baseToolArgs,
 )
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, patch
 
 
 class TestOpenSearchHelper:
@@ -211,6 +211,7 @@ class TestOpenSearchHelper:
 
         # Ensure env var is not set
         import os
+
         os.environ.pop('OPENSEARCH_QUERY_TIMEOUT', None)
 
         result = await self.search_index(
@@ -375,218 +376,209 @@ class TestOpenSearchHelper:
         # Execute and assert
         result = await get_opensearch_version(args)
         assert result is None
-        
+
     def test_convert_search_results_to_csv_hits_only(self):
         """Test convert_search_results_to_csv with hits only."""
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         convert_search_results_to_csv = helper.convert_search_results_to_csv
-        
+
         search_results = {
-            "hits": {
-                "total": {"value": 2, "relation": "eq"},
-                "hits": [
+            'hits': {
+                'total': {'value': 2, 'relation': 'eq'},
+                'hits': [
                     {
-                        "_index": "products",
-                        "_id": "1",
-                        "_score": 1.5,
-                        "_source": {
-                            "name": "Laptop",
-                            "price": 999.99,
-                            "category": "electronics"
-                        }
+                        '_index': 'products',
+                        '_id': '1',
+                        '_score': 1.5,
+                        '_source': {'name': 'Laptop', 'price': 999.99, 'category': 'electronics'},
                     },
                     {
-                        "_index": "products",
-                        "_id": "2",
-                        "_score": 1.2,
-                        "_source": {
-                            "name": "Phone",
-                            "price": 599.99,
-                            "category": "electronics"
-                        }
-                    }
-                ]
+                        '_index': 'products',
+                        '_id': '2',
+                        '_score': 1.2,
+                        '_source': {'name': 'Phone', 'price': 599.99, 'category': 'electronics'},
+                    },
+                ],
             }
         }
-        
+
         result = convert_search_results_to_csv(search_results)
-        assert "_id,_index,_score,category,name,price" in result
-        assert "1,products,1.5,electronics,Laptop,999.99" in result
-        assert "2,products,1.2,electronics,Phone,599.99" in result
+        assert '_id,_index,_score,category,name,price' in result
+        assert '1,products,1.5,electronics,Laptop,999.99' in result
+        assert '2,products,1.2,electronics,Phone,599.99' in result
 
     def test_convert_search_results_to_csv_aggregations_only(self):
         """Test convert_search_results_to_csv with aggregations only."""
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         convert_search_results_to_csv = helper.convert_search_results_to_csv
-        
+
         search_results = {
-            "hits": {"total": {"value": 100}, "hits": []},
-            "aggregations": {
-                "categories": {
-                    "buckets": [
-                        {"key": "electronics", "doc_count": 45},
-                        {"key": "books", "doc_count": 30},
-                        {"key": "clothing", "doc_count": 25}
+            'hits': {'total': {'value': 100}, 'hits': []},
+            'aggregations': {
+                'categories': {
+                    'buckets': [
+                        {'key': 'electronics', 'doc_count': 45},
+                        {'key': 'books', 'doc_count': 30},
+                        {'key': 'clothing', 'doc_count': 25},
                     ]
                 },
-                "avg_price": {
-                    "value": 299.99
-                }
-            }
+                'avg_price': {'value': 299.99},
+            },
         }
-        
+
         result = convert_search_results_to_csv(search_results)
-        assert "categories" in result
-        assert "avg_price" in result
-        assert "electronics" in result
-        assert "299.99" in result
+        assert 'categories' in result
+        assert 'avg_price' in result
+        assert 'electronics' in result
+        assert '299.99' in result
 
     def test_convert_search_results_to_csv_hits_and_aggregations(self):
         """Test convert_search_results_to_csv with both hits and aggregations."""
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         convert_search_results_to_csv = helper.convert_search_results_to_csv
-        
+
         search_results = {
-            "hits": {
-                "total": {"value": 1},
-                "hits": [
+            'hits': {
+                'total': {'value': 1},
+                'hits': [
                     {
-                        "_index": "products",
-                        "_id": "1",
-                        "_score": 1.0,
-                        "_source": {
-                            "name": "Laptop",
-                            "price": 999.99
-                        }
+                        '_index': 'products',
+                        '_id': '1',
+                        '_score': 1.0,
+                        '_source': {'name': 'Laptop', 'price': 999.99},
                     }
-                ]
+                ],
             },
-            "aggregations": {
-                "price_stats": {
-                    "min": 99.99,
-                    "max": 1999.99,
-                    "avg": 549.99
-                }
-            }
+            'aggregations': {'price_stats': {'min': 99.99, 'max': 1999.99, 'avg': 549.99}},
         }
-        
+
         result = convert_search_results_to_csv(search_results)
-        assert "SEARCH HITS:" in result
-        assert "AGGREGATIONS:" in result
-        assert "_id,_index,_score,name,price" in result
-        assert "1,products,1.0,Laptop,999.99" in result
-        assert "price_stats" in result
-        assert "549.99" in result
+        assert 'SEARCH HITS:' in result
+        assert 'AGGREGATIONS:' in result
+        assert '_id,_index,_score,name,price' in result
+        assert '1,products,1.0,Laptop,999.99' in result
+        assert 'price_stats' in result
+        assert '549.99' in result
 
     def test_convert_search_results_to_csv_nested_aggregations(self):
         """Test convert_search_results_to_csv with nested aggregations."""
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         convert_search_results_to_csv = helper.convert_search_results_to_csv
-        
+
         search_results = {
-            "hits": {"total": {"value": 1000}, "hits": []},
-            "aggregations": {
-                "categories": {
-                    "buckets": [
+            'hits': {'total': {'value': 1000}, 'hits': []},
+            'aggregations': {
+                'categories': {
+                    'buckets': [
                         {
-                            "key": "electronics",
-                            "doc_count": 500,
-                            "avg_price": {"value": 299.99},
-                            "brands": {
-                                "buckets": [
-                                    {"key": "Apple", "doc_count": 200},
-                                    {"key": "Samsung", "doc_count": 150}
+                            'key': 'electronics',
+                            'doc_count': 500,
+                            'avg_price': {'value': 299.99},
+                            'brands': {
+                                'buckets': [
+                                    {'key': 'Apple', 'doc_count': 200},
+                                    {'key': 'Samsung', 'doc_count': 150},
                                 ]
-                            }
+                            },
                         },
                         {
-                            "key": "books",
-                            "doc_count": 300,
-                            "avg_price": {"value": 19.99},
-                            "genres": {
-                                "buckets": [
-                                    {"key": "fiction", "doc_count": 180},
-                                    {"key": "non-fiction", "doc_count": 120}
+                            'key': 'books',
+                            'doc_count': 300,
+                            'avg_price': {'value': 19.99},
+                            'genres': {
+                                'buckets': [
+                                    {'key': 'fiction', 'doc_count': 180},
+                                    {'key': 'non-fiction', 'doc_count': 120},
                                 ]
-                            }
-                        }
+                            },
+                        },
                     ]
                 },
-                "total_revenue": {
-                    "value": 125000.50
-                }
-            }
+                'total_revenue': {'value': 125000.50},
+            },
         }
-        
+
         result = convert_search_results_to_csv(search_results)
-        assert "categories" in result
-        assert "total_revenue" in result
-        assert "electronics" in result
-        assert "Apple" in result
-        assert "fiction" in result
-        assert "125000.5" in result
+        assert 'categories' in result
+        assert 'total_revenue' in result
+        assert 'electronics' in result
+        assert 'Apple' in result
+        assert 'fiction' in result
+        assert '125000.5' in result
 
     def test_convert_search_results_to_csv_nested_objects(self):
         """Test convert_search_results_to_csv with nested objects in hits."""
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         convert_search_results_to_csv = helper.convert_search_results_to_csv
-        
+
         search_results = {
-            "hits": {
-                "hits": [
+            'hits': {
+                'hits': [
                     {
-                        "_index": "users",
-                        "_id": "1",
-                        "_score": 1.0,
-                        "_source": {
-                            "name": "John Doe",
-                            "address": {
-                                "street": "123 Main St",
-                                "city": "New York",
-                                "coordinates": {
-                                    "lat": 40.7128,
-                                    "lon": -74.0060
-                                }
+                        '_index': 'users',
+                        '_id': '1',
+                        '_score': 1.0,
+                        '_source': {
+                            'name': 'John Doe',
+                            'address': {
+                                'street': '123 Main St',
+                                'city': 'New York',
+                                'coordinates': {'lat': 40.7128, 'lon': -74.0060},
                             },
-                            "tags": ["developer", "python"],
-                            "skills": [
-                                {"name": "Python", "level": "expert"},
-                                {"name": "JavaScript", "level": "intermediate"}
-                            ]
-                        }
+                            'tags': ['developer', 'python'],
+                            'skills': [
+                                {'name': 'Python', 'level': 'expert'},
+                                {'name': 'JavaScript', 'level': 'intermediate'},
+                            ],
+                        },
                     }
                 ]
             }
         }
-        
+
         result = convert_search_results_to_csv(search_results)
         # Check flattened nested fields
-        assert "address.city" in result
-        assert "address.coordinates.lat" in result
-        assert "address.coordinates.lon" in result
-        assert "New York" in result
-        assert "40.7128" in result
-        assert "-74.006" in result
+        assert 'address.city' in result
+        assert 'address.coordinates.lat' in result
+        assert 'address.coordinates.lon' in result
+        assert 'New York' in result
+        assert '40.7128' in result
+        assert '-74.006' in result
         # Check arrays are JSON encoded (CSV escapes quotes)
         assert '"[""developer"", ""python""]"' in result
 
@@ -594,50 +586,43 @@ class TestOpenSearchHelper:
         """Test convert_search_results_to_csv with empty results."""
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         convert_search_results_to_csv = helper.convert_search_results_to_csv
-        
+
         # Empty search results
-        assert convert_search_results_to_csv({}) == "No search results to convert"
-        assert convert_search_results_to_csv(None) == "No search results to convert"
-        
+        assert convert_search_results_to_csv({}) == 'No search results to convert'
+        assert convert_search_results_to_csv(None) == 'No search results to convert'
+
         # No hits
-        search_results = {"hits": {"hits": []}}
+        search_results = {'hits': {'hits': []}}
         result = convert_search_results_to_csv(search_results)
-        assert "No search results to convert" in result
-        
+        assert 'No search results to convert' in result
+
         # Only aggregations with empty hits
-        search_results = {
-            "hits": {"hits": []},
-            "aggregations": {"count": {"value": 0}}
-        }
+        search_results = {'hits': {'hits': []}, 'aggregations': {'count': {'value': 0}}}
         result = convert_search_results_to_csv(search_results)
-        assert "count" in result
-        assert "0" in result
+        assert 'count' in result
+        assert '0' in result
 
     def test_normalize_scientific_notation(self):
         import importlib.util
         import os
-        spec = importlib.util.spec_from_file_location("helper", os.path.join(os.path.dirname(__file__),
-                                                                             '../../src/opensearch/helper.py'))
+
+        spec = importlib.util.spec_from_file_location(
+            'helper', os.path.join(os.path.dirname(__file__), '../../src/opensearch/helper.py')
+        )
         helper = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(helper)
         normalize_scientific_notation = helper.normalize_scientific_notation
-        query_dsl = {
-            "query": {
-                "range": {
-                    "timestamp": {
-                        "gte": 1732693003E+3,
-                        "lte": 173.5
-                    }
-                }
-            }
-        }
+        query_dsl = {'query': {'range': {'timestamp': {'gte': 1732693003e3, 'lte': 173.5}}}}
         result = normalize_scientific_notation(query_dsl)
-        assert "1732693003000" in json.dumps(result)
-        assert "173.5" in json.dumps(result)
+        assert '1732693003000' in json.dumps(result)
+        assert '173.5' in json.dumps(result)
 
 
 class TestValidateJsonString:

--- a/tests/opensearch/test_response_size_limiting.py
+++ b/tests/opensearch/test_response_size_limiting.py
@@ -1,31 +1,22 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Unit tests for response size limiting functionality.
-"""
+"""Unit tests for response size limiting functionality."""
 
-import asyncio
 import os
-import tempfile
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-import aiohttp
-from aiohttp import ClientResponse
-import ssl
-
+import tempfile
+from mcp_server_opensearch.clusters_information import ClusterInfo
 from opensearch.client import (
     ConfigurationError,
     _create_opensearch_client,
 )
 from opensearch.connection import (
     DEFAULT_MAX_RESPONSE_SIZE,
-)
-from opensearch.connection import (
     BufferedAsyncHttpConnection,
     ResponseSizeExceededError,
 )
-from mcp_server_opensearch.clusters_information import ClusterInfo
+from unittest.mock import MagicMock, patch
 
 
 class TestBufferedAsyncHttpConnection:
@@ -33,12 +24,8 @@ class TestBufferedAsyncHttpConnection:
 
     def test_init_default_max_response_size(self):
         """Test initialization with default max_response_size (None - no limit)."""
-        connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False
-        )
-        
+        connection = BufferedAsyncHttpConnection(host='localhost', port=9200, use_ssl=False)
+
         assert connection.max_response_size == DEFAULT_MAX_RESPONSE_SIZE
         assert connection.max_response_size is None  # No limit by default
         assert connection.host == 'http://localhost:9200'
@@ -47,34 +34,29 @@ class TestBufferedAsyncHttpConnection:
         """Test initialization with custom max_response_size."""
         custom_size = 5 * 1024 * 1024  # 5MB
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False,
-            max_response_size=custom_size
+            host='localhost', port=9200, use_ssl=False, max_response_size=custom_size
         )
-        
+
         assert connection.max_response_size == custom_size
 
     @pytest.mark.asyncio
     async def test_perform_request_fallback_to_parent(self):
         """Test that perform_request falls back to parent implementation on error."""
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False,
-            max_response_size=1024
+            host='localhost', port=9200, use_ssl=False, max_response_size=1024
         )
-        
+
         # Mock parent class perform_request to return a successful response
         with patch.object(connection.__class__.__bases__[0], 'perform_request') as mock_parent:
-            mock_parent.return_value = (200, {'content-type': 'application/json'}, '{"status": "ok"}')
-            
-            # The streaming implementation will fail and fall back to parent
-            status, headers, data = await connection.perform_request(
-                method='GET',
-                url='/test'
+            mock_parent.return_value = (
+                200,
+                {'content-type': 'application/json'},
+                '{"status": "ok"}',
             )
-            
+
+            # The streaming implementation will fail and fall back to parent
+            status, headers, data = await connection.perform_request(method='GET', url='/test')
+
             assert status == 200
             assert data == '{"status": "ok"}'  # Should be string, not bytes
             mock_parent.assert_called_once()
@@ -89,14 +71,14 @@ class TestBufferedAsyncHttpConnection:
             assert isinstance(decoded, str)
         except UnicodeDecodeError:
             # Should not happen for valid UTF-8
-            assert False, "Valid UTF-8 should decode successfully"
-        
+            assert False, 'Valid UTF-8 should decode successfully'
+
         # Test binary data handling
         binary_data = b'\x89PNG\r\n\x1a\n'  # PNG header
         try:
             decoded = binary_data.decode('utf-8')
             # Should not reach here for binary data
-            assert False, "Binary data should not decode as UTF-8"
+            assert False, 'Binary data should not decode as UTF-8'
         except UnicodeDecodeError:
             # This is expected for binary data
             assert isinstance(binary_data, bytes)
@@ -105,27 +87,24 @@ class TestBufferedAsyncHttpConnection:
         """Test creating ResponseSizeExceededError with proper message."""
         max_size = 50
         actual_size = 100
-        
+
         error = ResponseSizeExceededError(
-            f"Response size exceeded limit of {max_size} bytes. "
-            f"Stopped reading at {actual_size} bytes to prevent memory exhaustion. "
-            f"Consider increasing max_response_size or refining your query to return less data."
+            f'Response size exceeded limit of {max_size} bytes. '
+            f'Stopped reading at {actual_size} bytes to prevent memory exhaustion. '
+            f'Consider increasing max_response_size or refining your query to return less data.'
         )
-        
+
         error_msg = str(error)
-        assert "Response size exceeded limit of 50 bytes" in error_msg
-        assert "Stopped reading at 100 bytes" in error_msg
-        assert "prevent memory exhaustion" in error_msg
+        assert 'Response size exceeded limit of 50 bytes' in error_msg
+        assert 'Stopped reading at 100 bytes' in error_msg
+        assert 'prevent memory exhaustion' in error_msg
 
     def test_connection_attributes(self):
         """Test that connection has proper attributes set."""
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False,
-            max_response_size=2048
+            host='localhost', port=9200, use_ssl=False, max_response_size=2048
         )
-        
+
         assert connection.max_response_size == 2048
         assert connection.host == 'http://localhost:9200'
         assert hasattr(connection, 'perform_request')
@@ -133,13 +112,9 @@ class TestBufferedAsyncHttpConnection:
     def test_ssl_connection_attributes(self):
         """Test SSL connection configuration."""
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9443,
-            use_ssl=True,
-            verify_certs=True,
-            max_response_size=1024
+            host='localhost', port=9443, use_ssl=True, verify_certs=True, max_response_size=1024
         )
-        
+
         assert connection.max_response_size == 1024
         assert connection.host == 'https://localhost:9443'
         # Test that SSL attributes are accessible
@@ -149,13 +124,9 @@ class TestBufferedAsyncHttpConnection:
     def test_no_ssl_verification_attributes(self):
         """Test connection with SSL verification disabled."""
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9443,
-            use_ssl=True,
-            verify_certs=False,
-            max_response_size=1024
+            host='localhost', port=9443, use_ssl=True, verify_certs=False, max_response_size=1024
         )
-        
+
         assert connection.max_response_size == 1024
         assert getattr(connection, 'use_ssl', True) is True
         # Test that the connection was created successfully with SSL disabled verification
@@ -164,19 +135,16 @@ class TestBufferedAsyncHttpConnection:
     def test_url_construction_with_params(self):
         """Test URL construction with parameters."""
         from urllib.parse import urlencode
-        
+
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False,
-            max_response_size=1024
+            host='localhost', port=9200, use_ssl=False, max_response_size=1024
         )
-        
+
         # Test URL construction logic (similar to what perform_request does)
         base_url = connection.host + '/test'
         params = {'q': 'search term', 'size': 10}
-        full_url = f"{base_url}?{urlencode(params)}"
-        
+        full_url = f'{base_url}?{urlencode(params)}'
+
         assert 'http://localhost:9200/test' in full_url
         assert 'q=search+term' in full_url or 'q=search%20term' in full_url
         assert 'size=10' in full_url
@@ -184,14 +152,11 @@ class TestBufferedAsyncHttpConnection:
     def test_inheritance_structure(self):
         """Test that BufferedAsyncHttpConnection properly inherits from AsyncHttpConnection."""
         from opensearchpy import AsyncHttpConnection
-        
+
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False,
-            max_response_size=1024
+            host='localhost', port=9200, use_ssl=False, max_response_size=1024
         )
-        
+
         assert isinstance(connection, AsyncHttpConnection)
         assert hasattr(connection, 'max_response_size')
         assert connection.max_response_size == 1024
@@ -205,17 +170,17 @@ class TestCreateOpenSearchClient:
         """Test client creation with max_response_size parameter."""
         mock_client = MagicMock()
         mock_opensearch.return_value = mock_client
-        
-        client = _create_opensearch_client(
+
+        _create_opensearch_client(
             opensearch_url='https://localhost:9200',
             opensearch_no_auth=True,  # Use no auth to avoid authentication complexity
-            max_response_size=5242880  # 5MB
+            max_response_size=5242880,  # 5MB
         )
-        
+
         # Verify AsyncOpenSearch was called with our custom connection class and max_response_size
         mock_opensearch.assert_called_once()
         call_kwargs = mock_opensearch.call_args[1]
-        
+
         assert call_kwargs['connection_class'] == BufferedAsyncHttpConnection
         assert call_kwargs['max_response_size'] == 5242880
         assert call_kwargs['hosts'] == ['https://localhost:9200']
@@ -225,16 +190,16 @@ class TestCreateOpenSearchClient:
         """Test client creation with default max_response_size."""
         mock_client = MagicMock()
         mock_opensearch.return_value = mock_client
-        
-        client = _create_opensearch_client(
+
+        _create_opensearch_client(
             opensearch_url='https://localhost:9200',
-            opensearch_no_auth=True  # Use no auth to avoid authentication complexity
+            opensearch_no_auth=True,  # Use no auth to avoid authentication complexity
         )
-        
+
         # Verify default max_response_size is used
         mock_opensearch.assert_called_once()
         call_kwargs = mock_opensearch.call_args[1]
-        
+
         assert call_kwargs['max_response_size'] == DEFAULT_MAX_RESPONSE_SIZE
 
     @patch('opensearch.client.AsyncOpenSearch')
@@ -242,19 +207,19 @@ class TestCreateOpenSearchClient:
         """Test client creation with all parameters including max_response_size."""
         mock_client = MagicMock()
         mock_opensearch.return_value = mock_client
-        
-        client = _create_opensearch_client(
+
+        _create_opensearch_client(
             opensearch_url='https://test.com:9200',
             opensearch_username='user',
             opensearch_password='pass',
             opensearch_timeout=60,
             ssl_verify=False,
-            max_response_size=1048576  # 1MB
+            max_response_size=1048576,  # 1MB
         )
-        
+
         mock_opensearch.assert_called_once()
         call_kwargs = mock_opensearch.call_args[1]
-        
+
         assert call_kwargs['connection_class'] == BufferedAsyncHttpConnection
         assert call_kwargs['max_response_size'] == 1048576
         assert call_kwargs['timeout'] == 60
@@ -320,18 +285,16 @@ class TestClusterInfoMaxResponseSize:
         """Test ClusterInfo creation with max_response_size."""
         cluster_info = ClusterInfo(
             opensearch_url='https://test.com:9200',
-            max_response_size=2097152  # 2MB
+            max_response_size=2097152,  # 2MB
         )
-        
+
         assert cluster_info.opensearch_url == 'https://test.com:9200'
         assert cluster_info.max_response_size == 2097152
 
     def test_cluster_info_without_max_response_size(self):
         """Test ClusterInfo creation without max_response_size (should be None)."""
-        cluster_info = ClusterInfo(
-            opensearch_url='https://test.com:9200'
-        )
-        
+        cluster_info = ClusterInfo(opensearch_url='https://test.com:9200')
+
         assert cluster_info.opensearch_url == 'https://test.com:9200'
         assert cluster_info.max_response_size is None
 
@@ -343,9 +306,9 @@ class TestClusterInfoMaxResponseSize:
             opensearch_password='password',
             timeout=30,
             ssl_verify=True,
-            max_response_size=5242880  # 5MB
+            max_response_size=5242880,  # 5MB
         )
-        
+
         assert cluster_info.opensearch_url == 'https://test.com:9200'
         assert cluster_info.opensearch_username == 'admin'
         assert cluster_info.opensearch_password == 'password'
@@ -359,17 +322,17 @@ class TestResponseSizeExceededError:
 
     def test_exception_creation(self):
         """Test creating ResponseSizeExceededError."""
-        error = ResponseSizeExceededError("Test error message")
-        
-        assert str(error) == "Test error message"
+        error = ResponseSizeExceededError('Test error message')
+
+        assert str(error) == 'Test error message'
         assert isinstance(error, Exception)
 
     def test_exception_inheritance(self):
         """Test that ResponseSizeExceededError inherits from OpenSearchClientError."""
         from opensearch.client import OpenSearchClientError
-        
-        error = ResponseSizeExceededError("Test error")
-        
+
+        error = ResponseSizeExceededError('Test error')
+
         assert isinstance(error, OpenSearchClientError)
         assert isinstance(error, Exception)
 
@@ -377,19 +340,19 @@ class TestResponseSizeExceededError:
         """Test exception with detailed message format."""
         max_size = 1024
         actual_size = 2048
-        
+
         message = (
-            f"Response size exceeded limit of {max_size} bytes. "
-            f"Stopped reading at {actual_size} bytes to prevent memory exhaustion. "
-            f"Consider increasing max_response_size or refining your query to return less data."
+            f'Response size exceeded limit of {max_size} bytes. '
+            f'Stopped reading at {actual_size} bytes to prevent memory exhaustion. '
+            f'Consider increasing max_response_size or refining your query to return less data.'
         )
-        
+
         error = ResponseSizeExceededError(message)
-        
-        assert "exceeded limit of 1024 bytes" in str(error)
-        assert "Stopped reading at 2048 bytes" in str(error)
-        assert "prevent memory exhaustion" in str(error)
-        assert "Consider increasing max_response_size" in str(error)
+
+        assert 'exceeded limit of 1024 bytes' in str(error)
+        assert 'Stopped reading at 2048 bytes' in str(error)
+        assert 'prevent memory exhaustion' in str(error)
+        assert 'Consider increasing max_response_size' in str(error)
 
 
 class TestIntegrationScenarios:
@@ -401,14 +364,14 @@ class TestIntegrationScenarios:
         max_size = 100
         chunk1_size = 50
         chunk2_size = 60  # This would exceed the limit
-        
+
         total_size = chunk1_size
         # First chunk is within limit
         assert total_size <= max_size
-        
+
         # Second chunk would exceed limit
         assert total_size + chunk2_size > max_size
-        
+
         # This simulates the logic in perform_request
         would_exceed = (total_size + chunk2_size) > max_size
         assert would_exceed is True
@@ -417,17 +380,17 @@ class TestIntegrationScenarios:
         """Test the chunk processing logic used in streaming."""
         chunks = [b'x' * 30, b'y' * 40, b'z' * 50]  # 30, 40, 50 bytes
         max_size = 100
-        
+
         processed_chunks = []
         total_size = 0
-        
+
         for chunk in chunks:
             if total_size + len(chunk) > max_size:
                 # This simulates stopping when limit would be exceeded
                 break
             processed_chunks.append(chunk)
             total_size += len(chunk)
-        
+
         # Should process first two chunks (70 bytes total)
         assert len(processed_chunks) == 2
         assert total_size == 70
@@ -437,14 +400,11 @@ class TestIntegrationScenarios:
         """Test behavior with very large limits."""
         large_limit = 100 * 1024 * 1024  # 100MB
         connection = BufferedAsyncHttpConnection(
-            host='localhost',
-            port=9200,
-            use_ssl=False,
-            max_response_size=large_limit
+            host='localhost', port=9200, use_ssl=False, max_response_size=large_limit
         )
-        
+
         assert connection.max_response_size == large_limit
-        
+
         # Simulate a response much smaller than the limit
         simulated_response_size = 20 * 1024  # 20KB
         assert simulated_response_size < large_limit

--- a/tests/opensearch/test_sigv4_auth.py
+++ b/tests/opensearch/test_sigv4_auth.py
@@ -4,10 +4,9 @@
 """Tests for SigV4 auth callable invocation in BufferedAsyncHttpConnection."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from multidict import CIMultiDict
-
 from opensearch.connection import BufferedAsyncHttpConnection
+from unittest.mock import AsyncMock, MagicMock
 
 
 class AsyncIterChunks:
@@ -71,8 +70,7 @@ class TestSigV4AuthCallable:
 
         auth_mock.assert_called_once()
         kwargs = auth_mock.call_args.kwargs
-        assert kwargs.get('body') is None, \
-            'GET request body must be None, not the query string'
+        assert kwargs.get('body') is None, 'GET request body must be None, not the query string'
 
     @pytest.mark.asyncio
     async def test_post_does_not_pass_body_as_headers(self):
@@ -88,10 +86,12 @@ class TestSigV4AuthCallable:
 
         auth_mock.assert_called_once()
         kwargs = auth_mock.call_args.kwargs
-        assert kwargs.get('body') == body, \
+        assert kwargs.get('body') == body, (
             'POST request body must be passed as body to auth callable'
-        assert isinstance(kwargs.get('headers'), dict), \
+        )
+        assert isinstance(kwargs.get('headers'), dict), (
             'headers param must be a dict, not request body bytes'
+        )
 
     @pytest.mark.asyncio
     async def test_auth_callable_uses_keyword_arguments(self):
@@ -102,5 +102,4 @@ class TestSigV4AuthCallable:
 
         auth_mock.assert_called_once()
         # Should be called with keyword args (no positional args beyond self)
-        assert auth_mock.call_args.kwargs, \
-            'Auth callable must be invoked with keyword arguments'
+        assert auth_mock.call_args.kwargs, 'Auth callable must be invoked with keyword arguments'

--- a/tests/tools/test_agentic_memory_tools.py
+++ b/tests/tools/test_agentic_memory_tools.py
@@ -56,14 +56,15 @@ class TestAgenticMemoryTools:
 
         # Set environment variable for agentic memory tools registration
         import os
+
         os.environ['OPENSEARCH_MEMORY_CONTAINER_ID'] = 'test-container-id'
 
         # Import after patching to ensure fresh imports
         from tools.agentic_memory.actions import (
             add_agentic_memories_tool,
             create_agentic_memory_session_tool,
-            delete_agentic_memory_by_query_tool,
             delete_agentic_memory_by_id_tool,
+            delete_agentic_memory_by_query_tool,
             get_agentic_memory_tool,
             search_agentic_memory_tool,
             update_agentic_memory_tool,
@@ -101,6 +102,7 @@ class TestAgenticMemoryTools:
 
         # Clean up environment variable
         import os
+
         if 'OPENSEARCH_MEMORY_CONTAINER_ID' in os.environ:
             del os.environ['OPENSEARCH_MEMORY_CONTAINER_ID']
 

--- a/tests/tools/test_config.py
+++ b/tests/tools/test_config.py
@@ -6,6 +6,7 @@ import os
 import yaml
 from tools.config import apply_custom_tool_config
 
+
 MOCK_TOOL_REGISTRY = {
     'ListIndexTool': {
         'display_name': 'ListIndexTool',

--- a/tests/tools/test_experiment_tools.py
+++ b/tests/tools/test_experiment_tools.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 
 class TestExperimentTools:
@@ -23,17 +23,18 @@ class TestExperimentTools:
         self.init_client_patcher.start()
 
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]
 
         from tools.tools import (
-            GetExperimentArgs,
             CreateExperimentArgs,
             DeleteExperimentArgs,
-            get_experiment_tool,
+            GetExperimentArgs,
             create_experiment_tool,
             delete_experiment_tool,
+            get_experiment_tool,
         )
 
         self.GetExperimentArgs = GetExperimentArgs
@@ -301,6 +302,7 @@ class TestExperimentTools:
     async def test_experiment_tools_registered_in_registry(self):
         """Test that all experiment tools are registered in the TOOL_REGISTRY."""
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]

--- a/tests/tools/test_generic_tool.py
+++ b/tests/tools/test_generic_tool.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""
-Simple test script for the GenericOpenSearchApiTool
-"""
+"""Simple test script for the GenericOpenSearchApiTool."""
 
 import asyncio
-import sys
 import os
 import pytest
+import sys
+
 
 # Add the src directory to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
@@ -17,7 +16,6 @@ from tools.generic_api_tool import GenericOpenSearchApiArgs, generic_opensearch_
 @pytest.mark.asyncio
 async def test_generic_tool():
     """Test the generic OpenSearch API tool with a simple cluster health check."""
-
     # Test 1: Simple cluster health check
     print('Test 1: Cluster Health Check')
     args = GenericOpenSearchApiArgs(

--- a/tests/tools/test_judgment_tool_evals.py
+++ b/tests/tools/test_judgment_tool_evals.py
@@ -1,10 +1,10 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-import pytest
 import anthropic
-from unittest.mock import patch, Mock, AsyncMock
+import pytest
+import sys
+from unittest.mock import AsyncMock, Mock, patch
 
 
 JUDGMENT_CREATE_TOOLS = [
@@ -59,7 +59,7 @@ class TestJudgmentToolRouting:
     def test_selects_import_tool_for_manual_ratings(self):
         """When a user has manually annotated ratings, the agent should use CreateJudgmentListTool."""
         tool_use = self.ask_agent(
-            "I have manually graded search results and want to store them as a judgment list "
+            'I have manually graded search results and want to store them as a judgment list '
             "called 'manual-judgments'. Here are my ratings: "
             '[{"query": "laptop", "ratings": [{"docId": "doc1", "rating": 3}, {"docId": "doc2", "rating": 1}]}]'
         )

--- a/tests/tools/test_judgment_tools.py
+++ b/tests/tools/test_judgment_tools.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 
 class TestJudgmentTools:
@@ -23,21 +23,22 @@ class TestJudgmentTools:
         self.init_client_patcher.start()
 
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]
 
         from tools.tools import (
-            GetJudgmentListArgs,
             CreateJudgmentListArgs,
             CreateLLMJudgmentListArgs,
             CreateUBIJudgmentListArgs,
             DeleteJudgmentListArgs,
-            get_judgment_list_tool,
+            GetJudgmentListArgs,
             create_judgment_list_tool,
             create_llm_judgment_list_tool,
             create_ubi_judgment_list_tool,
             delete_judgment_list_tool,
+            get_judgment_list_tool,
         )
 
         self.GetJudgmentListArgs = GetJudgmentListArgs
@@ -64,7 +65,9 @@ class TestJudgmentTools:
             '_source': {
                 'name': 'my-judgments',
                 'type': 'IMPORT_JUDGMENT',
-                'judgmentRatings': [{'query': 'laptop', 'ratings': [{'docId': 'doc1', 'rating': 3}]}],
+                'judgmentRatings': [
+                    {'query': 'laptop', 'ratings': [{'docId': 'doc1', 'rating': 3}]}
+                ],
             },
         }
         self.mock_client.plugins.search_relevance.get_judgments.return_value = mock_response
@@ -379,6 +382,7 @@ class TestJudgmentTools:
     async def test_judgment_tools_registered_in_registry(self):
         """Test that all judgment tools are registered in the TOOL_REGISTRY."""
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]
@@ -391,7 +395,13 @@ class TestJudgmentTools:
         assert 'CreateLLMJudgmentListTool' in TOOL_REGISTRY
         assert 'DeleteJudgmentListTool' in TOOL_REGISTRY
 
-        for tool_name in ['GetJudgmentListTool', 'CreateJudgmentListTool', 'CreateUBIJudgmentListTool', 'CreateLLMJudgmentListTool', 'DeleteJudgmentListTool']:
+        for tool_name in [
+            'GetJudgmentListTool',
+            'CreateJudgmentListTool',
+            'CreateUBIJudgmentListTool',
+            'CreateLLMJudgmentListTool',
+            'DeleteJudgmentListTool',
+        ]:
             tool = TOOL_REGISTRY[tool_name]
             assert 'description' in tool
             assert 'input_schema' in tool

--- a/tests/tools/test_memory_tools.py
+++ b/tests/tools/test_memory_tools.py
@@ -277,9 +277,7 @@ class TestSearchMemoryTool:
         """Create a mock OpenSearch client for search tests."""
         mock_client = AsyncMock()
         mock_client.indices.exists.return_value = index_exists
-        mock_client.search.return_value = search_response or {
-            'hits': {'hits': []}
-        }
+        mock_client.search.return_value = search_response or {'hits': {'hits': []}}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
         return mock_client
@@ -287,21 +285,23 @@ class TestSearchMemoryTool:
     @pytest.mark.asyncio
     async def test_search_semantic_query(self):
         """Test semantic search wraps query in script_score."""
-        mock_client = self._make_mock_client({
-            'hits': {
-                'hits': [
-                    {
-                        '_id': 'hit-1',
-                        '_score': 5.0,
-                        '_source': {
-                            'memory_text': 'User likes dark mode',
-                            'created_at': '2026-04-15T10:00:00+00:00',
-                            'user_id': 'alice',
-                        },
-                    }
-                ]
+        mock_client = self._make_mock_client(
+            {
+                'hits': {
+                    'hits': [
+                        {
+                            '_id': 'hit-1',
+                            '_score': 5.0,
+                            '_source': {
+                                'memory_text': 'User likes dark mode',
+                                'created_at': '2026-04-15T10:00:00+00:00',
+                                'user_id': 'alice',
+                            },
+                        }
+                    ]
+                }
             }
-        })
+        )
 
         args = self.SearchMemoryArgs(
             query='dark mode preference',
@@ -326,20 +326,22 @@ class TestSearchMemoryTool:
     @pytest.mark.asyncio
     async def test_search_list_all_no_script_score(self):
         """Test that * query uses match_all without script_score."""
-        mock_client = self._make_mock_client({
-            'hits': {
-                'hits': [
-                    {
-                        '_id': 'hit-1',
-                        '_score': 1.0,
-                        '_source': {
-                            'memory_text': 'Some memory',
-                            'created_at': '2026-04-15T10:00:00+00:00',
-                        },
-                    }
-                ]
+        mock_client = self._make_mock_client(
+            {
+                'hits': {
+                    'hits': [
+                        {
+                            '_id': 'hit-1',
+                            '_score': 1.0,
+                            '_source': {
+                                'memory_text': 'Some memory',
+                                'created_at': '2026-04-15T10:00:00+00:00',
+                            },
+                        }
+                    ]
+                }
             }
-        })
+        )
 
         args = self.SearchMemoryArgs(
             query='*',
@@ -360,9 +362,7 @@ class TestSearchMemoryTool:
     @pytest.mark.asyncio
     async def test_search_empty_query_treated_as_list_all(self):
         """Test that empty string query is treated as list-all."""
-        mock_client = self._make_mock_client({
-            'hits': {'hits': []}
-        })
+        mock_client = self._make_mock_client({'hits': {'hits': []}})
 
         args = self.SearchMemoryArgs(
             query='  ',
@@ -477,24 +477,26 @@ class TestSearchMemoryTool:
     @pytest.mark.asyncio
     async def test_search_result_formatting(self):
         """Test that search results include all expected fields."""
-        mock_client = self._make_mock_client({
-            'hits': {
-                'hits': [
-                    {
-                        '_id': 'mem-1',
-                        '_score': 8.5,
-                        '_source': {
-                            'memory_text': 'Project uses pytest',
-                            'created_at': '2026-04-15T10:00:00+00:00',
-                            'user_id': 'alice',
-                            'agent_id': 'kiro',
-                            'session_id': 'sess-1',
-                            'tags': ['project', 'testing'],
-                        },
-                    }
-                ]
+        mock_client = self._make_mock_client(
+            {
+                'hits': {
+                    'hits': [
+                        {
+                            '_id': 'mem-1',
+                            '_score': 8.5,
+                            '_source': {
+                                'memory_text': 'Project uses pytest',
+                                'created_at': '2026-04-15T10:00:00+00:00',
+                                'user_id': 'alice',
+                                'agent_id': 'kiro',
+                                'session_id': 'sess-1',
+                                'tags': ['project', 'testing'],
+                            },
+                        }
+                    ]
+                }
             }
-        })
+        )
 
         args = self.SearchMemoryArgs(
             query='pytest',
@@ -657,7 +659,10 @@ class TestHelperFunctions:
         from tools.memory_tools import _get_collection_id_from_url
 
         with patch.dict(os.environ, {'AWS_OPENSEARCH_COLLECTION_ID': 'override-id'}):
-            assert _get_collection_id_from_url('https://abc.us-east-1.aoss.amazonaws.com') == 'override-id'
+            assert (
+                _get_collection_id_from_url('https://abc.us-east-1.aoss.amazonaws.com')
+                == 'override-id'
+            )
 
     def test_get_domain_name_from_url(self):
         """Test domain name extraction from managed domain URL."""

--- a/tests/tools/test_query_set_tools.py
+++ b/tests/tools/test_query_set_tools.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 
 class TestQuerySetTools:
@@ -24,19 +24,20 @@ class TestQuerySetTools:
         self.init_client_patcher.start()
 
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]
 
         from tools.tools import (
-            GetQuerySetArgs,
             CreateQuerySetArgs,
-            SampleQuerySetArgs,
             DeleteQuerySetArgs,
-            get_query_set_tool,
+            GetQuerySetArgs,
+            SampleQuerySetArgs,
             create_query_set_tool,
-            sample_query_set_tool,
             delete_query_set_tool,
+            get_query_set_tool,
+            sample_query_set_tool,
         )
 
         self.GetQuerySetArgs = GetQuerySetArgs
@@ -307,6 +308,7 @@ class TestQuerySetTools:
     async def test_query_set_tools_registered_in_registry(self):
         """Test that all query set tools are registered in the TOOL_REGISTRY."""
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]
@@ -318,7 +320,12 @@ class TestQuerySetTools:
         assert 'SampleQuerySetTool' in TOOL_REGISTRY
         assert 'DeleteQuerySetTool' in TOOL_REGISTRY
 
-        for tool_name in ['GetQuerySetTool', 'CreateQuerySetTool', 'SampleQuerySetTool', 'DeleteQuerySetTool']:
+        for tool_name in [
+            'GetQuerySetTool',
+            'CreateQuerySetTool',
+            'SampleQuerySetTool',
+            'DeleteQuerySetTool',
+        ]:
             tool = TOOL_REGISTRY[tool_name]
             assert 'description' in tool
             assert 'input_schema' in tool

--- a/tests/tools/test_skills_tools.py
+++ b/tests/tools/test_skills_tools.py
@@ -1,11 +1,9 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import pytest
 import sys
-from unittest.mock import Mock, patch
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 
 class TestSkillsTools:
@@ -13,7 +11,7 @@ class TestSkillsTools:
         """Setup that runs before each test method."""
         # Create a properly configured mock client
         self.mock_client = Mock()
-        
+
         # Configure mock client methods to return proper data structures
         # Use AsyncMock for async methods
         self.mock_client.transport.perform_request = AsyncMock(return_value={})
@@ -38,9 +36,9 @@ class TestSkillsTools:
             SKILLS_TOOLS_REGISTRY,
             DataDistributionToolArgs,
             LogPatternAnalysisToolArgs,
+            call_opensearch_tool,
             data_distribution_tool,
             log_pattern_analysis_tool,
-            call_opensearch_tool,
         )
 
         self.SKILLS_TOOLS_REGISTRY = SKILLS_TOOLS_REGISTRY
@@ -58,23 +56,22 @@ class TestSkillsTools:
     async def test_call_opensearch_tool_success(self):
         """Test call_opensearch_tool successful execution."""
         # Setup
-        mock_response = {
-            'status': 'success',
-            'result': {'analysis': 'data distribution complete'}
-        }
+        mock_response = {'status': 'success', 'result': {'analysis': 'data distribution complete'}}
         self.mock_client.transport.perform_request.return_value = mock_response
-        
+
         args = self.DataDistributionToolArgs(
             index='test-index',
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
-        
+
         # Execute
-        result = await self._call_opensearch_tool('DataDistributionTool', {'index': 'test-index'}, args)
-        
+        result = await self._call_opensearch_tool(
+            'DataDistributionTool', {'index': 'test-index'}, args
+        )
+
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
@@ -83,7 +80,7 @@ class TestSkillsTools:
         self.mock_client.transport.perform_request.assert_called_once_with(
             'POST',
             '/_plugins/_ml/tools/_execute/DataDistributionTool',
-            body={'parameters': {'index': 'test-index'}}
+            body={'parameters': {'index': 'test-index'}},
         )
 
     @pytest.mark.asyncio
@@ -91,18 +88,20 @@ class TestSkillsTools:
         """Test call_opensearch_tool exception handling."""
         # Setup
         self.mock_client.transport.perform_request.side_effect = Exception('Test error')
-        
+
         args = self.DataDistributionToolArgs(
             index='test-index',
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
-        
+
         # Execute
-        result = await self._call_opensearch_tool('DataDistributionTool', {'index': 'test-index'}, args)
-        
+        result = await self._call_opensearch_tool(
+            'DataDistributionTool', {'index': 'test-index'}, args
+        )
+
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
@@ -114,38 +113,38 @@ class TestSkillsTools:
         # Setup
         mock_response = {
             'status': 'success',
-            'result': {'field_distributions': {'field1': {'count': 100}}}
+            'result': {'field_distributions': {'field1': {'count': 100}}},
         }
         self.mock_client.transport.perform_request.return_value = mock_response
-        
+
         args = self.DataDistributionToolArgs(
             index='test-index',
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
-        
+
         # Execute
         result = await self._data_distribution_tool(args)
-        
+
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'DataDistributionTool result:' in result[0]['text']
-        
+
         # Verify the correct parameters were passed
         expected_params = {
             'index': 'test-index',
             'timeField': '@timestamp',
             'selectionTimeRangeStart': '2023-01-01T00:00:00Z',
             'selectionTimeRangeEnd': '2023-01-02T00:00:00Z',
-            'size': 1000
+            'size': 1000,
         }
         self.mock_client.transport.perform_request.assert_called_once_with(
             'POST',
             '/_plugins/_ml/tools/_execute/DataDistributionTool',
-            body={'parameters': expected_params}
+            body={'parameters': expected_params},
         )
 
     @pytest.mark.asyncio
@@ -154,7 +153,7 @@ class TestSkillsTools:
         # Setup
         mock_response = {'status': 'success', 'result': {}}
         self.mock_client.transport.perform_request.return_value = mock_response
-        
+
         args = self.DataDistributionToolArgs(
             index='test-index',
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
@@ -163,12 +162,12 @@ class TestSkillsTools:
             baselineTimeRangeStart='2022-12-01T00:00:00Z',
             baselineTimeRangeEnd='2022-12-02T00:00:00Z',
             size=500,
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
-        
+
         # Execute
-        result = await self._data_distribution_tool(args)
-        
+        await self._data_distribution_tool(args)
+
         # Assert
         expected_params = {
             'index': 'test-index',
@@ -177,12 +176,12 @@ class TestSkillsTools:
             'selectionTimeRangeEnd': '2023-01-02T00:00:00Z',
             'size': 500,
             'baselineTimeRangeStart': '2022-12-01T00:00:00Z',
-            'baselineTimeRangeEnd': '2022-12-02T00:00:00Z'
+            'baselineTimeRangeEnd': '2022-12-02T00:00:00Z',
         }
         self.mock_client.transport.perform_request.assert_called_once_with(
             'POST',
             '/_plugins/_ml/tools/_execute/DataDistributionTool',
-            body={'parameters': expected_params}
+            body={'parameters': expected_params},
         )
 
     @pytest.mark.asyncio
@@ -191,38 +190,38 @@ class TestSkillsTools:
         # Setup
         mock_response = {
             'status': 'success',
-            'result': {'patterns': [{'pattern': 'ERROR', 'count': 10}]}
+            'result': {'patterns': [{'pattern': 'ERROR', 'count': 10}]},
         }
         self.mock_client.transport.perform_request.return_value = mock_response
-        
+
         args = self.LogPatternAnalysisToolArgs(
             index='logs-index',
             logFieldName='message',
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
-        
+
         # Execute
         result = await self._log_pattern_analysis_tool(args)
-        
+
         # Assert
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'LogPatternAnalysisTool result:' in result[0]['text']
-        
+
         expected_params = {
             'index': 'logs-index',
             'timeField': '@timestamp',
             'logFieldName': 'message',
             'selectionTimeRangeStart': '2023-01-01T00:00:00Z',
-            'selectionTimeRangeEnd': '2023-01-02T00:00:00Z'
+            'selectionTimeRangeEnd': '2023-01-02T00:00:00Z',
         }
         self.mock_client.transport.perform_request.assert_called_once_with(
             'POST',
             '/_plugins/_ml/tools/_execute/LogPatternAnalysisTool',
-            body={'parameters': expected_params}
+            body={'parameters': expected_params},
         )
 
     @pytest.mark.asyncio
@@ -231,7 +230,7 @@ class TestSkillsTools:
         # Setup
         mock_response = {'status': 'success', 'result': {}}
         self.mock_client.transport.perform_request.return_value = mock_response
-        
+
         args = self.LogPatternAnalysisToolArgs(
             index='logs-index',
             logFieldName='message',
@@ -241,12 +240,12 @@ class TestSkillsTools:
             traceFieldName='trace_id',
             baseTimeRangeStart='2022-12-01T00:00:00Z',
             baseTimeRangeEnd='2022-12-02T00:00:00Z',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
-        
+
         # Execute
-        result = await self._log_pattern_analysis_tool(args)
-        
+        await self._log_pattern_analysis_tool(args)
+
         # Assert
         expected_params = {
             'index': 'logs-index',
@@ -256,12 +255,12 @@ class TestSkillsTools:
             'selectionTimeRangeEnd': '2023-01-02T00:00:00Z',
             'traceFieldName': 'trace_id',
             'baseTimeRangeStart': '2022-12-01T00:00:00Z',
-            'baseTimeRangeEnd': '2022-12-02T00:00:00Z'
+            'baseTimeRangeEnd': '2022-12-02T00:00:00Z',
         }
         self.mock_client.transport.perform_request.assert_called_once_with(
             'POST',
             '/_plugins/_ml/tools/_execute/LogPatternAnalysisTool',
-            body={'parameters': expected_params}
+            body={'parameters': expected_params},
         )
 
     def test_skills_tools_registry(self):
@@ -289,7 +288,7 @@ class TestSkillsTools:
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
         assert args.index == 'test-index'
         assert args.timeField == '@timestamp'
@@ -302,7 +301,7 @@ class TestSkillsTools:
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
             size=500,
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
         assert args_custom.size == 500
 
@@ -315,7 +314,7 @@ class TestSkillsTools:
             selectionTimeRangeStart='2023-01-01T00:00:00Z',
             selectionTimeRangeEnd='2023-01-02T00:00:00Z',
             timeField='@timestamp',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
         assert args.index == 'logs-index'
         assert args.logFieldName == 'message'
@@ -332,7 +331,7 @@ class TestSkillsTools:
             traceFieldName='trace_id',
             baseTimeRangeStart='2022-12-01T00:00:00Z',
             baseTimeRangeEnd='2022-12-02T00:00:00Z',
-            opensearch_cluster_name=''
+            opensearch_cluster_name='',
         )
         assert args_full.traceFieldName == 'trace_id'
         assert args_full.baseTimeRangeStart == '2022-12-01T00:00:00Z'
@@ -343,6 +342,6 @@ class TestSkillsTools:
         with pytest.raises(ValueError):
             self.DataDistributionToolArgs(opensearch_cluster_name='')  # Missing required fields
 
-        # Test LogPatternAnalysisToolArgs - should fail without required fields  
+        # Test LogPatternAnalysisToolArgs - should fail without required fields
         with pytest.raises(ValueError):
             self.LogPatternAnalysisToolArgs(opensearch_cluster_name='')  # Missing required fields

--- a/tests/tools/test_srw_search_tools.py
+++ b/tests/tools/test_srw_search_tools.py
@@ -3,7 +3,7 @@
 
 import json
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 
 class TestSRWSearchTools:
@@ -20,19 +20,20 @@ class TestSRWSearchTools:
         self.init_client_patcher.start()
 
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]
 
         from tools.tools import (
+            SearchExperimentsArgs,
+            SearchJudgmentsArgs,
             SearchQuerySetsArgs,
             SearchSearchConfigurationsArgs,
-            SearchJudgmentsArgs,
-            SearchExperimentsArgs,
+            search_experiments_tool,
+            search_judgments_tool,
             search_query_sets_tool,
             search_search_configurations_tool,
-            search_judgments_tool,
-            search_experiments_tool,
         )
 
         self.SearchQuerySetsArgs = SearchQuerySetsArgs
@@ -120,7 +121,10 @@ class TestSRWSearchTools:
         assert 'Search configuration search results' in result[0]['text']
 
         call_kwargs = self.mock_client.transport.perform_request.call_args
-        assert call_kwargs.kwargs['url'] == '/_plugins/_search_relevance/search_configurations/_search'
+        assert (
+            call_kwargs.kwargs['url']
+            == '/_plugins/_search_relevance/search_configurations/_search'
+        )
         body = json.loads(call_kwargs.kwargs['body'])
         assert body == {'query': {'match_all': {}}}
 
@@ -131,7 +135,7 @@ class TestSRWSearchTools:
         self.mock_client.transport.perform_request.return_value = mock_response
 
         query_body = {'query': {'match': {'name': 'bm25'}}, 'size': 10}
-        result = await self._search_search_configurations_tool(
+        await self._search_search_configurations_tool(
             self.SearchSearchConfigurationsArgs(opensearch_cluster_name='', query_body=query_body)
         )
 
@@ -179,7 +183,7 @@ class TestSRWSearchTools:
         self.mock_client.transport.perform_request.return_value = mock_response
 
         query_body = {'query': {'match': {'name': 'my-judgments'}}}
-        result = await self._search_judgments_tool(
+        await self._search_judgments_tool(
             self.SearchJudgmentsArgs(opensearch_cluster_name='', query_body=query_body)
         )
 
@@ -227,7 +231,7 @@ class TestSRWSearchTools:
         self.mock_client.transport.perform_request.return_value = mock_response
 
         query_body = {'query': {'term': {'type.keyword': 'PAIRWISE_COMPARISON'}}, 'size': 10}
-        result = await self._search_experiments_tool(
+        await self._search_experiments_tool(
             self.SearchExperimentsArgs(opensearch_cluster_name='', query_body=query_body)
         )
 
@@ -253,6 +257,7 @@ class TestSRWSearchTools:
     async def test_srw_search_tools_registered_in_registry(self):
         """Test that all SRW search tools are registered in the TOOL_REGISTRY."""
         import sys
+
         for module in ['tools.tools']:
             if module in sys.modules:
                 del sys.modules[module]

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -165,8 +165,7 @@ class TestGetTools:
         assert 'SearchIndexTool' not in result
         assert 'param1' in result['ListIndexTool']['input_schema']['properties']
         assert (
-            'opensearch_cluster_name'
-            not in result['ListIndexTool']['input_schema']['properties']
+            'opensearch_cluster_name' not in result['ListIndexTool']['input_schema']['properties']
         )
 
     @pytest.mark.asyncio
@@ -237,7 +236,9 @@ class TestGetTools:
         )
 
     @pytest.mark.asyncio
-    async def test_get_tools_skills_tools_version_filtering(self, mock_tool_registry, mock_patches):
+    async def test_get_tools_skills_tools_version_filtering(
+        self, mock_tool_registry, mock_patches
+    ):
         """Test that skills tools are filtered based on version compatibility."""
         mock_get_version, mock_is_compatible = mock_patches
 
@@ -262,9 +263,13 @@ class TestGetTools:
         assert 'SearchIndexTool' in result
 
     @pytest.mark.asyncio
-    async def test_get_tools_skills_tools_compatible_version(self, mock_tool_registry, mock_patches):
-        """Test that skills tools are excluded by default even when version is compatible,
-        since they belong to the 'skills' category which is not enabled by default."""
+    async def test_get_tools_skills_tools_compatible_version(
+        self, mock_tool_registry, mock_patches
+    ):
+        """Test that skills tools are excluded by default even when version is compatible.
+
+        Since they belong to the 'skills' category which is not enabled by default.
+        """
         mock_get_version, mock_is_compatible = mock_patches
 
         # Setup mocks - simulate OpenSearch 3.5.0 (above skills tools min version 3.3.0)
@@ -362,7 +367,7 @@ class TestProcessToolFilter:
         assert 'ExplainTool' not in self.tool_registry
 
     def test_process_tool_filter_rename_tool(self):
-        """Test processing tool filtering with tool renaming feature"""
+        """Test processing tool filtering with tool renaming feature."""
         process_tool_filter(
             tool_registry=self.tool_registry,
             enabled_tools='ModelListTool',
@@ -383,7 +388,7 @@ class TestProcessToolFilter:
         assert 'ModelListTool' not in self.tool_registry
 
     def test_core_tools_default(self):
-        """Test core tools enabled by default"""
+        """Test core tools enabled by default."""
         process_tool_filter(
             tool_registry=self.tool_registry,
             allow_write=True,
@@ -398,7 +403,7 @@ class TestProcessToolFilter:
         assert 'ListModelTool' not in self.tool_registry
 
     def test_disable_core_tools(self):
-        """Test disable core tools categories, which is enabled by default"""
+        """Test disable core tools categories, which is enabled by default."""
         process_tool_filter(
             tool_registry=self.tool_registry,
             disabled_categories='core_tools',
@@ -411,7 +416,7 @@ class TestProcessToolFilter:
         assert 'ExplainTool' not in self.tool_registry
 
     def test_skills_category_is_not_enabled_by_default(self):
-        """skills tools are not enabled unless the category is explicitly enabled."""
+        """Skills tools are not enabled unless the category is explicitly enabled."""
         registry = {
             'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
             'DataDistributionTool': {
@@ -430,7 +435,7 @@ class TestProcessToolFilter:
         assert 'LogPatternAnalysisTool' not in registry
 
     def test_skills_category_can_be_enabled(self):
-        """skills tools are exposed when the category is explicitly enabled."""
+        """Skills tools are exposed when the category is explicitly enabled."""
         registry = {
             'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
             'DataDistributionTool': {
@@ -494,7 +499,10 @@ class TestProcessToolFilter:
             'SampleQuerySetTool': {'display_name': 'SampleQuerySetTool', 'http_methods': 'POST'},
             'DeleteQuerySetTool': {'display_name': 'DeleteQuerySetTool', 'http_methods': 'DELETE'},
             'GetJudgmentListTool': {'display_name': 'GetJudgmentListTool', 'http_methods': 'GET'},
-            'CreateJudgmentListTool': {'display_name': 'CreateJudgmentListTool', 'http_methods': 'PUT'},
+            'CreateJudgmentListTool': {
+                'display_name': 'CreateJudgmentListTool',
+                'http_methods': 'PUT',
+            },
             'CreateUBIJudgmentListTool': {
                 'display_name': 'CreateUBIJudgmentListTool',
                 'http_methods': 'PUT',
@@ -503,14 +511,35 @@ class TestProcessToolFilter:
                 'display_name': 'CreateLLMJudgmentListTool',
                 'http_methods': 'PUT',
             },
-            'DeleteJudgmentListTool': {'display_name': 'DeleteJudgmentListTool', 'http_methods': 'DELETE'},
+            'DeleteJudgmentListTool': {
+                'display_name': 'DeleteJudgmentListTool',
+                'http_methods': 'DELETE',
+            },
             'GetExperimentTool': {'display_name': 'GetExperimentTool', 'http_methods': 'GET'},
-            'CreateExperimentTool': {'display_name': 'CreateExperimentTool', 'http_methods': 'PUT'},
-            'DeleteExperimentTool': {'display_name': 'DeleteExperimentTool', 'http_methods': 'DELETE'},
-            'SearchQuerySetsTool': {'display_name': 'SearchQuerySetsTool', 'http_methods': 'GET, POST'},
-            'SearchSearchConfigurationsTool': {'display_name': 'SearchSearchConfigurationsTool', 'http_methods': 'GET, POST'},
-            'SearchJudgmentsTool': {'display_name': 'SearchJudgmentsTool', 'http_methods': 'GET, POST'},
-            'SearchExperimentsTool': {'display_name': 'SearchExperimentsTool', 'http_methods': 'GET, POST'},
+            'CreateExperimentTool': {
+                'display_name': 'CreateExperimentTool',
+                'http_methods': 'PUT',
+            },
+            'DeleteExperimentTool': {
+                'display_name': 'DeleteExperimentTool',
+                'http_methods': 'DELETE',
+            },
+            'SearchQuerySetsTool': {
+                'display_name': 'SearchQuerySetsTool',
+                'http_methods': 'GET, POST',
+            },
+            'SearchSearchConfigurationsTool': {
+                'display_name': 'SearchSearchConfigurationsTool',
+                'http_methods': 'GET, POST',
+            },
+            'SearchJudgmentsTool': {
+                'display_name': 'SearchJudgmentsTool',
+                'http_methods': 'GET, POST',
+            },
+            'SearchExperimentsTool': {
+                'display_name': 'SearchExperimentsTool',
+                'http_methods': 'GET, POST',
+            },
         }
         process_tool_filter(tool_registry=registry, allow_write=True)
 
@@ -557,7 +586,10 @@ class TestProcessToolFilter:
             'SampleQuerySetTool': {'display_name': 'SampleQuerySetTool', 'http_methods': 'POST'},
             'DeleteQuerySetTool': {'display_name': 'DeleteQuerySetTool', 'http_methods': 'DELETE'},
             'GetJudgmentListTool': {'display_name': 'GetJudgmentListTool', 'http_methods': 'GET'},
-            'CreateJudgmentListTool': {'display_name': 'CreateJudgmentListTool', 'http_methods': 'PUT'},
+            'CreateJudgmentListTool': {
+                'display_name': 'CreateJudgmentListTool',
+                'http_methods': 'PUT',
+            },
             'CreateUBIJudgmentListTool': {
                 'display_name': 'CreateUBIJudgmentListTool',
                 'http_methods': 'PUT',
@@ -566,14 +598,35 @@ class TestProcessToolFilter:
                 'display_name': 'CreateLLMJudgmentListTool',
                 'http_methods': 'PUT',
             },
-            'DeleteJudgmentListTool': {'display_name': 'DeleteJudgmentListTool', 'http_methods': 'DELETE'},
+            'DeleteJudgmentListTool': {
+                'display_name': 'DeleteJudgmentListTool',
+                'http_methods': 'DELETE',
+            },
             'GetExperimentTool': {'display_name': 'GetExperimentTool', 'http_methods': 'GET'},
-            'CreateExperimentTool': {'display_name': 'CreateExperimentTool', 'http_methods': 'PUT'},
-            'DeleteExperimentTool': {'display_name': 'DeleteExperimentTool', 'http_methods': 'DELETE'},
-            'SearchQuerySetsTool': {'display_name': 'SearchQuerySetsTool', 'http_methods': 'GET, POST'},
-            'SearchSearchConfigurationsTool': {'display_name': 'SearchSearchConfigurationsTool', 'http_methods': 'GET, POST'},
-            'SearchJudgmentsTool': {'display_name': 'SearchJudgmentsTool', 'http_methods': 'GET, POST'},
-            'SearchExperimentsTool': {'display_name': 'SearchExperimentsTool', 'http_methods': 'GET, POST'},
+            'CreateExperimentTool': {
+                'display_name': 'CreateExperimentTool',
+                'http_methods': 'PUT',
+            },
+            'DeleteExperimentTool': {
+                'display_name': 'DeleteExperimentTool',
+                'http_methods': 'DELETE',
+            },
+            'SearchQuerySetsTool': {
+                'display_name': 'SearchQuerySetsTool',
+                'http_methods': 'GET, POST',
+            },
+            'SearchSearchConfigurationsTool': {
+                'display_name': 'SearchSearchConfigurationsTool',
+                'http_methods': 'GET, POST',
+            },
+            'SearchJudgmentsTool': {
+                'display_name': 'SearchJudgmentsTool',
+                'http_methods': 'GET, POST',
+            },
+            'SearchExperimentsTool': {
+                'display_name': 'SearchExperimentsTool',
+                'http_methods': 'GET, POST',
+            },
         }
         process_tool_filter(
             tool_registry=registry,

--- a/tests/tools/test_tool_logging.py
+++ b/tests/tools/test_tool_logging.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import pytest
-
 from tools.tool_logging import log_tool_error
 
 

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -58,40 +58,40 @@ class TestTools:
         # Import after patching to ensure fresh imports
         from tools.tools import (
             TOOL_REGISTRY,
+            CatNodesArgs,
+            CreateSearchConfigurationArgs,
+            DeleteSearchConfigurationArgs,
+            GetAllocationArgs,
+            GetClusterStateArgs,
+            GetIndexInfoArgs,
             GetIndexMappingArgs,
+            GetIndexStatsArgs,
+            GetLongRunningTasksArgs,
+            GetNodesArgs,
+            GetNodesHotThreadsArgs,
+            GetQueryInsightsArgs,
+            GetSearchConfigurationArgs,
+            GetSegmentsArgs,
             GetShardsArgs,
             ListIndicesArgs,
             SearchIndexArgs,
-            GetClusterStateArgs,
-            GetSegmentsArgs,
-            CatNodesArgs,
-            GetNodesArgs,
-            GetIndexInfoArgs,
-            GetIndexStatsArgs,
-            GetQueryInsightsArgs,
-            GetNodesHotThreadsArgs,
-            GetAllocationArgs,
-            GetLongRunningTasksArgs,
-            CreateSearchConfigurationArgs,
-            GetSearchConfigurationArgs,
-            DeleteSearchConfigurationArgs,
+            cat_nodes_tool,
+            create_search_configuration_tool,
+            delete_search_configuration_tool,
+            get_allocation_tool,
+            get_cluster_state_tool,
+            get_index_info_tool,
             get_index_mapping_tool,
+            get_index_stats_tool,
+            get_long_running_tasks_tool,
+            get_nodes_hot_threads_tool,
+            get_nodes_tool,
+            get_query_insights_tool,
+            get_search_configuration_tool,
+            get_segments_tool,
             get_shards_tool,
             list_indices_tool,
             search_index_tool,
-            get_cluster_state_tool,
-            get_segments_tool,
-            cat_nodes_tool,
-            get_nodes_tool,
-            get_index_info_tool,
-            get_index_stats_tool,
-            get_query_insights_tool,
-            get_nodes_hot_threads_tool,
-            get_allocation_tool,
-            get_long_running_tasks_tool,
-            create_search_configuration_tool,
-            get_search_configuration_tool,
-            delete_search_configuration_tool,
         )
 
         self.ListIndicesArgs = ListIndicesArgs
@@ -240,8 +240,7 @@ class TestTools:
         assert '"index1"' in result[0]['text']
         assert '"number_of_shards":"1"' in result[0]['text']
         assert (
-            '"field1":{"type":"text"}' in result[0]['text']
-            or '"type":"text"' in result[0]['text']
+            '"field1":{"type":"text"}' in result[0]['text'] or '"type":"text"' in result[0]['text']
         )
         self.mock_client.indices.get.assert_called_once_with(index='index1')
 
@@ -253,19 +252,17 @@ class TestTools:
             {'index': 'cwl-2024-01', 'health': 'green'},
             {'index': 'cwl-2024-02', 'health': 'green'},
         ]
-        
+
         # Execute - explicitly set include_detail=False with pattern
-        args = self.ListIndicesArgs(
-            index='cwl*', include_detail=False, opensearch_cluster_name=''
-        )
+        args = self.ListIndicesArgs(index='cwl*', include_detail=False, opensearch_cluster_name='')
         result = await self._list_indices_tool(args)
-        
+
         # Assert - should return only the matching index names
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         payload = json.loads(result[0]['text'].split('\n', 1)[1])
         assert payload == ['cwl-2024-01', 'cwl-2024-02']
-        
+
         # cat.indices should be called with the pattern when include_detail=False
         self.mock_client.cat.indices.assert_called_once_with(index='cwl*', format='json')
         self.mock_client.indices.get.assert_not_called()
@@ -689,8 +686,7 @@ class TestTools:
         assert 'Detailed information for index: test-index' in result[0]['text']
         assert '"test-index"' in result[0]['text']
         assert (
-            '"field1":{"type":"text"}' in result[0]['text']
-            or '"type":"text"' in result[0]['text']
+            '"field1":{"type":"text"}' in result[0]['text'] or '"type":"text"' in result[0]['text']
         )
         assert '"number_of_shards":"1"' in result[0]['text']
         self.mock_client.indices.get.assert_called_once_with(index='test-index')
@@ -867,7 +863,7 @@ class TestTools:
         mock_hot_threads = """
 ::: {node1}{xyzdef-1234} {master}
    Hot threads at 2023-04-01T12:00:00Z, interval=500ms, busiestThreads=3, ignoreIdleThreads=true:
-   
+
    0.23% (1.2s out of 500ms) cpu usage by thread 'elasticsearch[node1][search][T#1]'
      10/10 snapshots sharing following 5 elements
        java.lang.Thread.yield(Thread.java:1343)
@@ -1369,7 +1365,7 @@ class TestListClustersTool:
         )
         self.init_client_patcher.start()
 
-        from tools.tools import list_clusters_tool, ListClustersArgs
+        from tools.tools import ListClustersArgs, list_clusters_tool
 
         self._list_clusters_tool = list_clusters_tool
         self.ListClustersArgs = ListClustersArgs

--- a/tests/tools/test_write_protection_simple.py
+++ b/tests/tools/test_write_protection_simple.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""
-Simple test script to verify write protection logic in GenericOpenSearchApiTool
-"""
+"""Simple test script to verify write protection logic in GenericOpenSearchApiTool."""
 
 import os
 import sys
+
 
 # Add the src directory to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
@@ -12,7 +11,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
 def test_write_protection_logic():
     """Test the write protection logic directly."""
-
     print('Testing Write Protection Logic...')
 
     # Save original setting


### PR DESCRIPTION
### Description

Fix all ruff linting issues and add a code quality gate to CI.

**Changes:**
- Replace `from tools.tool_params import *` with explicit imports in `src/opensearch/helper.py`
- Fix docstring formatting (D205) across multiple files
- Fix missing argument descriptions in docstrings (D417)
- Move module-level import to top of file (E402) in `src/tools/tools.py`
- Add missing docstrings (D101/D102/D103/D107) to public classes/methods/functions in `src/`
- Suppress docstring lint rules for `tests/` (matching existing `integration_tests/` config)
- Add `lint` job to CI workflow that runs `ruff format --check .` and `ruff check .`

### Issues Resolved

_N/A — code quality improvement._

### Testing

- All 457 unit tests pass
- `uv run ruff check .` passes
- `uv run ruff format --check .` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).