### PR TITLE
Add caller attribution to tool execution structured logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `ListIndexTool` now falls back to `GET /_resolve/index/*` when `_cat/indices` returns 403, allowing users with only index-level read permissions to list indices. The response is annotated when the fallback is used to indicate that health, size, and doc count are unavailable ([#279](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/279))
 - Add skills tools for root-cause analysis (`DataDistributionTool`, `LogPatternAnalysisTool`, `MetricChangeAnalysisTool`) that surface categorical value shifts, ML-clustered log patterns, and percentile changes between a baseline and an anomaly window. Skills tools are in the `skills_tools` category and can be enabled via `enabled_categories: ["skills_tools"]` ([#259](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/259))
 - Add `PPLQueryTool` for executing PPL (Piped Processing Language) queries via `/_plugins/_ppl` endpoint, with support for `jdbc`, `csv`, and `raw` output formats. Tool is in the `observability` category. ([#257](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/257))
+- Add client attribution to tool execution structured logs via optional `X-MCP-Client-Name` HTTP header. When multiple clients share a single MCP server, each client can identify itself and the `client_name` field appears in `tool_execution` log events for per-client metric filtering ([#281](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/281))
 
 
 ### Fixed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -987,6 +987,34 @@ python -m mcp_server_opensearch --log-format json
 
 For a complete RFC with detailed field references, metric filter patterns, and integration test results, see [RFC: Structured JSON Logging for Monitoring and Metrics](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/177).
 
+### Client Attribution
+
+When multiple clients share a single MCP server instance, you can identify each client in the structured logs by sending an `X-MCP-Client-Name` HTTP header. The server includes the header value as a `client_name` field in every `tool_execution` log event, enabling per-client metric filtering (e.g., CloudWatch MetricFilter dimensions, Datadog tags, or Grafana label selectors).
+
+**Setup:** Set the header on your HTTP client. For example, with Python's httpx:
+
+```python
+import httpx
+
+http_client = httpx.AsyncClient(
+    headers={"X-MCP-Client-Name": "my-agent"},
+)
+```
+
+All MCP requests made through this client will carry the header automatically.
+
+**Example log output:**
+
+```json
+{"timestamp": "2026-07-14T20:18:28.004Z", "level": "INFO", "event_type": "tool_execution", "tool_name": "SearchIndexTool", "status": "success", "duration_ms": 142.0, "client_name": "my-agent"}
+```
+
+**Behavior:**
+
+- If the header is absent, `client_name` defaults to `"unknown"`.
+- The value is sanitized: only alphanumeric characters, hyphens, underscores, and dots are allowed, with a maximum length of 64 characters. Invalid values fall back to `"unknown"`.
+- The middleware runs on all HTTP requests regardless of transport (Streamable HTTP `POST /mcp`, SSE `GET /sse`, and `POST /messages/`). Clients that set the header at the HTTP client level include it on every request automatically.
+
 ## LangChain Integration
 
 The OpenSearch MCP server can be easily integrated with LangChain using the SSE server transport.

--- a/src/mcp_server_opensearch/client_context.py
+++ b/src/mcp_server_opensearch/client_context.py
@@ -1,0 +1,86 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-request client identification for multi-client MCP deployments.
+
+Provides a Starlette middleware that extracts the ``X-MCP-Client-Name`` HTTP
+header from incoming requests and stores the value in a :mod:`contextvars`
+variable. Downstream code (e.g., :mod:`tool_executor`) reads the variable to
+include client attribution in structured log events, enabling per-client metric
+filtering without changes to the MCP protocol itself.
+
+The header is optional — if absent, the client name defaults to ``"unknown"``.
+"""
+
+import contextvars
+import re
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+#: Context variable holding the client name for the current request.
+#: Defaults to ``"unknown"`` when the ``X-MCP-Client-Name`` header is not provided.
+client_name_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    'mcp_client_name', default='unknown'
+)
+
+# Header name (lowercase for case-insensitive lookup in ASGI scope).
+_HEADER_NAME = b'x-mcp-client-name'
+
+# Maximum allowed length for the client name.
+_MAX_CLIENT_NAME_LENGTH = 64
+
+# Pattern: only alphanumeric, hyphens, underscores, and dots are allowed.
+_VALID_CLIENT_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9._-]+$')
+
+
+def _sanitize_client_name(raw: str) -> str:
+    """Sanitize and validate the client name header value.
+
+    Enforces a length limit and character allowlist to prevent log injection
+    or metric dimension pollution from malformed/malicious header values.
+
+    Args:
+        raw: The raw decoded header value.
+
+    Returns:
+        The sanitized client name, or ``"unknown"`` if the value is
+        empty or contains invalid characters.
+    """
+    if not raw:
+        return 'unknown'
+    truncated = raw[:_MAX_CLIENT_NAME_LENGTH]
+    if not _VALID_CLIENT_NAME_PATTERN.match(truncated):
+        return 'unknown'
+    return truncated
+
+
+class ClientNameMiddleware:
+    """Pure-ASGI middleware that extracts ``X-MCP-Client-Name`` into a contextvar.
+
+    Using a raw ASGI middleware (instead of Starlette's BaseHTTPMiddleware)
+    avoids the per-request overhead of wrapping the response in a background
+    task and is compatible with streaming/SSE endpoints.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Initialize with the wrapped ASGI application."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Extract client name header and forward to the wrapped app."""
+        if scope['type'] not in ('http', 'websocket'):
+            await self.app(scope, receive, send)
+            return
+
+        # Extract X-MCP-Client-Name from raw ASGI headers (list of [name, value] byte pairs).
+        client_name = 'unknown'
+        for header_name, header_value in scope.get('headers', []):
+            if header_name == _HEADER_NAME:
+                client_name = _sanitize_client_name(header_value.decode('latin-1'))
+                break
+
+        token = client_name_var.set(client_name)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            client_name_var.reset(token)

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -9,6 +9,7 @@ from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import CallToolResult, Tool
+from mcp_server_opensearch.client_context import ClientNameMiddleware
 from mcp_server_opensearch.clusters_information import load_clusters_from_yaml
 from mcp_server_opensearch.global_state import set_config_file_path, set_mode, set_profile
 from mcp_server_opensearch.server_instructions import get_server_instructions
@@ -155,7 +156,7 @@ class MCPStarletteApp:
         """Create the Starlette application with routes."""
         # Serve bare '/mcp' via Route (a Mount alone 307-redirects '/mcp' to '/mcp/'); Mount handles sub-paths.
         streamable_http_app = _ASGIApp(self.handle_streamable_http)
-        return Starlette(
+        app = Starlette(
             routes=[
                 Route('/sse', endpoint=self.handle_sse, methods=['GET']),
                 Route('/health', endpoint=self.handle_health, methods=['GET']),
@@ -165,6 +166,8 @@ class MCPStarletteApp:
             ],
             lifespan=self.lifespan,
         )
+        app.add_middleware(ClientNameMiddleware)
+        return app
 
 
 async def serve(

--- a/src/mcp_server_opensearch/tool_executor.py
+++ b/src/mcp_server_opensearch/tool_executor.py
@@ -18,6 +18,7 @@ tool invocation, enabling metric filters for:
 import logging
 import time
 from mcp.types import CallToolResult, TextContent
+from mcp_server_opensearch.client_context import client_name_var
 
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,7 @@ async def execute_tool(
             'tool_name': name,
             'status': status,
             'duration_ms': duration_ms,
+            'client_name': client_name_var.get('unknown'),
         }
         if found_tool_key:
             log_extra['tool_key'] = found_tool_key

--- a/tests/mcp_server_opensearch/test_client_context.py
+++ b/tests/mcp_server_opensearch/test_client_context.py
@@ -1,0 +1,115 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from mcp_server_opensearch.client_context import (
+    _MAX_CLIENT_NAME_LENGTH,
+    ClientNameMiddleware,
+    _sanitize_client_name,
+    client_name_var,
+)
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+def _make_app():
+    """Create a minimal Starlette app that echoes the client_name_var value."""
+
+    async def echo_client_name(request: Request) -> JSONResponse:
+        return JSONResponse({'client_name': client_name_var.get('unknown')})
+
+    app = Starlette(routes=[Route('/test', endpoint=echo_client_name)])
+    app.add_middleware(ClientNameMiddleware)
+    return app
+
+
+class TestSanitizeClientName:
+    """Tests for the _sanitize_client_name validation function."""
+
+    def test_valid_simple_name(self):
+        """Alphanumeric names pass through unchanged."""
+        assert _sanitize_client_name('default') == 'default'
+        assert _sanitize_client_name('art') == 'art'
+
+    def test_valid_with_hyphens_underscores_dots(self):
+        """Hyphens, underscores, and dots are allowed."""
+        assert _sanitize_client_name('my-agent') == 'my-agent'
+        assert _sanitize_client_name('my_agent') == 'my_agent'
+        assert _sanitize_client_name('agent.v2') == 'agent.v2'
+
+    def test_empty_string_returns_unknown(self):
+        """Empty header value defaults to unknown."""
+        assert _sanitize_client_name('') == 'unknown'
+
+    def test_too_long_is_truncated(self):
+        """Values exceeding the max length are truncated."""
+        long_value = 'a' * 200
+        result = _sanitize_client_name(long_value)
+        assert len(result) == _MAX_CLIENT_NAME_LENGTH
+        assert result == 'a' * _MAX_CLIENT_NAME_LENGTH
+
+    def test_invalid_characters_returns_unknown(self):
+        """Values with special characters are rejected."""
+        assert _sanitize_client_name('agent;DROP TABLE') == 'unknown'
+        assert _sanitize_client_name('agent\ninjection') == 'unknown'
+        assert _sanitize_client_name('agent/sub') == 'unknown'
+        assert _sanitize_client_name('<script>alert(1)</script>') == 'unknown'
+        assert _sanitize_client_name('agent name with spaces') == 'unknown'
+
+    def test_truncation_before_validation(self):
+        """Truncation happens before character validation."""
+        # Valid chars but too long — should truncate and pass
+        valid_long = 'a-b_c.' * 20  # 120 chars
+        result = _sanitize_client_name(valid_long)
+        assert len(result) == _MAX_CLIENT_NAME_LENGTH
+
+
+class TestClientNameMiddleware:
+    """Tests for the X-MCP-Client-Name header extraction middleware."""
+
+    def test_header_present_sets_client_name(self):
+        """Middleware extracts X-MCP-Client-Name header value into contextvar."""
+        client = TestClient(_make_app())
+        response = client.get('/test', headers={'X-MCP-Client-Name': 'my-agent'})
+        assert response.status_code == 200
+        assert response.json() == {'client_name': 'my-agent'}
+
+    def test_header_absent_defaults_to_unknown(self):
+        """Without the header, client name defaults to 'unknown'."""
+        client = TestClient(_make_app())
+        response = client.get('/test')
+        assert response.status_code == 200
+        assert response.json() == {'client_name': 'unknown'}
+
+    def test_header_case_insensitive(self):
+        """HTTP headers are case-insensitive; lowercase should work."""
+        client = TestClient(_make_app())
+        response = client.get('/test', headers={'x-mcp-client-name': 'lower-case'})
+        assert response.status_code == 200
+        assert response.json() == {'client_name': 'lower-case'}
+
+    def test_client_name_does_not_leak_across_requests(self):
+        """Each request gets its own contextvar scope."""
+        client = TestClient(_make_app())
+        resp1 = client.get('/test', headers={'X-MCP-Client-Name': 'agent-a'})
+        resp2 = client.get('/test')
+        resp3 = client.get('/test', headers={'X-MCP-Client-Name': 'agent-b'})
+
+        assert resp1.json() == {'client_name': 'agent-a'}
+        assert resp2.json() == {'client_name': 'unknown'}
+        assert resp3.json() == {'client_name': 'agent-b'}
+
+    def test_malicious_header_sanitized(self):
+        """Headers with invalid characters are sanitized to 'unknown'."""
+        client = TestClient(_make_app())
+        response = client.get('/test', headers={'X-MCP-Client-Name': 'evil\ninjection'})
+        assert response.json() == {'client_name': 'unknown'}
+
+    def test_oversized_header_truncated(self):
+        """Headers exceeding max length are truncated."""
+        client = TestClient(_make_app())
+        long_name = 'a' * 200
+        response = client.get('/test', headers={'X-MCP-Client-Name': long_name})
+        assert len(response.json()['client_name']) == _MAX_CLIENT_NAME_LENGTH

--- a/tests/mcp_server_opensearch/test_tool_executor.py
+++ b/tests/mcp_server_opensearch/test_tool_executor.py
@@ -4,6 +4,7 @@
 import logging
 import pytest
 from mcp.types import CallToolResult
+from mcp_server_opensearch.client_context import client_name_var
 from mcp_server_opensearch.tool_executor import execute_tool
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -180,3 +181,44 @@ class TestExecuteTool:
         records = [r for r in caplog.records if hasattr(r, 'tool_key')]
         assert len(records) == 1
         assert records[0].tool_key == 'SearchIndexTool'
+
+    @pytest.mark.asyncio
+    @patch('tools.tool_params.validate_args_for_mode')
+    async def test_client_name_field_logged_from_contextvar(self, mock_validate, caplog):
+        """The 'client_name' field in the log reflects the client_name_var contextvar."""
+        mock_validate.return_value = Mock()
+        enabled_tools = make_enabled_tools()
+
+        # Simulate middleware having set the client name
+        token = client_name_var.set('test-agent')
+        try:
+            with caplog.at_level(logging.INFO):
+                await execute_tool('TestTool', {}, enabled_tools)
+        finally:
+            client_name_var.reset(token)
+
+        records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
+        assert len(records) == 1
+        assert records[0].client_name == 'test-agent'
+
+    @pytest.mark.asyncio
+    @patch('tools.tool_params.validate_args_for_mode')
+    async def test_client_name_defaults_to_unknown(self, mock_validate, caplog):
+        """Without middleware, client name defaults to 'unknown'."""
+        mock_validate.return_value = Mock()
+        enabled_tools = make_enabled_tools()
+
+        with caplog.at_level(logging.INFO):
+            await execute_tool('TestTool', {}, enabled_tools)
+
+        records = [
+            r
+            for r in caplog.records
+            if hasattr(r, 'event_type') and r.event_type == 'tool_execution'
+        ]
+        assert len(records) == 1
+        assert records[0].client_name == 'unknown'


### PR DESCRIPTION
### Description
When different agents or applications share a single MCP server instance, there is no way to attribute tool execution metrics to a specific caller. This adds support for an optional X-MCP-Caller HTTP header that agents or applications can set to identify themselves.

Changes:
- New caller_context.py: pure-ASGI middleware extracts X-MCP-Caller header into a contextvars.ContextVar (defaults to "unknown" if absent)
- tool_executor.py: includes "caller" field in every tool_execution log event
- streaming_server.py: registers the middleware on the Starlette app
- Tests for the middleware and the updated log field

The header is optional and backward-compatible — existing clients that do not send the header will appear as caller="unknown" in logs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).