### PR TITLE
Fix Streamable HTTP /mcp endpoint 307-redirecting to /mcp/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Fixed
+- Fix Streamable HTTP `/mcp` endpoint issuing a 307 redirect to `/mcp/`, which broke strict proxies/clients that don't follow redirects mid-session. The bare `/mcp` path is now served directly via a `Route` ([#273](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/273))
 
 ### Removed
 

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -82,6 +82,16 @@ async def create_mcp_server(
     return server
 
 
+class _ASGIApp:
+    """ASGI app object wrapping a handler, so Starlette's Route treats it as a raw ASGI endpoint."""
+
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self._handler(scope, receive, send)
+
+
 class MCPStarletteApp:
     """Starlette application wrapper for the MCP server."""
 
@@ -143,13 +153,15 @@ class MCPStarletteApp:
 
     def create_app(self) -> Starlette:
         """Create the Starlette application with routes."""
+        # Serve bare '/mcp' via Route (a Mount alone 307-redirects '/mcp' to '/mcp/'); Mount handles sub-paths.
+        streamable_http_app = _ASGIApp(self.handle_streamable_http)
         return Starlette(
             routes=[
                 Route('/sse', endpoint=self.handle_sse, methods=['GET']),
                 Route('/health', endpoint=self.handle_health, methods=['GET']),
                 Mount('/messages/', app=self.sse.handle_post_message),
-                Mount('/mcp', app=self.handle_streamable_http),
-                Mount('/mcp/', app=self.handle_streamable_http),
+                Route('/mcp', endpoint=streamable_http_app),
+                Mount('/mcp', app=streamable_http_app),
             ],
             lifespan=self.lifespan,
         )

--- a/tests/mcp_server_opensearch/test_streaming_server.py
+++ b/tests/mcp_server_opensearch/test_streaming_server.py
@@ -167,6 +167,8 @@ class TestMCPStarletteApp:
 
     def test_create_app(self, app_handler):
         """Test Starlette application creation and configuration."""
+        from starlette.routing import Mount, Route
+
         app = app_handler.create_app()
         assert len(app.routes) == 5
 
@@ -174,7 +176,28 @@ class TestMCPStarletteApp:
         assert app.routes[0].path == '/sse'
         assert app.routes[1].path == '/health'
         assert app.routes[2].path == '/messages'
-        assert app.routes[3].path == '/mcp'
+        # Bare '/mcp' is a Route (served directly, no 307); sub-paths go through the Mount.
+        assert app.routes[3].path == '/mcp' and isinstance(app.routes[3], Route)
+        assert app.routes[4].path == '/mcp' and isinstance(app.routes[4], Mount)
+
+    @pytest.mark.asyncio
+    async def test_mcp_endpoint_no_redirect(self, app_handler):
+        """Bare '/mcp' is served directly without a 307 redirect to '/mcp/' (issue #271)."""
+        from starlette.responses import PlainTextResponse
+        from starlette.testclient import TestClient
+
+        async def fake_handle_request(scope, receive, send):
+            await PlainTextResponse('ok')(scope, receive, send)
+
+        app_handler.session_manager.handle_request = fake_handle_request
+        app = app_handler.create_app()
+        app.router.lifespan_context = None  # skip the real session manager startup
+        client = TestClient(app)
+
+        for method in ('GET', 'POST', 'DELETE'):
+            response = client.request(method, '/mcp', follow_redirects=False)
+            assert response.status_code == 200
+            assert response.headers.get('location') is None
 
     @pytest.mark.asyncio
     async def test_handle_sse(self, app_handler):


### PR DESCRIPTION
### Description

The Streamable HTTP endpoint was registered with two `Mount`s:

```python
Mount('/mcp', app=self.handle_streamable_http),
Mount('/mcp/', app=self.handle_streamable_http),
```

The second is a no-op: `Mount.__init__` does `self.path = path.rstrip("/")`, so both compile to the identical regex `^/mcp/(?P<path>.*)$`. A `Mount` only matches paths *under* the prefix (`/mcp/...`), so a request to the bare `/mcp` never matched and fell through to Starlette's `redirect_slashes` logic, which issued a **307 to `/mcp/`**. This broke strict proxies/clients that don't follow redirects mid-session (observed with agentgateway) and is misaligned with the MCP spec's single-endpoint requirement.

### Fix

Serve the bare `/mcp` path directly via a `Route`, keeping a `Mount` for any sub-paths:

```python
streamable_http_app = _ASGIApp(self.handle_streamable_http)
...
Route('/mcp', endpoint=streamable_http_app),
Mount('/mcp', app=streamable_http_app),
```

The handler is wrapped in a small `_ASGIApp` object so Starlette treats it as a raw ASGI endpoint (passing GET/POST/DELETE straight through) rather than a request/response function. This mirrors how the MCP Python SDK's `FastMCP` registers its streamable HTTP endpoint.

### Verification

- `GET`/`POST`/`DELETE /mcp` now return **200 with no `location` header** (previously 307).
- Added regression test `test_mcp_endpoint_no_redirect` and updated `test_create_app`.
- All package tests pass; `ruff format` + `ruff check` clean.

Resolves #271

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (CHANGELOG).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.