### PR TITLE
Fix CVE-2026-7246 by requiring click>=8.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix Streamable HTTP `/mcp` endpoint issuing a 307 redirect to `/mcp/`, which broke strict proxies/clients that don't follow redirects mid-session. The bare `/mcp` path is now served directly via a `Route` ([#273](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/273))
 - Constrain `mcp[cli]` to `>=1.9.4,<2`. The `mcp` 2.0 release removes the `@server.list_tools()` and `@server.call_tool()` decorators and the `request_ctx` contextvar that this server is built on, so an unbounded floor resolved to an incompatible major version and broke installs and CI
+- Fix CVE-2026-7246 by requiring `click>=8.3.3`, and sync the `uv.lock` project version to 0.11.0 ([#286](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/286))
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.13.4",
     "boto3>=1.39.0",
+    "click>=8.3.3",
     "idna>=3.15",
     # Capped below 2.0: mcp 2.0 removes the @server.list_tools()/@server.call_tool()
     # decorators and the request_ctx contextvar this server is built on, replacing

--- a/uv.lock
+++ b/uv.lock
@@ -431,14 +431,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1324,11 +1324,12 @@ wheels = [
 
 [[package]]
 name = "opensearch-mcp-server-py"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },
+    { name = "click" },
     { name = "idna" },
     { name = "mcp", extra = ["cli"] },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1367,6 +1368,7 @@ integration = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "boto3", specifier = ">=1.39.0" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "idna", specifier = ">=3.15" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.4,<2" },
     { name = "numpy", specifier = ">=1.24.0" },


### PR DESCRIPTION
### Description

Mend flagged `click` 8.3.1 in `uv.lock` for [CVE-2026-7246](https://www.mend.io/vulnerability-database/CVE-2026-7246) (CVSS 7.2), a command injection in `click.edit()` affecting 8.3.2 and below.

`click` is purely transitive here — `mcp[cli]` pulls it in through both `uvicorn` and `typer`. Neither this server nor those two call `click.edit()`, so there is no reachable path and no practical exposure. The lockfile still resolves an affected version though, so the scanner reports it on every commit.

This adds a direct `click>=8.3.3` floor, which raises the lock to 8.4.2. That follows how `idna` and `urllib3` are already handled in `pyproject.toml`: a direct constraint on a transitive dependency, needed because no `mcp` release has bounds that exclude the affected `click` versions.

Also syncs the `uv.lock` project version to 0.11.0 — the 0.11.0 release bumped `pyproject.toml` but left the lock at 0.10.0, and `uv lock` corrects it. The changelog entry is filed under 0.11.0 since this is intended to ship with that release.

Verification:
- `click` 8.3.3 and 8.4.2 both keep `requires-python >=3.10`, so the project floor is unaffected.
- Full unit suite passes (584 passed, 3 skipped); `ruff check` clean.
- Streaming server starts and serves under `uvicorn` with `click` 8.4.2.
- An OSV `querybatch` over every package in `uv.lock` reports `click` as the only one with an outstanding advisory.

### Issues Resolved

Closes #286

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).