### PR TITLE
Fix OPENSEARCH_QUERY_TIMEOUT bare integer causing search failures (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix Streamable HTTP `/mcp` endpoint issuing a 307 redirect to `/mcp/`, which broke strict proxies/clients that don't follow redirects mid-session. The bare `/mcp` path is now served directly via a `Route` ([#273](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/273))
+- Normalize bare integer `OPENSEARCH_QUERY_TIMEOUT` values to seconds so `30` is treated as `30s` instead of causing OpenSearch parse errors ([#272](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/272))
 
 ### Removed
 

--- a/src/mcp_server_opensearch/__init__.py
+++ b/src/mcp_server_opensearch/__init__.py
@@ -157,7 +157,10 @@ def main() -> None:
     configure_logging(level=log_level, log_format=args.log_format)
     logger = logging.getLogger(__name__)
 
+    from opensearch.helper import log_query_timeout_warning
+
     logger.info('Starting MCP server...')
+    log_query_timeout_warning()
     cli_tool_overrides = parse_unknown_args_to_dict(unknown)
 
     # Import servers lazily to avoid circular imports at module load time

--- a/src/opensearch/helper.py
+++ b/src/opensearch/helper.py
@@ -64,6 +64,20 @@ logger = logging.getLogger(__name__)
 
 # List all the helper functions, these functions perform a single rest call to opensearch
 # these functions will be used in tools folder to eventually write more complex tools
+
+
+def log_query_timeout_warning() -> None:
+    """Warn when OPENSEARCH_QUERY_TIMEOUT is unitless and will be treated as seconds."""
+    raw_timeout = os.getenv('OPENSEARCH_QUERY_TIMEOUT', '').strip()
+    if raw_timeout.isdigit():
+        logger.warning(
+            'OPENSEARCH_QUERY_TIMEOUT=%s is unitless; treating it as %ss. '
+            'Set an explicit unit like "30s".',
+            raw_timeout,
+            raw_timeout,
+        )
+
+
 async def list_indices(args: ListIndicesArgs) -> json:
     """List indices matching the given pattern."""
     from .client import get_opensearch_client
@@ -120,12 +134,25 @@ async def search_index(args: SearchIndexArgs) -> json:
 
         search_params = {'index': args.index, 'body': query}
 
-        query_timeout = os.getenv('OPENSEARCH_QUERY_TIMEOUT', '').strip() or None
+        query_timeout = _normalize_query_timeout(os.getenv('OPENSEARCH_QUERY_TIMEOUT', ''))
         if query_timeout:
             search_params['cancel_after_time_interval'] = query_timeout
 
         response = await client.search(**search_params)
         return response
+
+
+def _normalize_query_timeout(raw_timeout: str) -> str | None:
+    """Normalize OPENSEARCH_QUERY_TIMEOUT for OpenSearch search requests.
+
+    Bare integers are treated as seconds so `30` behaves like `30s`.
+    """
+    timeout = raw_timeout.strip()
+    if not timeout:
+        return None
+    if timeout.isdigit():
+        return f'{timeout}s'
+    return timeout
 
 
 async def get_shards(args: GetShardsArgs) -> json:

--- a/tests/opensearch/test_helper.py
+++ b/tests/opensearch/test_helper.py
@@ -20,6 +20,7 @@ class TestOpenSearchHelper:
             get_index_mapping,
             get_shards,
             list_indices,
+            log_query_timeout_warning,
             search_index,
         )
 
@@ -28,6 +29,7 @@ class TestOpenSearchHelper:
         self.get_index_mapping = get_index_mapping
         self.search_index = search_index
         self.get_shards = get_shards
+        self.log_query_timeout_warning = log_query_timeout_warning
 
     @pytest.mark.asyncio
     @patch('opensearch.client.get_opensearch_client')
@@ -163,6 +165,35 @@ class TestOpenSearchHelper:
 
     @pytest.mark.asyncio
     @patch('opensearch.client.get_opensearch_client')
+    @patch.dict('os.environ', {'OPENSEARCH_QUERY_TIMEOUT': '30'})
+    async def test_search_index_with_bare_integer_query_timeout(self, mock_get_client):
+        """Test that a bare integer timeout is normalized to seconds."""
+        mock_response = {
+            'hits': {
+                'total': {'value': 1},
+                'hits': [{'_index': 'test-index', '_id': '1', '_source': {'field': 'value'}}],
+            }
+        }
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+
+        mock_get_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_get_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        test_query = {'query': {'match_all': {}}}
+
+        result = await self.search_index(
+            SearchIndexArgs(index='test-index', query_dsl=test_query, opensearch_cluster_name='')
+        )
+
+        assert result == mock_response
+        expected_body = {'query': {'match_all': {}}, 'size': 10}
+        mock_client.search.assert_called_once_with(
+            index='test-index', body=expected_body, cancel_after_time_interval='30s'
+        )
+
+    @pytest.mark.asyncio
+    @patch('opensearch.client.get_opensearch_client')
     @patch.dict('os.environ', {'OPENSEARCH_QUERY_TIMEOUT': '10s'})
     async def test_search_index_with_query_timeout(self, mock_get_client):
         """Test that OPENSEARCH_QUERY_TIMEOUT is passed as cancel_after_time_interval."""
@@ -221,6 +252,15 @@ class TestOpenSearchHelper:
         assert result == mock_response
         expected_body = {'query': {'match_all': {}}, 'size': 10}
         mock_client.search.assert_called_once_with(index='test-index', body=expected_body)
+
+    @patch.dict('os.environ', {'OPENSEARCH_QUERY_TIMEOUT': '30'})
+    def test_log_query_timeout_warning_for_unitless_value(self, caplog):
+        """Test that a unitless OPENSEARCH_QUERY_TIMEOUT emits a startup warning."""
+        with caplog.at_level('WARNING'):
+            self.log_query_timeout_warning()
+
+        assert 'OPENSEARCH_QUERY_TIMEOUT=30 is unitless' in caplog.text
+        assert 'treating it as 30s' in caplog.text
 
     @pytest.mark.asyncio
     @patch('opensearch.client.get_opensearch_client')


### PR DESCRIPTION
## Problem

Setting `OPENSEARCH_QUERY_TIMEOUT` to a bare integer (e.g., `30`) instead of an explicit unit (e.g., `30s`) silently breaks all SearchIndexTool queries with an opaque OpenSearch error:

```
illegal_argument_exception: failed to parse setting [cancel_after_time_interval] 
with value [30] as a time value: unit is missing or unrecognized
```

This inconsistency exists because `OPENSEARCH_TIMEOUT` (connection timeout) accepts bare seconds, but `OPENSEARCH_QUERY_TIMEOUT` (query timeout) requires explicit units. There was no validation or normalization, making misconfiguration a common footgun.

## Solution

- **Normalize** bare integers to seconds format: `30` → `30s` in `search_index()`
- **Warn** at MCP server startup if a unitless timeout is detected, so operators catch the misconfiguration immediately
- **Add regression tests** for timeout normalization and startup warning

## Changes

- `src/opensearch/helper.py`: Add `log_query_timeout_warning()` (startup check) and `_normalize_query_timeout()` (runtime normalization)
- `src/mcp_server_opensearch/__init__.py`: Call startup warning during server initialization
- `tests/opensearch/test_helper.py`: Add unit tests for normalization and startup warning
- `CHANGELOG.md`: Document the fix

## Testing

- ✅ Unit tests pass (43 tests in `tests/opensearch/test_helper.py`)
- ✅ Timeout normalization: bare `30` → `30s` in search parameters
- ✅ Startup warning: detects and warns on unitless timeout at boot
- ✅ Backward compatible: existing `30s` and `30ms` formats pass through unchanged

### Issues Resolved
https://github.com/opensearch-project/opensearch-mcp-server-py/issues/272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).