### PR TITLE
Fixed `SearchExperimentsTool` using incorrect API path (`experiment` instead of `experiments`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `SearchIndexTool` ignoring `size=0`, causing aggregation-only queries to always return 10 hits ([#217](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/217))
 - Infer default TCP port from URL scheme (`http` → 80, `https` → 443) when no port is specified, instead of relying on implicit 9200 behavior ([#170](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/170))
 - Move skills tools to disabled-by-default category([#225](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/225/))
+- Fixed `SearchExperimentsTool` using incorrect API path (`experiment` instead of `experiments`)([#261](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/261))
 
 ### Dependencies
 - Bump `mcp` from 1.23.0 to 1.27.0, `python-dotenv` from 1.1.0 to 1.2.2 (CVE-2026-28684), and `python-multipart` from 0.0.22 to 0.0.27 (CVE-2026-40347) ([#233](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/233))

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -477,7 +477,7 @@ async def _srw_search(args, entity: str) -> json:
     Args:
         args: Tool args containing the optional query_body
         entity: The SRW entity name, e.g. 'query_sets', 'search_configurations',
-                'judgments', or 'experiment'
+                'judgments', or 'experiments'
 
     Returns:
         json: OpenSearch search response
@@ -626,7 +626,7 @@ async def search_experiments(args: SearchExperimentsArgs) -> json:
     Returns:
         json: OpenSearch search response
     """
-    return await _srw_search(args, 'experiment')
+    return await _srw_search(args, 'experiments')
 
 
 def convert_search_results_to_csv(search_results: dict) -> str:

--- a/tests/tools/test_srw_search_tools.py
+++ b/tests/tools/test_srw_search_tools.py
@@ -220,7 +220,7 @@ class TestSRWSearchTools:
         assert 'Experiment search results' in result[0]['text']
 
         call_kwargs = self.mock_client.transport.perform_request.call_args
-        assert call_kwargs.kwargs['url'] == '/_plugins/_search_relevance/experiment/_search'
+        assert call_kwargs.kwargs['url'] == '/_plugins/_search_relevance/experiments/_search'
         body = json.loads(call_kwargs.kwargs['body'])
         assert body == {'query': {'match_all': {}}}
 


### PR DESCRIPTION
### Description
Changed `SearchExperimentsTool` API path from `experiment` to `experiments`.
Correct API path should use plural: https://docs.opensearch.org/latest/search-plugins/search-relevance/experiments/#endpoints

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-mcp-server-py/issues/242

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).