### PR TITLE
Constrain mcp[cli] below 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix Streamable HTTP `/mcp` endpoint issuing a 307 redirect to `/mcp/`, which broke strict proxies/clients that don't follow redirects mid-session. The bare `/mcp` path is now served directly via a `Route` ([#273](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/273))
+- Constrain `mcp[cli]` to `>=1.9.4,<2`. The `mcp` 2.0 release removes the `@server.list_tools()` and `@server.call_tool()` decorators and the `request_ctx` contextvar that this server is built on, so an unbounded floor resolved to an incompatible major version and broke installs and CI
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,11 @@ dependencies = [
     "aiohttp>=3.13.4",
     "boto3>=1.39.0",
     "idna>=3.15",
-    "mcp[cli]>=1.9.4",
+    # Capped below 2.0: mcp 2.0 removes the @server.list_tools()/@server.call_tool()
+    # decorators and the request_ctx contextvar this server is built on, replacing
+    # them with constructor-injected handlers that receive request context explicitly.
+    # Porting to that API is tracked separately.
+    "mcp[cli]>=1.9.4,<2",
     "numpy>=1.24.0",
     "opensearch-py==3.1.0",
     "pydantic>=2.11.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1368,7 +1368,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "boto3", specifier = ">=1.39.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.9.4" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.9.4,<2" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "opensearch-py", specifier = "==3.1.0" },
     { name = "pydantic", specifier = ">=2.11.3" },


### PR DESCRIPTION
## Summary

The `mcp[cli]` dependency had an unbounded floor of `>=1.9.4`. When `mcp` 2.0.0 was released, a fresh install and `uv sync` both began resolving to it, and CI failed at integration test collection:

```
ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'
```

This caps the dependency at `>=1.9.4,<2` so installs stay on the 1.x line the code targets. It is a dependency constraint only, with no source changes.

## Why cap rather than port

Two APIs are gone in 2.0, not the one the error names.

| API in use | 2.0 |
|---|---|
| `streamablehttp_client` | Renamed to `streamable_http_client` |
| `@server.list_tools()` / `@server.call_tool()` | Removed. Handlers are now passed to the `Server` constructor (`on_list_tools=`, `on_call_tool=`) and receive a `ServerRequestContext` argument |
| `request_ctx` contextvar | Removed outright, not renamed |
| `Server.run(..., stateless=)` | Parameter dropped |
| `Server.__init__` | Keyword-only after `name` |

The decorator removal and the `request_ctx` removal are the same underlying change: 2.0 stopped using an ambient contextvar and now threads request context explicitly into handlers. Both server entrypoints (`streaming_server.py`, `stdio_server.py`) register their handlers through the decorators, and `_get_auth_from_headers` in `src/opensearch/client.py` reads the request through `request_ctx.get()`, so the request context has to flow from the new handler signature down into that function.

That makes 2.0 a port of the server layer rather than a compatibility fix, and it deserves its own change with its own review. Capping restores working installs now.

One thing worth flagging for whoever picks up the port: `_get_auth_from_headers` wraps its body in `except Exception` and returns all-`None` on failure, so a context that is not wired correctly would silently report "no headers present" rather than erroring. Every header credential path (`opensearch-url`, `aws-*`, `Authorization`) would quietly fall back to environment or anonymous credentials. The six existing tests that patch `opensearch.client.request_ctx` would still pass, since they patch the symbol being removed, so the port needs coverage that does not rely on that contextvar.

## Test plan

- [x] Clean install with the cap resolves `mcp` 1.29.0, the newest 1.x, and both previously failing imports succeed
- [x] `uv sync` resolves 1.28.1 per the lockfile
- [x] Integration test collection succeeds, 122 tests collected, which is the step that failed in CI
- [x] 584 unit tests pass, 3 skipped, identical to the pre-cap baseline on the same commit
- [x] `uv run ruff format --check .` and `uv run ruff check .` both clean

## Notes for reviewers

`uv.lock` changes by one line, the recorded specifier for `mcp`. The resolved version is unchanged at 1.28.1, so no package is upgraded or downgraded by this PR. Running `uv lock` locally rewrote every `upload-time` key to `upload_time` across the file, which is a `uv` version difference unrelated to this change, so the specifier was edited directly to keep the diff reviewable.

CI installs with `uv sync` rather than `uv sync --frozen`, so it re-resolves and will pick up a new major version whenever the constraints allow. That is how 2.0.0 was reached. The cap closes that for `mcp`; other unbounded floors in `pyproject.toml` have the same exposure and are worth a separate look.
