### PR TITLE
Prepare 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [Released 0.11.0]
+
+### Added
+
 - Set MCP `CallToolResult.isError` when tool responses indicate failure (`is_error`), so clients can distinguish errors from successful tool calls ([#265](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/265))
 - `ListIndexTool` now falls back to `GET /_resolve/index/*` when `_cat/indices` returns 403, allowing users with only index-level read permissions to list indices. The response is annotated when the fallback is used to indicate that health, size, and doc count are unavailable ([#279](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/279))
 - Add skills tools for root-cause analysis (`DataDistributionTool`, `LogPatternAnalysisTool`, `MetricChangeAnalysisTool`) that surface categorical value shifts, ML-clustered log patterns, and percentile changes between a baseline and an anomaly window. Skills tools are in the `skills_tools` category and can be enabled via `enabled_categories: ["skills_tools"]` ([#259](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/259))
 - Add `PPLQueryTool` for executing PPL (Piped Processing Language) queries via `/_plugins/_ppl` endpoint, with support for `jdbc`, `csv`, and `raw` output formats. Tool is in the `observability` category. ([#257](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/257))
 - Add client attribution to tool execution structured logs via optional `X-MCP-Client-Name` HTTP header. When multiple clients share a single MCP server, each client can identify itself and the `client_name` field appears in `tool_execution` log events for per-client metric filtering ([#281](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/281))
-
 
 ### Fixed
 - Fix Streamable HTTP `/mcp` endpoint issuing a 307 redirect to `/mcp/`, which broke strict proxies/clients that don't follow redirects mid-session. The bare `/mcp` path is now served directly via a `Route` ([#273](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/273))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensearch-mcp-server-py"
-version = "0.10.0"
+version = "0.11.0"
 description = "OpenSearch MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Description

Prepares the `0.11.0` release.

- Bump version `0.10.0` -> `0.11.0` in `pyproject.toml`.
- Roll the `[Unreleased]` CHANGELOG section into `## [Released 0.11.0]` and add a fresh empty `[Unreleased]` skeleton for the next cycle.

Release `0.11.0` contents (from `[Unreleased]`):

**Added**
- Set MCP `CallToolResult.isError` when tool responses indicate failure (#265)
- `ListIndexTool` falls back to `GET /_resolve/index/*` on 403 (#279)
- RCA skills tools: `DataDistributionTool`, `LogPatternAnalysisTool`, `MetricChangeAnalysisTool` (#259)
- `PPLQueryTool` for PPL queries via `/_plugins/_ppl` (#257)
- Client attribution in structured logs via `X-MCP-Client-Name` header (#281)

**Fixed**
- Streamable HTTP `/mcp` 307 redirect served directly via a `Route` (#273)
- Constrain `mcp[cli]` to `>=1.9.4,<2`

### Check List
- [x] Built distribution with `uv build` (wheel + sdist, both `0.11.0`).
- [x] `twine check dist/*` passed for both artifacts.
- [x] Installed both sdist and wheel in clean environments; `importlib.metadata` reports `0.11.0`, new tools present in `TOOL_REGISTRY`, console scripts intact.
- [x] Commits are signed off (`-s`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.