### PR TITLE
feat: GH-265 handle isError field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Set MCP `CallToolResult.isError` when tool responses indicate failure (`is_error`), so clients can distinguish errors from successful tool calls ([#265](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/265))
+
 ### Fixed
 - Fix Streamable HTTP `/mcp` endpoint issuing a 307 redirect to `/mcp/`, which broke strict proxies/clients that don't follow redirects mid-session. The bare `/mcp` path is now served directly via a `Route` ([#273](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/273))
 

--- a/integration_tests/framework/assertions.py
+++ b/integration_tests/framework/assertions.py
@@ -23,6 +23,7 @@ def assert_tool_success(result, *expected: str) -> str:
     Returns:
         The concatenated text content from the response.
     """
+    assert not result.isError
     text = _extract_texts(result)
     assert not text.startswith(_ERROR_PREFIXES), f'Tool returned error: {text[:500]}'
     for exp in expected:
@@ -44,6 +45,7 @@ def assert_tool_error(result, expected_substring: str | None = None) -> str:
     Returns:
         The concatenated text content from the error response.
     """
+    assert result.isError
     text = _extract_texts(result)
     assert text.startswith(_ERROR_PREFIXES), f'Expected error but got success: {text[:500]}'
     if expected_substring:

--- a/src/mcp_server_opensearch/stdio_server.py
+++ b/src/mcp_server_opensearch/stdio_server.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import CallToolResult, Tool
 from mcp_server_opensearch.clusters_information import load_clusters_from_yaml
 from mcp_server_opensearch.global_state import set_config_file_path, set_mode, set_profile
 from mcp_server_opensearch.server_instructions import get_server_instructions
@@ -67,7 +67,7 @@ async def serve(
         return tools
 
     @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    async def call_tool(name: str, arguments: dict) -> CallToolResult:
         from mcp_server_opensearch.tool_executor import execute_tool
 
         return await execute_tool(name, arguments, enabled_tools)

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -8,7 +8,7 @@ import uvicorn
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.types import TextContent, Tool
+from mcp.types import CallToolResult, Tool
 from mcp_server_opensearch.clusters_information import load_clusters_from_yaml
 from mcp_server_opensearch.global_state import set_config_file_path, set_mode, set_profile
 from mcp_server_opensearch.server_instructions import get_server_instructions
@@ -74,7 +74,7 @@ async def create_mcp_server(
         return tools
 
     @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    async def call_tool(name: str, arguments: dict) -> CallToolResult:
         from mcp_server_opensearch.tool_executor import execute_tool
 
         return await execute_tool(name, arguments, enabled_tools)

--- a/src/mcp_server_opensearch/tool_executor.py
+++ b/src/mcp_server_opensearch/tool_executor.py
@@ -17,17 +17,35 @@ tool invocation, enabling metric filters for:
 
 import logging
 import time
-from mcp.types import TextContent
+from mcp.types import CallToolResult, TextContent
 
 
 logger = logging.getLogger(__name__)
+
+
+def _build_call_tool_result(result: list, is_error: bool) -> CallToolResult:
+    # Convert a tool's raw content list into a CallToolResult.
+
+    content: list[TextContent] = []
+    for item in result or []:
+        if isinstance(item, dict):
+            content.append(
+                TextContent(
+                    type=item.get('type', 'text'),
+                    text=item.get('text', ''),
+                )
+            )
+        else:
+            content.append(item)
+
+    return CallToolResult(content=content, isError=is_error)
 
 
 async def execute_tool(
     name: str,
     arguments: dict,
     enabled_tools: dict,
-) -> list[TextContent]:
+) -> CallToolResult:
     """Execute an MCP tool with structured logging for metrics.
 
     Resolves the tool by display name, validates arguments, executes,
@@ -48,6 +66,7 @@ async def execute_tool(
     status = 'success'
     error_type = None
     found_tool_key = None
+    is_error = False
 
     try:
         # Resolve tool by display name
@@ -73,8 +92,9 @@ async def execute_tool(
         if result and len(result) > 0:
             if isinstance(result[0], dict) and result[0].get('is_error'):
                 status = 'error'
+                is_error = True
 
-        return result
+        return _build_call_tool_result(result, is_error)
 
     except ValueError:
         # For unknown tool, status/error_type were already set above.

--- a/tests/mcp_server_opensearch/test_tool_executor.py
+++ b/tests/mcp_server_opensearch/test_tool_executor.py
@@ -3,6 +3,7 @@
 
 import logging
 import pytest
+from mcp.types import CallToolResult
 from mcp_server_opensearch.tool_executor import execute_tool
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -32,7 +33,10 @@ class TestExecuteTool:
         with caplog.at_level(logging.INFO):
             result = await execute_tool('TestTool', {}, enabled_tools)
 
-        assert result == [{'type': 'text', 'text': 'Success'}]
+        # Success is returned as a CallToolResult with isError=False.
+        assert isinstance(result, CallToolResult)
+        assert result.isError is False
+        assert result.content[0].text == 'Success'
         # Check structured log was emitted
         assert any('Tool executed: TestTool' in r.message for r in caplog.records)
         # Check extra fields
@@ -62,7 +66,10 @@ class TestExecuteTool:
         with caplog.at_level(logging.ERROR):
             result = await execute_tool('TestTool', {}, enabled_tools)
 
-        assert result[0]['is_error'] is True
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+        assert getattr(result.content[0], 'is_error', None) is None
+        assert result.content[0].text == 'Error searching index: connection refused'
         error_records = [
             r
             for r in caplog.records


### PR DESCRIPTION
### Description
- Propagate the existing internal error signal to CallToolResult.isError for all tools (generic, not per-tool).
- No change to the human-readable error text/format.

### Issues Resolved
Closes [GH-265]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).