### PR TITLE
Add per-category write permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add `User-Agent` header (`opensearch-mcp-server-py/<version>`) to all OpenSearch requests for MCP traffic identification in cluster logs ([#207](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/207))
 - Add new toolset for the OpenSearch Agentic Memory API: `CreateAgenticMemorySessionTool`, `AddAgenticMemoriesTool`, `GetAgenticMemoryTool`, `UpdateAgenticMemoryTool`, `DeleteAgenticMemoryByIDTool`, `DeleteAgenticMemoryByQueryTool`, and `SearchAgenticMemoryTool`. Agentic memory tools are in the `agentic_memory` category and can be enabled via `enabled_categories: ["agentic_memory"]`. The `memory_container_id` is automatically pre-filled in all tool calls when configured via the `agentic_memory` config section or `OPENSEARCH_MEMORY_CONTAINER_ID` environment variable. ([#138](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/138))
 - Add `AGENTS.md` and rewrite `DEVELOPER_GUIDE.md` "Adding Custom Tools" section with detailed 4-piece tool anatomy, error handling contracts, and tool category documentation ([#214](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/214))
-
-- Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings
+- Add OpenSearch mTLS support for single-cluster and multi-cluster configurations, including CA bundle, client certificate, and client key settings ([#204](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/204))
+- Add per-category write permissions ([#256](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/256))
 
 ### Changed
 - Default `--host` for the `stream` transport from `0.0.0.0` to `127.0.0.1` so the streamable HTTP listener binds to loopback by default. Operators who need to expose the listener on other interfaces opt in explicitly with `--host 0.0.0.0` ([#253](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/253))
@@ -26,7 +26,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Switch CI from `pull_request` to `pull_request_target` so integration tests run on fork PRs ([#219](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/219))
 - Fix multi-mode IT failing for `ListClustersTool` which has no `opensearch_cluster_name` parameter ([#220](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/220))
 - Fix non-ASCII characters (e.g. Chinese, Japanese, accented characters) being escaped to Unicode sequences in all tool JSON responses ([#164](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/164))
-
 - Fix `SearchIndexTool` ignoring `size=0`, causing aggregation-only queries to always return 10 hits ([#217](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/217))
 - Infer default TCP port from URL scheme (`http` → 80, `https` → 443) when no port is specified, instead of relying on implicit 9200 behavior ([#170](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/170))
 - Move skills tools to disabled-by-default category([#225](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/225/))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -631,6 +631,7 @@ If the port is omitted, this server inserts the usual HTTP(S) default so traffic
 | `OPENSEARCH_ENABLED_TOOLS_REGEX` | No | `''` | Comma-separated list of regex patterns for enabled tools |
 | `OPENSEARCH_DISABLED_TOOLS_REGEX` | No | `''` | Comma-separated list of regex patterns for disabled tools |
 | `OPENSEARCH_SETTINGS_ALLOW_WRITE` | No | `"true"` | Enable/disable write operations (`"true"` or `"false"`) |
+| `OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES` | No | `''` | Comma-separated list of categories that allow write operations |
 
 ### Agentic Memory Variables
 
@@ -714,6 +715,8 @@ tool_filters:
     - <regex_pattern_to_disable>
   settings:
     allow_write: true  # Enable/disable write-only operations
+    allow_write_categories:  # Categories that allow write operations
+      - <category_name_to_allow_write>
 ```
 
 To use your configuration file, start the server with the `--config` flag:
@@ -747,7 +750,32 @@ export OPENSEARCH_DISABLED_TOOLS_REGEX="<regex_pattern>"
 
 # Operation Settings
 export OPENSEARCH_SETTINGS_ALLOW_WRITE=true
+export OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES="<category_name>,<category_name>"
 ```
+
+### Per-Category Write Permissions
+
+Categories listed in `allow_write_categories` allow write operations. Tools not in the listed categories remain blocked.
+
+**YAML Configuration:**
+```yaml
+tool_filters:
+  enabled_categories:
+    - <category_name>
+  settings:
+    allow_write: false
+    allow_write_categories:
+      - <category_name>
+```
+
+**Environment Variables:**
+```bash
+export OPENSEARCH_SETTINGS_ALLOW_WRITE=false
+export OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES="<category_name>"
+export OPENSEARCH_ENABLED_CATEGORIES="<category_name>"
+```
+
+**Note:** `allow_write_categories` only takes effect when `allow_write` is `false`. It selectively enables write operations for the specified categories while keeping all other tools read-only.
 
 ### Important Notes
 - Tool names are case-insensitive

--- a/example_config.yml
+++ b/example_config.yml
@@ -99,7 +99,10 @@ tools:
 #   disabled_tools_regex:
 #     - "debug.*"  # Example: disable all tools starting with debug
 #   settings:
-#     allow_write: true  # Enable/disable write operations
+#     allow_write: true  # Enable/disable write operations globally
+#     allow_write_categories:  # Categories that allow write operations
+#       - search_relevance
+#       - agentic_memory
 
 
 # Example configurations for different authentication methods:

--- a/integration_tests/write_protection/test_write_categories.py
+++ b/integration_tests/write_protection/test_write_categories.py
@@ -1,0 +1,68 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import pytest_asyncio
+from integration_tests.framework.assertions import assert_tool_error, assert_tool_success
+from integration_tests.framework.aws_helpers import get_default_server_env
+from integration_tests.framework.client import mcp_client
+from integration_tests.framework.constants import TEST_INDEX
+from integration_tests.framework.server import MCPServerProcess
+
+
+@pytest.mark.tools
+class TestWriteCategories:
+    """Verify allow_write_categories exempts specific categories from write protection."""
+
+    @pytest_asyncio.fixture
+    async def write_categories_client(self, seed_test_index):
+        env = {
+            **get_default_server_env(),
+            'OPENSEARCH_SETTINGS_ALLOW_WRITE': 'false',
+            'OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES': 'search_relevance',
+            'OPENSEARCH_ENABLED_CATEGORIES': 'core_tools,search_relevance',
+        }
+        server = MCPServerProcess(env=env)
+        await server.start()
+        try:
+            async with mcp_client(server.url) as session:
+                yield session
+        finally:
+            await server.stop()
+
+    async def test_search_relevance_write_tools_available(self, write_categories_client):
+        """search_relevance write tools should be listed when exempted via allow_write_categories."""
+        tools = await write_categories_client.list_tools()
+        tool_names = {t.name for t in tools.tools}
+        assert 'CreateQuerySetTool' in tool_names
+        assert 'CreateSearchConfigurationTool' in tool_names
+        assert 'DeleteQuerySetTool' in tool_names
+        assert 'CreateExperimentTool' in tool_names
+
+    async def test_generic_api_write_still_blocked(self, write_categories_client):
+        """GenericOpenSearchApiTool write operations should still be blocked at runtime."""
+        result = await write_categories_client.call_tool(
+            'GenericOpenSearchApiTool',
+            arguments={
+                'path': f'/{TEST_INDEX}/_doc',
+                'method': 'POST',
+                'body': {'test': 'data'},
+            },
+        )
+        assert_tool_error(result, 'Write operations are disabled')
+
+    async def test_generic_api_read_still_works(self, write_categories_client):
+        """GenericOpenSearchApiTool GET operations should still work."""
+        result = await write_categories_client.call_tool(
+            'GenericOpenSearchApiTool',
+            arguments={'path': '/_cluster/health', 'method': 'GET'},
+        )
+        assert_tool_success(result, 'OpenSearch API Response')
+
+    async def test_core_tools_read_still_works(self, write_categories_client):
+        """Core read tools should still be available and functional."""
+        result = await write_categories_client.call_tool(
+            'ClusterHealthTool',
+            arguments={},
+        )
+        assert_tool_success(result)

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -21,6 +21,9 @@ from opensearch.helper import get_opensearch_version
 # This is set during server initialization and used by individual tools
 _resolved_allow_write_setting = None
 
+# Global variable to store the resolved allow_write_categories setting
+_resolved_allow_write_categories = None
+
 
 def process_regex_patterns(regex_list, tool_names):
     """Process regex patterns and return matching tool names."""
@@ -44,6 +47,36 @@ def set_allow_write_setting(allow_write: bool) -> None:
     global _resolved_allow_write_setting
     _resolved_allow_write_setting = allow_write
     logging.debug(f'Set global allow_write setting to: {allow_write}')
+
+
+def set_allow_write_categories(categories: list) -> None:
+    """Set the global allow_write_categories setting.
+
+    When allow_write is false, tools belonging to these categories are still
+    permitted to perform write operations. This allows granular control over
+    which tool categories can write while keeping the global default restrictive.
+
+    Args:
+        categories: List of category names allowed to perform write operations
+    """
+    global _resolved_allow_write_categories
+    _resolved_allow_write_categories = categories
+    logging.debug(f'Set allow_write_categories to: {categories}')
+
+
+def get_allow_write_categories() -> list:
+    """Get the allow_write_categories setting.
+
+    Returns:
+        list: List of category names allowed to perform write operations, or empty list if not set
+    """
+    global _resolved_allow_write_categories
+    if _resolved_allow_write_categories is not None:
+        return _resolved_allow_write_categories
+    env_value = os.getenv('OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES', '')
+    if env_value:
+        return parse_comma_separated(env_value)
+    return []
 
 
 def get_allow_write_setting() -> bool:
@@ -100,14 +133,48 @@ def _resolve_allow_write_setting(config_file_path: str = None) -> bool:
     return allow_write
 
 
-def apply_write_filter(registry):
+def _resolve_allow_write_categories(config_file_path: str = None) -> list:
+    """Resolve the allow_write_categories setting from environment variable or config file.
+
+    Args:
+        config_file_path: Optional path to config file
+
+    Returns:
+        list: List of category names allowed to perform write operations
+    """
+    categories = parse_comma_separated(os.getenv('OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES', ''))
+
+    if config_file_path and os.path.exists(config_file_path):
+        try:
+            config = load_yaml_config(config_file_path)
+            if config:
+                tool_filters = config.get('tool_filters', {})
+                settings = tool_filters.get('settings', {})
+                if 'allow_write_categories' in settings:
+                    categories = settings.get('allow_write_categories', [])
+                    logging.debug(
+                        f'Using allow_write_categories from config file: {config_file_path}'
+                    )
+        except Exception as e:
+            logging.debug(f'Could not load config file {config_file_path}: {e}')
+
+    return categories
+
+
+def apply_write_filter(registry, exempt_tools=None):
     """Apply allow_write filters to the registry.
 
     Removes tools that only have write HTTP methods, unless the tool
-    has ``bypass_write_filter`` set to True (e.g. memory tools).
+    has ``bypass_write_filter`` set to True (e.g. memory tools) or in the exempt_tools set.
+
+    Args:
+        registry: The tool registry to filter
+        exempt_tools: Set of tool names (registry keys) exempt from the write filter
     """
+    if exempt_tools is None:
+        exempt_tools = set()
     for tool_name in list(registry.keys()):
-        if registry[tool_name].get('bypass_write_filter'):
+        if registry[tool_name].get('bypass_write_filter') or tool_name in exempt_tools:
             continue
         http_methods = registry[tool_name].get('http_methods', [])
         if 'GET' not in http_methods:
@@ -134,6 +201,7 @@ def process_tool_filter(
     enabled_tools_regex: str = None,
     disabled_tools_regex: str = None,
     allow_write: bool = None,
+    allow_write_categories: list = None,
     filter_path: str = None,
     tool_registry: dict = None,
 ) -> None:
@@ -148,6 +216,7 @@ def process_tool_filter(
         enabled_tools_regex: Comma-separates list of enabled tools regex
         disabled_tools_regex: Comma-separated list of disabled tools regex
         allow_write: If True, allow tools with PUT/POST methods
+        allow_write_categories: List of category names whose tools are exempt from the write filter
         filter_path: Path to the YAML filter configuration file
         tool_registry: The tool registry to filter.
     """
@@ -285,6 +354,8 @@ def process_tool_filter(
             settings = tool_filters.get('settings', {})
             if settings:
                 allow_write = settings.get('allow_write', True)
+                if 'allow_write_categories' in settings:
+                    allow_write_categories = settings.get('allow_write_categories', [])
 
         # Process environment variables
         if tool_categories:
@@ -311,7 +382,22 @@ def process_tool_filter(
 
         # Apply allow_write filter first
         if not allow_write:
-            apply_write_filter(tool_registry)
+            exempt_tools = set()
+            if allow_write_categories:
+                display_to_key = {
+                    info.get('display_name', '').lower(): key
+                    for key, info in tool_registry.items()
+                }
+                for category in allow_write_categories:
+                    category_tool_names = category_to_tools.get(category, [])
+                    for tool_display_name in category_tool_names:
+                        key = display_to_key.get(tool_display_name.lower())
+                        if key:
+                            exempt_tools.add(key)
+                logging.debug(
+                    f'Tools exempt from write filter via allow_write_categories: {exempt_tools}'
+                )
+            apply_write_filter(tool_registry, exempt_tools=exempt_tools)
 
         # Process tools from categories and regex patterns
         enabled_tools_from_categories = process_categories(
@@ -406,6 +492,10 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
     resolved_allow_write = _resolve_allow_write_setting(config_file_path)
     set_allow_write_setting(resolved_allow_write)
 
+    # Resolve and set the global allow_write_categories setting
+    resolved_categories = _resolve_allow_write_categories(config_file_path)
+    set_allow_write_categories(resolved_categories)
+
     # In multi mode, always strip connection override fields — dynamic per-call
     # connection params are a single-mode feature. Multi mode uses
     # opensearch_cluster_name to select a pre-configured cluster.
@@ -439,6 +529,10 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
         'enabled_tools_regex': os.getenv('OPENSEARCH_ENABLED_TOOLS_REGEX', ''),
         'disabled_tools_regex': os.getenv('OPENSEARCH_DISABLED_TOOLS_REGEX', ''),
         'allow_write': os.getenv('OPENSEARCH_SETTINGS_ALLOW_WRITE', 'true').lower() == 'true',
+        'allow_write_categories': parse_comma_separated(
+            os.getenv('OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES', '')
+        )
+        or None,
     }
 
     # Check if both config and env variables are set

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -21,9 +21,6 @@ from opensearch.helper import get_opensearch_version
 # This is set during server initialization and used by individual tools
 _resolved_allow_write_setting = None
 
-# Global variable to store the resolved allow_write_categories setting
-_resolved_allow_write_categories = None
-
 
 def process_regex_patterns(regex_list, tool_names):
     """Process regex patterns and return matching tool names."""
@@ -47,36 +44,6 @@ def set_allow_write_setting(allow_write: bool) -> None:
     global _resolved_allow_write_setting
     _resolved_allow_write_setting = allow_write
     logging.debug(f'Set global allow_write setting to: {allow_write}')
-
-
-def set_allow_write_categories(categories: list) -> None:
-    """Set the global allow_write_categories setting.
-
-    When allow_write is false, tools belonging to these categories are still
-    permitted to perform write operations. This allows granular control over
-    which tool categories can write while keeping the global default restrictive.
-
-    Args:
-        categories: List of category names allowed to perform write operations
-    """
-    global _resolved_allow_write_categories
-    _resolved_allow_write_categories = categories
-    logging.debug(f'Set allow_write_categories to: {categories}')
-
-
-def get_allow_write_categories() -> list:
-    """Get the allow_write_categories setting.
-
-    Returns:
-        list: List of category names allowed to perform write operations, or empty list if not set
-    """
-    global _resolved_allow_write_categories
-    if _resolved_allow_write_categories is not None:
-        return _resolved_allow_write_categories
-    env_value = os.getenv('OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES', '')
-    if env_value:
-        return parse_comma_separated(env_value)
-    return []
 
 
 def get_allow_write_setting() -> bool:
@@ -131,34 +98,6 @@ def _resolve_allow_write_setting(config_file_path: str = None) -> bool:
             logging.debug(f'Could not load config file {config_file_path}: {e}')
 
     return allow_write
-
-
-def _resolve_allow_write_categories(config_file_path: str = None) -> list:
-    """Resolve the allow_write_categories setting from environment variable or config file.
-
-    Args:
-        config_file_path: Optional path to config file
-
-    Returns:
-        list: List of category names allowed to perform write operations
-    """
-    categories = parse_comma_separated(os.getenv('OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES', ''))
-
-    if config_file_path and os.path.exists(config_file_path):
-        try:
-            config = load_yaml_config(config_file_path)
-            if config:
-                tool_filters = config.get('tool_filters', {})
-                settings = tool_filters.get('settings', {})
-                if 'allow_write_categories' in settings:
-                    categories = settings.get('allow_write_categories', [])
-                    logging.debug(
-                        f'Using allow_write_categories from config file: {config_file_path}'
-                    )
-        except Exception as e:
-            logging.debug(f'Could not load config file {config_file_path}: {e}')
-
-    return categories
 
 
 def apply_write_filter(registry, exempt_tools=None):
@@ -491,10 +430,6 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
     # This needs to be done in both single and multi mode
     resolved_allow_write = _resolve_allow_write_setting(config_file_path)
     set_allow_write_setting(resolved_allow_write)
-
-    # Resolve and set the global allow_write_categories setting
-    resolved_categories = _resolve_allow_write_categories(config_file_path)
-    set_allow_write_categories(resolved_categories)
 
     # In multi mode, always strip connection override fields — dynamic per-call
     # connection params are a single-mode feature. Multi mode uses

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -883,64 +883,6 @@ class TestAllowWriteCategories:
         assert 'CreateQuerySetTool' in registry
         assert 'GenericOpenSearchApiTool' in registry
 
-    @patch.dict(
-        'os.environ',
-        {'OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES': 'search_relevance,agentic_memory'},
-    )
-    def test_get_allow_write_categories_from_env(self):
-        """get_allow_write_categories reads from environment variable."""
-        from tools.tool_filter import get_allow_write_categories, set_allow_write_categories
-
-        # Reset the global to force env fallback
-        set_allow_write_categories(None)
-        result = get_allow_write_categories()
-        assert result == ['search_relevance', 'agentic_memory']
-
-    def test_get_allow_write_categories_returns_empty_by_default(self):
-        """get_allow_write_categories returns empty list when nothing is configured."""
-        from tools.tool_filter import get_allow_write_categories, set_allow_write_categories
-
-        set_allow_write_categories(None)
-        result = get_allow_write_categories()
-        assert result == []
-
-    @patch('tools.tool_filter.load_yaml_config')
-    @patch('os.path.exists')
-    def test_resolve_allow_write_categories_from_config(self, mock_exists, mock_load_yaml):
-        """_resolve_allow_write_categories reads from config file."""
-        from tools.tool_filter import _resolve_allow_write_categories
-
-        mock_exists.return_value = True
-        mock_load_yaml.return_value = {
-            'tool_filters': {
-                'settings': {'allow_write_categories': ['search_relevance', 'agentic_memory']}
-            }
-        }
-
-        result = _resolve_allow_write_categories('/path/to/config.yml')
-        assert result == ['search_relevance', 'agentic_memory']
-
-    @patch('tools.tool_filter.load_yaml_config')
-    @patch('os.path.exists')
-    def test_resolve_allow_write_categories_config_overrides_env(
-        self, mock_exists, mock_load_yaml
-    ):
-        """Config file allow_write_categories overrides environment variable."""
-        import os
-        from tools.tool_filter import _resolve_allow_write_categories
-
-        os.environ['OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES'] = 'skills'
-        mock_exists.return_value = True
-        mock_load_yaml.return_value = {
-            'tool_filters': {'settings': {'allow_write_categories': ['search_relevance']}}
-        }
-
-        result = _resolve_allow_write_categories('/path/to/config.yml')
-        assert result == ['search_relevance']
-
-        # Cleanup
-        del os.environ['OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES']
-
 
 class TestAllowWriteSettings:
     """Test cases for the allow_write setting functionality."""

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -758,6 +758,190 @@ class TestProcessToolFilter:
         assert 'IndicesCreateTool' not in registry
 
 
+class TestAllowWriteCategories:
+    """Test cases for allow_write_categories setting."""
+
+    def test_allow_write_false_removes_write_only_tools(self):
+        """When allow_write is false, write-only tools are removed."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'SearchIndexTool': {'display_name': 'SearchIndexTool', 'http_methods': 'GET, POST'},
+            'CreateQuerySetTool': {'display_name': 'CreateQuerySetTool', 'http_methods': 'PUT'},
+            'DeleteQuerySetTool': {'display_name': 'DeleteQuerySetTool', 'http_methods': 'DELETE'},
+            'GenericOpenSearchApiTool': {
+                'display_name': 'GenericOpenSearchApiTool',
+                'http_methods': 'GET, POST, PUT, DELETE, HEAD, PATCH',
+            },
+        }
+        process_tool_filter(tool_registry=registry, allow_write=False)
+
+        assert 'ListIndexTool' in registry
+        assert 'SearchIndexTool' in registry
+        assert 'GenericOpenSearchApiTool' in registry  # has GET, so survives
+        assert 'CreateQuerySetTool' not in registry  # PUT only, removed
+        assert 'DeleteQuerySetTool' not in registry  # DELETE only, removed
+
+    def test_allow_write_categories_exempts_category_from_write_filter(self):
+        """Tools in allow_write_categories survive the write filter even with allow_write=false."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'SearchIndexTool': {'display_name': 'SearchIndexTool', 'http_methods': 'GET, POST'},
+            'CreateQuerySetTool': {'display_name': 'CreateQuerySetTool', 'http_methods': 'PUT'},
+            'DeleteQuerySetTool': {'display_name': 'DeleteQuerySetTool', 'http_methods': 'DELETE'},
+            'GetQuerySetTool': {'display_name': 'GetQuerySetTool', 'http_methods': 'GET'},
+            'GenericOpenSearchApiTool': {
+                'display_name': 'GenericOpenSearchApiTool',
+                'http_methods': 'GET, POST, PUT, DELETE, HEAD, PATCH',
+            },
+            'IndicesCreateTool': {'display_name': 'IndicesCreateTool', 'http_methods': 'PUT'},
+        }
+        process_tool_filter(
+            tool_registry=registry,
+            allow_write=False,
+            allow_write_categories=['search_relevance'],
+            enabled_categories='core_tools,search_relevance',
+        )
+
+        # search_relevance write tools survive because of allow_write_categories
+        assert 'CreateQuerySetTool' in registry
+        assert 'DeleteQuerySetTool' in registry
+        assert 'GetQuerySetTool' in registry
+
+        # core_tools with GET survive normally
+        assert 'ListIndexTool' in registry
+        assert 'SearchIndexTool' in registry
+        assert 'GenericOpenSearchApiTool' in registry  # has GET
+
+        # Non-exempted write-only tool is removed
+        assert 'IndicesCreateTool' not in registry
+
+    def test_allow_write_categories_does_not_affect_generic_api_runtime(self):
+        """GenericOpenSearchApiTool still blocked at runtime when allow_write=false."""
+        from tools.tool_filter import get_allow_write_setting, set_allow_write_setting
+
+        set_allow_write_setting(False)
+        assert get_allow_write_setting() is False
+
+    def test_allow_write_categories_multiple_categories(self):
+        """Multiple categories can be specified in allow_write_categories."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'CreateQuerySetTool': {'display_name': 'CreateQuerySetTool', 'http_methods': 'PUT'},
+            'DataDistributionTool': {
+                'display_name': 'DataDistributionTool',
+                'http_methods': 'POST',
+            },
+            'IndicesCreateTool': {'display_name': 'IndicesCreateTool', 'http_methods': 'PUT'},
+        }
+        process_tool_filter(
+            tool_registry=registry,
+            allow_write=False,
+            allow_write_categories=['search_relevance', 'skills'],
+            enabled_categories='core_tools,search_relevance,skills',
+        )
+
+        assert 'ListIndexTool' in registry
+        assert 'CreateQuerySetTool' in registry  # search_relevance, exempted
+        assert 'DataDistributionTool' in registry  # skills, exempted
+        assert 'IndicesCreateTool' not in registry  # not in any exempted category
+
+    def test_allow_write_categories_empty_has_no_effect(self):
+        """Empty allow_write_categories doesn't exempt any tools."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'CreateQuerySetTool': {'display_name': 'CreateQuerySetTool', 'http_methods': 'PUT'},
+        }
+        process_tool_filter(
+            tool_registry=registry,
+            allow_write=False,
+            allow_write_categories=[],
+            enabled_categories='core_tools,search_relevance',
+        )
+
+        assert 'ListIndexTool' in registry
+        assert 'CreateQuerySetTool' not in registry  # no exemption
+
+    def test_allow_write_categories_with_allow_write_true_is_noop(self):
+        """When allow_write=true, allow_write_categories has no effect (write filter not applied)."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'CreateQuerySetTool': {'display_name': 'CreateQuerySetTool', 'http_methods': 'PUT'},
+            'GenericOpenSearchApiTool': {
+                'display_name': 'GenericOpenSearchApiTool',
+                'http_methods': 'GET, POST, PUT, DELETE, HEAD, PATCH',
+            },
+        }
+        process_tool_filter(
+            tool_registry=registry,
+            allow_write=True,
+            allow_write_categories=['search_relevance'],
+            enabled_categories='core_tools,search_relevance',
+        )
+
+        # All tools in enabled categories survive when allow_write=true
+        assert 'ListIndexTool' in registry
+        assert 'CreateQuerySetTool' in registry
+        assert 'GenericOpenSearchApiTool' in registry
+
+    @patch.dict(
+        'os.environ',
+        {'OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES': 'search_relevance,agentic_memory'},
+    )
+    def test_get_allow_write_categories_from_env(self):
+        """get_allow_write_categories reads from environment variable."""
+        from tools.tool_filter import get_allow_write_categories, set_allow_write_categories
+
+        # Reset the global to force env fallback
+        set_allow_write_categories(None)
+        result = get_allow_write_categories()
+        assert result == ['search_relevance', 'agentic_memory']
+
+    def test_get_allow_write_categories_returns_empty_by_default(self):
+        """get_allow_write_categories returns empty list when nothing is configured."""
+        from tools.tool_filter import get_allow_write_categories, set_allow_write_categories
+
+        set_allow_write_categories(None)
+        result = get_allow_write_categories()
+        assert result == []
+
+    @patch('tools.tool_filter.load_yaml_config')
+    @patch('os.path.exists')
+    def test_resolve_allow_write_categories_from_config(self, mock_exists, mock_load_yaml):
+        """_resolve_allow_write_categories reads from config file."""
+        from tools.tool_filter import _resolve_allow_write_categories
+
+        mock_exists.return_value = True
+        mock_load_yaml.return_value = {
+            'tool_filters': {
+                'settings': {'allow_write_categories': ['search_relevance', 'agentic_memory']}
+            }
+        }
+
+        result = _resolve_allow_write_categories('/path/to/config.yml')
+        assert result == ['search_relevance', 'agentic_memory']
+
+    @patch('tools.tool_filter.load_yaml_config')
+    @patch('os.path.exists')
+    def test_resolve_allow_write_categories_config_overrides_env(
+        self, mock_exists, mock_load_yaml
+    ):
+        """Config file allow_write_categories overrides environment variable."""
+        import os
+        from tools.tool_filter import _resolve_allow_write_categories
+
+        os.environ['OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES'] = 'skills'
+        mock_exists.return_value = True
+        mock_load_yaml.return_value = {
+            'tool_filters': {'settings': {'allow_write_categories': ['search_relevance']}}
+        }
+
+        result = _resolve_allow_write_categories('/path/to/config.yml')
+        assert result == ['search_relevance']
+
+        # Cleanup
+        del os.environ['OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES']
+
+
 class TestAllowWriteSettings:
     """Test cases for the allow_write setting functionality."""
 


### PR DESCRIPTION
### Problem
 The `OPENSEARCH_SETTINGS_ALLOW_WRITE` setting is a global toggle. When set to false, it blocks write operations across all tools — including tools in categories that require write access to maximize their functionality (e.g., search relevance). To enable those tools, users must set `allow_write=true`, which also unlocks write operations for `GenericOpenSearchApiTool` (arbitrary index deletion, bulk writes, etc.), creating an all-or-nothing trade-off between safety and functionality.

### Solution

Introduce `allow_write_categories` — a new setting that selectively enables write operations for specific tool categories while keeping the global write protection active. For example:
**YAML config:**
```yaml
  tool_filters:
    settings:
      allow_write: false
      allow_write_categories:
        - search_relevance
```

  **Environment variable:**
```
  export OPENSEARCH_SETTINGS_ALLOW_WRITE=false
  export OPENSEARCH_SETTINGS_ALLOW_WRITE_CATEGORIES="search_relevance"
  ```
This keeps `GenericOpenSearchApiTool` write operations blocked at runtime, while `search_relevance` tools with read and write operations remain in the registry and fully functional.

### Note
- When both config file and environment variables are set, the config file takes precedence — consistent with existing tool filtering behavior (https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/USER_GUIDE.md#important-notes)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).