### PR TITLE
Default streamable HTTP --host to 127.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings
 
+### Changed
+- Default `--host` for the `stream` transport from `0.0.0.0` to `127.0.0.1` so the streamable HTTP listener binds to loopback by default. Operators who need to expose the listener on other interfaces opt in explicitly with `--host 0.0.0.0` ([#253](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/253))
+
 ### Infrastructure
 - Add code quality CI job running `ruff format --check` and `ruff check` on every PR ([#241](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/241))
 - Fix all ruff linting issues: replace star imports with explicit imports, add missing docstrings, fix docstring formatting ([#241](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/241))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -564,7 +564,7 @@ python -m mcp_server_opensearch --mode multi
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--transport` | string | `stdio` | Transport type: `stdio` or `stream` |
-| `--host` | string | `0.0.0.0` | Host to bind to (streaming only) |
+| `--host` | string | `127.0.0.1` | Host to bind to (streaming only). Pass `0.0.0.0` to expose on all interfaces; the listener has no built-in auth, so front it with an authenticating proxy or restrict access via network controls. |
 | `--port` | integer | `9900` | Port to listen on (streaming only) |
 | `--mode` | string | `single` | Server mode: `single` or `multi` |
 | `--profile` | string | `''` | AWS profile to use for OpenSearch connection |

--- a/src/mcp_server_opensearch/__init__.py
+++ b/src/mcp_server_opensearch/__init__.py
@@ -113,7 +113,11 @@ def main() -> None:
         default='stdio',
         help='Transport type (stdio or stream)',
     )
-    parser.add_argument('--host', default='0.0.0.0', help='Host to bind to (streaming only)')
+    parser.add_argument(
+        '--host',
+        default='127.0.0.1',
+        help='Host to bind to (streaming only). Defaults to loopback; pass 0.0.0.0 to expose on all interfaces.',
+    )
     parser.add_argument(
         '--port', type=int, default=9900, help='Port to listen on (streaming only)'
     )

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -156,7 +156,7 @@ class MCPStarletteApp:
 
 
 async def serve(
-    host: str = '0.0.0.0',
+    host: str = '127.0.0.1',
     port: int = 9900,
     mode: str = 'single',
     profile: str = '',


### PR DESCRIPTION
## Summary

- Change default `--host` for the `stream` transport from `0.0.0.0` to `127.0.0.1` so the streamable HTTP listener binds to loopback by default.
- Operators who need to expose the listener on other interfaces opt in explicitly with `--host 0.0.0.0`.
- Update `USER_GUIDE.md` to document the new default and call out that the listener has no built-in inbound auth — operators binding to non-loopback should front it with an authenticating proxy or restrict access via network controls.

## Why

The MCP server's streamable HTTP listener has no built-in client→server authentication. The MCP authorization spec (2025-06-18) makes inbound auth optional, and almost every comparable self-hosted MCP server (official references, `elastic/mcp-server-elasticsearch`, `awslabs/mcp`, etc.) ships none. Defaulting `--host` to `0.0.0.0` means an operator running `opensearch-mcp-server --transport stream` without reading the flags exposes every registered tool on every interface the host can reach.

This matches the posture of `mongodb-js/mongodb-mcp-server`, which binds HTTP to `127.0.0.1` by default and documents that operators must front it with a gateway for production use. The flag itself is unchanged — only the default flips.

## Test plan

- [x] `opensearch-mcp-server --transport stream` binds to `127.0.0.1:9900`
- [x] `opensearch-mcp-server --transport stream --host 0.0.0.0` still binds to all interfaces
- [x] Existing unit + integration tests pass (no test asserts the old default)