### PR TITLE
Make AWS and ML dependencies optional extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,14 +155,14 @@ jobs:
 
       - name: Install from tar.gz (Unix)
         if: runner.os != 'Windows'
-        run: pip install dist/*.tar.gz
+        run: pip install "$(ls dist/*.tar.gz)[aws]"
 
       - name: Install from tar.gz (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $tarball = Get-ChildItem dist/*.tar.gz | Select-Object -First 1
-          pip install $tarball.FullName
+          pip install "$($tarball.FullName)[aws]"
 
       - name: Show metadata (tar.gz)
         run: pip show opensearch-mcp-server-py
@@ -172,14 +172,14 @@ jobs:
 
       - name: Install from wheel (Unix)
         if: runner.os != 'Windows'
-        run: pip install dist/*.whl
+        run: pip install "$(ls dist/*.whl)[aws]"
 
       - name: Install from wheel (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $wheel = Get-ChildItem dist/*.whl | Select-Object -First 1
-          pip install $wheel.FullName
+          pip install "$($wheel.FullName)[aws]"
 
       - name: Show metadata (wheel)
         run: pip show opensearch-mcp-server-py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv sync
+          uv sync --all-extras
 
       - name: Check formatting
         run: uv run ruff format --check .
@@ -121,7 +121,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv sync
+          uv sync --all-extras
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
@@ -129,7 +129,7 @@ jobs:
         run: |
           uv venv
           .\.venv\Scripts\Activate.ps1
-          uv sync
+          uv sync --all-extras
 
       - name: Run unit tests (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Changed
+- Move AWS and ML dependencies into optional extras. `boto3`, `requests-aws4auth` are now installed via `opensearch-mcp-server-py[aws]` and `numpy`, `scipy`, `scikit-learn` via `[ml]` (`[all]` installs both). The base install drops from 67 to 57 packages and from ~330 MB to ~86 MB, and no longer imports the ML stack at startup. `LogPatternAnalysisTool` is registered only when the `ml` extra is present; `DataDistributionTool` and `MetricChangeAnalysisTool` are pure Python and unaffected. AWS code paths import `boto3` on demand and report the required extra if it is missing ([#296](https://github.com/opensearch-project/opensearch-mcp-server-py/issues/296))
 - Upgrade `mcp[cli]` to `>=2.0.0`. Ports the server to the mcp 2.0 API: replaces removed `@server.list_tools()` / `@server.call_tool()` decorators with constructor-injected `on_list_tools` / `on_call_tool` handlers, replaces removed `request_ctx` contextvar with a local `request_context_var`, and updates renamed fields (`isError` → `is_error`, `inputSchema` → `input_schema`). Integration test client updated for the renamed `streamable_http_client` function and `httpx2`-based header/timeout configuration ([#292](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/292))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Opensearch-mcp-server-py can be installed from [PyPI](https://pypi.org/project/o
 pip install opensearch-mcp-server-py
 ```
 
+### Optional features
+
+The base install covers no-auth, basic-auth and bearer-token connections. Two features
+ship as extras, so their dependencies are only downloaded when you need them:
+
+| Extra | Install | Adds |
+|---|---|---|
+| `aws` | `pip install "opensearch-mcp-server-py[aws]"` | AWS authentication: IAM credentials, assumed roles, SigV4 signing, region discovery from profiles |
+| `ml` | `pip install "opensearch-mcp-server-py[ml]"` | `LogPatternAnalysisTool`, which clusters log messages |
+| `all` | `pip install "opensearch-mcp-server-py[all]"` | Both of the above |
+
+`DataDistributionTool` and `MetricChangeAnalysisTool` are always available — they need no
+extra. `LogPatternAnalysisTool` is only registered when the `ml` extra is installed, and
+AWS authentication reports which extra to install if it is missing.
+
 ### Zero-Config Setup
 
 The server can be started with no environment variables at all. Agents provide connection details dynamically on each tool call:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -43,6 +43,40 @@ Install from [PyPI](https://pypi.org/project/opensearch-mcp-server-py/):
 pip install opensearch-mcp-server-py
 ```
 
+### Optional extras
+
+The base install supports no-auth, basic-auth and bearer-token connections. Add an extra
+if you need AWS authentication or log pattern analysis:
+
+```bash
+pip install "opensearch-mcp-server-py[aws]"   # IAM credentials, assumed roles, SigV4 signing
+pip install "opensearch-mcp-server-py[ml]"    # LogPatternAnalysisTool (clusters log messages)
+pip install "opensearch-mcp-server-py[all]"   # both
+```
+
+With `uvx`, request the extra in the package spec:
+
+```json
+{
+  "mcpServers": {
+    "opensearch": {
+      "command": "uvx",
+      "args": ["opensearch-mcp-server-py[aws]"]
+    }
+  }
+}
+```
+
+Notes:
+- `LogPatternAnalysisTool` is only registered when the `ml` extra is present. The other
+  analysis tools (`DataDistributionTool`, `MetricChangeAnalysisTool`) are pure Python and
+  always available.
+- If AWS authentication is configured without the `aws` extra, the server reports the
+  exact install command instead of failing with an import traceback.
+- Keeping the extras out of the base install matters for `stdio` clients: the ML stack
+  alone is about 180 MB and adds several seconds to every server start, which counts
+  against the client's `initialize` deadline.
+
 ## Quick Start
 
 ### Prerequisites

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -56,7 +56,14 @@ def _create_os_client():
 
     if aws_key and aws_secret:
         from opensearchpy import RequestsHttpConnection
-        from requests_aws4auth import AWS4Auth
+
+        try:
+            from requests_aws4auth import AWS4Auth
+        except ImportError:
+            pytest.skip(
+                'AWS integration tests need the "aws" extra: '
+                'pip install "opensearch-mcp-server-py[aws]"'
+            )
 
         session_token = os.environ.get('IT_AWS_SESSION_TOKEN', '')
         aws_auth = AWS4Auth(aws_key, aws_secret, aws_region, 'es', session_token=session_token)

--- a/integration_tests/errors/test_credential_isolation.py
+++ b/integration_tests/errors/test_credential_isolation.py
@@ -15,6 +15,7 @@ No cluster and no AWS credentials are needed. Each case is refused before any
 network call, so the caller's URL is never contacted.
 """
 
+import importlib.util
 import os
 import pytest
 from integration_tests.framework.assertions import assert_tool_error
@@ -28,6 +29,13 @@ UNREACHED_URL = 'https://caller-chosen.us-east-1.es.amazonaws.com'
 NO_CALLER_CREDS = 'No caller-supplied credentials for the requested URL'
 NO_BASE_CREDS_FOR_ROLE = 'No caller-supplied base credentials to assume the requested IAM role'
 BAD_PROFILE = 'Failed to create boto3 session with the requested profile'
+
+# The profile guard runs inside boto3 session creation, so it only exists when the
+# "aws" extra is installed. Without it the server refuses earlier, naming the extra.
+requires_aws_extra = pytest.mark.skipif(
+    importlib.util.find_spec('boto3') is None,
+    reason='needs the "aws" extra: pip install "opensearch-mcp-server-py[aws]"',
+)
 
 # The test host may have usable AWS credentials in ~/.aws or an instance role, which
 # would let the opt-in succeed where a test means to leave the server nothing to fall
@@ -109,6 +117,7 @@ class TestCredentialIsolation:
         )
         assert_tool_error(result, NO_BASE_CREDS_FOR_ROLE)
 
+    @requires_aws_extra
     async def test_named_profile_that_fails_to_build_is_fatal(self):
         """A caller-named profile must not quietly degrade to the server's identity."""
         result = await _call_list_indices(
@@ -226,6 +235,7 @@ class TestAmbientAwsFallbackOptIn:
         )
         assert_tool_error(result, NO_CALLER_CREDS)
 
+    @requires_aws_extra
     async def test_enabled_keeps_failed_profile_fatal(self):
         """A profile that cannot build must not degrade to the default identity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,13 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.3",
-    "boto3>=1.39.0",
     "click>=8.3.3",
     "idna>=3.15",
     "mcp[cli]>=2.0.0",
-    "numpy>=1.24.0",
     "opensearch-py==3.1.0",
     "pydantic>=2.11.3",
     "pyyaml>=6.0.2",
     "requests>=2.33.0",
-    "requests-aws4auth>=1.3.1",
-    "scikit-learn>=1.3.0",
-    "scipy>=1.10.0",
     "semver>=3.0.4",
     "pyjwt>=2.13.0",
     "urllib3>=2.7.0",
@@ -25,6 +20,22 @@ dependencies = [
 
 license = "Apache-2.0"
 license-files = ["LICENSE.txt", "NOTICE.txt"]
+
+[project.optional-dependencies]
+# AWS authentication (IAM credentials, assumed roles, SigV4 signing).
+aws = [
+    "boto3>=1.39.0",
+    "requests-aws4auth>=1.3.1",
+]
+# Log pattern analysis: clustering of log messages.
+ml = [
+    "numpy>=1.24.0",
+    "scikit-learn>=1.3.0",
+    "scipy>=1.10.0",
+]
+all = [
+    "opensearch-mcp-server-py[aws,ml]",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,19 @@ all = [
 ]
 
 [dependency-groups]
+# The optional extras are included here so the full test suite runs on a plain
+# `uv sync`: the tests exercise the AWS and analysis code paths directly.
 dev = [
     "anthropic>=0.50.0",
+    "boto3>=1.39.0",
+    "numpy>=1.24.0",
     "pytest>=8.3.5",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.2.1",
+    "requests-aws4auth>=1.3.1",
     "ruff>=0.9.7",
+    "scikit-learn>=1.3.0",
+    "scipy>=1.10.0",
 ]
 integration = [
     "pytest>=8.3.5",

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -8,7 +8,6 @@ authentication methods and connection modes (single vs multi-cluster).
 """
 
 import asyncio
-import boto3
 import importlib.metadata
 import ipaddress
 import logging
@@ -18,7 +17,6 @@ from .connection import (
     BufferedAsyncHttpConnection,
     OpenSearchClientError,
 )
-from botocore.credentials import Credentials
 from contextlib import asynccontextmanager
 from http.client import HTTP_PORT, HTTPS_PORT
 from mcp_server_opensearch.client_context import request_context_var
@@ -61,6 +59,62 @@ class ConfigurationError(OpenSearchClientError):
     """Exception raised when configuration is invalid."""
 
     pass
+
+
+AWS_EXTRA_HINT = (
+    'AWS authentication requires the optional "aws" dependencies. '
+    'Install them with: pip install "opensearch-mcp-server-py[aws]"'
+)
+
+
+def _import_boto3():
+    """Import boto3 on demand.
+
+    boto3 is only needed for AWS authentication, so it is imported here rather than at
+    module level. That keeps it out of the import path for basic-auth, no-auth and
+    bearer-token users, who make up the majority of self-managed deployments.
+    """
+    try:
+        import boto3
+    except ImportError as e:
+        raise ConfigurationError(AWS_EXTRA_HINT) from e
+    return boto3
+
+
+def _import_aws_credentials():
+    """Import botocore's Credentials on demand. See _import_boto3."""
+    try:
+        from botocore.credentials import Credentials
+    except ImportError as e:
+        raise ConfigurationError(AWS_EXTRA_HINT) from e
+    return Credentials
+
+
+def _optional_boto3():
+    """Return boto3 if the "aws" extra is installed, otherwise None.
+
+    Used by region discovery, where a missing region is an acceptable outcome for
+    basic-auth and no-auth deployments and must not turn into an error.
+    """
+    try:
+        import boto3
+    except ImportError:
+        logger.debug('boto3 is not installed; skipping AWS region discovery')
+        return None
+    return boto3
+
+
+def __getattr__(name: str):
+    """Expose boto3 and Credentials as module attributes without importing them eagerly.
+
+    Keeps `opensearch.client.boto3` resolvable for callers and test patches while the
+    actual import stays deferred until an AWS code path runs.
+    """
+    if name == 'boto3':
+        return _import_boto3()
+    if name == 'Credentials':
+        return _import_aws_credentials()
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
 # Public API Functions
@@ -841,18 +895,27 @@ def _create_opensearch_client(
     else:
         logger.info('Configuring OpenSearch client with no response size limit')
 
-    # Create boto3 session
-    try:
-        session = boto3.Session(profile_name=profile) if profile else boto3.Session()
-    except Exception as e:
-        # Falling back to a bare session here would swap the caller's chosen
-        # profile for the server's own credentials, so fail instead.
-        if require_named_profile:
-            raise AuthenticationError(
-                f"Failed to create boto3 session with the requested profile '{profile}': {e}"
-            )
-        logger.warning(f"Failed to create boto3 session with profile '{profile}': {e}")
-        session = boto3.Session()
+    # Create the boto3 session lazily: only the IAM-role and AWS-credentials paths below
+    # need it, so no-auth, bearer-token and basic-auth connections never import boto3.
+    _session = None
+
+    def get_session():
+        nonlocal _session
+        if _session is not None:
+            return _session
+        boto3 = _import_boto3()
+        try:
+            _session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+        except Exception as e:
+            # Falling back to a bare session here would swap the caller's chosen
+            # profile for the server's own credentials, so fail instead.
+            if require_named_profile:
+                raise AuthenticationError(
+                    f"Failed to create boto3 session with the requested profile '{profile}': {e}"
+                )
+            logger.warning(f"Failed to create boto3 session with profile '{profile}': {e}")
+            _session = boto3.Session()
+        return _session
 
     # Authentication logic with proper error handling
     try:
@@ -887,7 +950,7 @@ def _create_opensearch_client(
                     raise AuthenticationError(
                         'AWS region is required for header-based authentication'
                     )
-                credentials = Credentials(
+                credentials = _import_aws_credentials()(
                     access_key=aws_access_key_id,
                     secret_key=aws_secret_access_key,
                     token=aws_session_token,
@@ -916,12 +979,12 @@ def _create_opensearch_client(
                 if not aws_region or (isinstance(aws_region, str) and not aws_region.strip()):
                     raise AuthenticationError('AWS region is required for IAM role authentication')
 
-                sts_client = session.client('sts', region_name=aws_region)
+                sts_client = get_session().client('sts', region_name=aws_region)
                 assumed_role = sts_client.assume_role(
                     RoleArn=iam_arn.strip(), RoleSessionName='OpenSearchClientSession'
                 )
                 creds_dict = assumed_role['Credentials']
-                credentials = Credentials(
+                credentials = _import_aws_credentials()(
                     access_key=creds_dict['AccessKeyId'],
                     secret_key=creds_dict['SecretAccessKey'],
                     token=creds_dict.get('SessionToken'),
@@ -963,7 +1026,7 @@ def _create_opensearch_client(
                     'AWS region is required for AWS credentials authentication'
                 )
 
-            credentials = session.get_credentials()
+            credentials = get_session().get_credentials()
             if not credentials:
                 raise AuthenticationError('No AWS credentials found in session')
 
@@ -1069,6 +1132,12 @@ def get_aws_region_single_mode() -> Optional[str]:
             logger.debug(f'Using AWS_REGION: {aws_region}')
             return aws_region
 
+        # The remaining lookups need boto3; without the "aws" extra there is no region
+        # to discover, which is fine for basic auth and no auth.
+        boto3 = _optional_boto3()
+        if boto3 is None:
+            return None
+
         # Try command line argument, then environment variable
         aws_profile = get_profile() or os.getenv('AWS_PROFILE', '').strip()
         if aws_profile:
@@ -1124,7 +1193,8 @@ def get_aws_region_multi_mode(cluster_info: ClusterInfo) -> Optional[str]:
             return cluster_info.aws_region.strip()
 
         # Try cluster-specific profile
-        if cluster_info.profile and cluster_info.profile.strip():
+        boto3 = _optional_boto3()
+        if boto3 is not None and cluster_info.profile and cluster_info.profile.strip():
             try:
                 session = boto3.Session(profile_name=cluster_info.profile)
                 region = session.region_name

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -1,10 +1,10 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib.util
 import logging
 from .analysis.data_distribution import execute_data_distribution
 from .analysis.data_fetching_helper import AnalysisParameters
-from .analysis.log_pattern_analysis import execute_log_pattern_analysis
 from .analysis.metric_change_analysis import execute_metric_change_analysis
 from .tool_logging import log_tool_error
 from .tool_params import baseToolArgs
@@ -14,6 +14,21 @@ from pydantic import Field
 
 
 logger = logging.getLogger(__name__)
+
+# Log pattern analysis clusters messages with numpy/scipy/scikit-learn. Those packages
+# add roughly 180 MB and about 12 seconds of import time, so they ship as the optional
+# "ml" extra and the tool is only registered when they are present. The other analysis
+# tools in this module are pure Python and always available.
+ML_EXTRA_HINT = (
+    'LogPatternAnalysisTool requires the optional "ml" dependencies. '
+    'Install them with: pip install "opensearch-mcp-server-py[ml]"'
+)
+_ML_MODULES = ('numpy', 'scipy', 'sklearn')
+
+
+def ml_dependencies_available() -> bool:
+    """Report whether the "ml" extra is installed, without importing it."""
+    return all(importlib.util.find_spec(module) is not None for module in _ML_MODULES)
 
 
 class DataDistributionToolArgs(baseToolArgs):
@@ -212,6 +227,12 @@ async def log_pattern_analysis_tool(args: LogPatternAnalysisToolArgs) -> list[di
                 'Missing required parameters: index, logFieldName, selectionTimeRangeStart, selectionTimeRangeEnd'
             )
 
+        # Imported here so the numpy/scipy/scikit-learn stack stays out of server startup.
+        try:
+            from .analysis.log_pattern_analysis import execute_log_pattern_analysis
+        except ImportError as e:
+            raise ImportError(ML_EXTRA_HINT) from e
+
         async with get_opensearch_client(args) as client:
             result = await execute_log_pattern_analysis(
                 client,
@@ -288,3 +309,8 @@ SKILLS_TOOLS_REGISTRY = {
         'http_methods': 'POST',
     },
 }
+
+if not ml_dependencies_available():
+    # Better to not advertise the tool at all than to expose one that fails on call.
+    del SKILLS_TOOLS_REGISTRY['LogPatternAnalysisTool']
+    logger.info(f'LogPatternAnalysisTool is not registered. {ML_EXTRA_HINT}')

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,146 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the optional "aws" and "ml" extras.
+
+The heavy dependencies must stay out of the import path taken at server startup.
+Importing the ML stack eagerly costs several seconds on a warm environment and far
+more on a cold one, which eats into an MCP client's initialize deadline.
+"""
+
+import builtins
+import pytest
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+
+SRC = str(Path(__file__).resolve().parents[1] / 'src')
+
+
+def _modules_loaded_after(import_statement: str) -> set[str]:
+    """Import a module in a clean interpreter and report which heavy packages it loaded."""
+    script = textwrap.dedent(f"""
+        import sys
+        sys.path.insert(0, {SRC!r})
+        {import_statement}
+        heavy = [m for m in ('boto3', 'botocore', 'numpy', 'scipy', 'sklearn') if m in sys.modules]
+        print(','.join(heavy))
+    """)
+    result = subprocess.run(
+        [sys.executable, '-c', script], capture_output=True, text=True, timeout=300
+    )
+    assert result.returncode == 0, f'import failed: {result.stderr}'
+    return {m for m in result.stdout.strip().split(',') if m}
+
+
+class TestLazyImports:
+    """Heavy dependencies must not be imported as a side effect of importing the server."""
+
+    def test_client_does_not_import_boto3(self):
+        assert 'boto3' not in _modules_loaded_after('import opensearch.client')
+
+    def test_skills_tools_does_not_import_ml_stack(self):
+        loaded = _modules_loaded_after('import tools.skills_tools')
+        assert not loaded & {'numpy', 'scipy', 'sklearn'}
+
+    def test_tool_registry_does_not_import_heavy_dependencies(self):
+        assert not _modules_loaded_after('import tools.tools')
+
+
+class TestAwsExtra:
+    """AWS helpers surface an actionable message when the extra is missing."""
+
+    def test_boto3_remains_accessible_as_module_attribute(self):
+        """Kept resolvable so existing `patch('opensearch.client.boto3.Session')` still works."""
+        import opensearch.client as client_module
+
+        assert client_module.boto3 is not None
+
+    def test_unknown_attribute_still_raises_attribute_error(self):
+        import opensearch.client as client_module
+
+        with pytest.raises(AttributeError):
+            client_module.does_not_exist
+
+    def test_import_boto3_raises_configuration_error_with_hint(self):
+        from opensearch.client import AWS_EXTRA_HINT, ConfigurationError, _import_boto3
+
+        real_import = builtins.__import__
+
+        def fail_boto3(name, *args, **kwargs):
+            if name == 'boto3':
+                raise ImportError('No module named boto3')
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, '__import__', side_effect=fail_boto3):
+            with pytest.raises(ConfigurationError) as excinfo:
+                _import_boto3()
+
+        assert 'opensearch-mcp-server-py[aws]' in str(excinfo.value)
+        assert AWS_EXTRA_HINT in str(excinfo.value)
+
+    def test_optional_boto3_returns_none_when_missing(self):
+        """Region discovery degrades to "no region" rather than failing."""
+        from opensearch.client import _optional_boto3
+
+        real_import = builtins.__import__
+
+        def fail_boto3(name, *args, **kwargs):
+            if name == 'boto3':
+                raise ImportError('No module named boto3')
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, '__import__', side_effect=fail_boto3):
+            assert _optional_boto3() is None
+
+
+class TestMlExtra:
+    """Analysis tools are registered according to what is installed."""
+
+    def test_ml_dependencies_available_reports_installed_state(self):
+        from tools.skills_tools import _ML_MODULES, ml_dependencies_available
+
+        expected = all(
+            __import__('importlib.util', fromlist=['util']).find_spec(m) for m in _ML_MODULES
+        )
+        assert ml_dependencies_available() is bool(expected)
+
+    def test_pure_python_tools_are_always_registered(self):
+        from tools.skills_tools import SKILLS_TOOLS_REGISTRY
+
+        assert 'DataDistributionTool' in SKILLS_TOOLS_REGISTRY
+        assert 'MetricChangeAnalysisTool' in SKILLS_TOOLS_REGISTRY
+
+    def test_log_pattern_tool_registration_follows_ml_availability(self):
+        from tools.skills_tools import SKILLS_TOOLS_REGISTRY, ml_dependencies_available
+
+        assert ('LogPatternAnalysisTool' in SKILLS_TOOLS_REGISTRY) is ml_dependencies_available()
+
+    @pytest.mark.asyncio
+    async def test_log_pattern_tool_reports_missing_extra(self):
+        """Calling the tool without the extra explains how to install it."""
+        from tools.skills_tools import LogPatternAnalysisToolArgs, log_pattern_analysis_tool
+
+        real_import = builtins.__import__
+
+        def fail_analysis(name, *args, **kwargs):
+            if 'log_pattern_analysis' in name:
+                raise ImportError('No module named sklearn')
+            return real_import(name, *args, **kwargs)
+
+        args = LogPatternAnalysisToolArgs(
+            opensearch_cluster_name='test-cluster',
+            index='logs',
+            timeField='@timestamp',
+            logFieldName='message',
+            selectionTimeRangeStart='2026-01-01 00:00:00',
+            selectionTimeRangeEnd='2026-01-01 01:00:00',
+        )
+
+        with patch.object(builtins, '__import__', side_effect=fail_analysis):
+            result = await log_pattern_analysis_tool(args)
+
+        assert 'opensearch-mcp-server-py[ml]' in result[0]['text']

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1424,24 +1424,40 @@ version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "boto3" },
     { name = "click" },
     { name = "idna" },
     { name = "mcp", extra = ["cli"] },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "opensearch-py" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "semver" },
+    { name = "urllib3" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "boto3" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "requests-aws4auth" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "semver" },
-    { name = "urllib3" },
+]
+aws = [
+    { name = "boto3" },
+    { name = "requests-aws4auth" },
+]
+ml = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -1462,22 +1478,24 @@ integration = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
-    { name = "boto3", specifier = ">=1.39.0" },
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.39.0" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "idna", specifier = ">=3.15" },
     { name = "mcp", extras = ["cli"], specifier = ">=2.0.0" },
-    { name = "numpy", specifier = ">=1.24.0" },
+    { name = "numpy", marker = "extra == 'ml'", specifier = ">=1.24.0" },
+    { name = "opensearch-mcp-server-py", extras = ["aws", "ml"], marker = "extra == 'all'" },
     { name = "opensearch-py", specifier = "==3.1.0" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.33.0" },
-    { name = "requests-aws4auth", specifier = ">=1.3.1" },
-    { name = "scikit-learn", specifier = ">=1.3.0" },
-    { name = "scipy", specifier = ">=1.10.0" },
+    { name = "requests-aws4auth", marker = "extra == 'aws'", specifier = ">=1.3.1" },
+    { name = "scikit-learn", marker = "extra == 'ml'", specifier = ">=1.3.0" },
+    { name = "scipy", marker = "extra == 'ml'", specifier = ">=1.10.0" },
     { name = "semver", specifier = ">=3.0.4" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
+provides-extras = ["aws", "ml", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2199,10 +2217,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -2249,11 +2267,11 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -2297,7 +2315,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2359,7 +2377,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1463,10 +1463,18 @@ ml = [
 [package.dev-dependencies]
 dev = [
     { name = "anthropic" },
+    { name = "boto3" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "requests-aws4auth" },
     { name = "ruff" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 integration = [
     { name = "httpx", extra = ["http2"] },
@@ -1500,10 +1508,15 @@ provides-extras = ["aws", "ml", "all"]
 [package.metadata.requires-dev]
 dev = [
     { name = "anthropic", specifier = ">=0.50.0" },
+    { name = "boto3", specifier = ">=1.39.0" },
+    { name = "numpy", specifier = ">=1.24.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "requests-aws4auth", specifier = ">=1.3.1" },
     { name = "ruff", specifier = ">=0.9.7" },
+    { name = "scikit-learn", specifier = ">=1.3.0" },
+    { name = "scipy", specifier = ">=1.10.0" },
 ]
 integration = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27" },


### PR DESCRIPTION
### Description

Moves the AWS and ML dependencies into optional extras, so the base install carries only what a no-auth / basic-auth / bearer-token deployment actually uses.

| Extra | Packages | Enables |
|---|---|---|
| `aws` | `boto3`, `requests-aws4auth` | IAM credentials, assumed roles, SigV4 signing, region discovery from profiles |
| `ml` | `numpy`, `scipy`, `scikit-learn` | `LogPatternAnalysisTool` |
| `all` | both | current behaviour |

Effect on the base install:

| | before | after |
|---|---|---|
| packages | 67 | 57 |
| venv size | ~330 MB | ~86 MB |
| `import tools.skills_tools` (warm) | ~5.4 s | ~1.0 s |

Measured on macOS arm64 / CPython 3.13, both environments fully warm and byte-compiled, three runs each. Worth stating explicitly because it is easy to measure wrong: a freshly created environment reports far higher numbers (~10 s even with no ML packages installed at all) because the OS is validating newly written native libraries and compiling bytecode. Those one-off costs are exactly what makes a large dependency tree expensive in practice — a package-runner launcher like `uvx` pays them again every time an upstream release invalidates its cached environment — but they are not attributable to the import itself, so the table above uses warm numbers only.

### Approach

**Only `LogPatternAnalysisTool` needs the ML stack.** `data_distribution`, `metric_change_analysis` and `data_fetching_helper` turned out to be pure Python — verified by importing each module in a clean interpreter and checking `sys.modules`. So the `ml` extra costs the user exactly one tool, not the whole analysis category. That tool is skipped at registration time when the extra is absent, rather than advertised and failing on call.

**AWS imports are deferred, not removed.** `boto3` and `Credentials` are imported inside the code paths that need them. Two distinct behaviours, matching what the surrounding code already documents:

- Authentication paths raise `ConfigurationError` naming the exact install command.
- Region discovery returns `None`, since "no region" is already the documented acceptable outcome for basic auth and no auth — a missing extra must not turn that into an error.

**`boto3` stays reachable as a module attribute.** A module-level `__getattr__` keeps `opensearch.client.boto3` resolvable while deferring the actual import, so the 24 existing tests patching `opensearch.client.boto3.Session` continue to work untouched.

**Lazy `boto3.Session` creation.** The session was previously constructed before the auth branch was chosen, so every basic-auth and no-auth connection built one (and logged a warning if the profile failed) despite never using it. It is now created on first use by the IAM-role and AWS-credentials paths only.

### Testing

- `tests/test_optional_dependencies.py` (new, 11 tests): asserts in clean subinterpreters that importing `opensearch.client`, `tools.skills_tools` and `tools.tools` pulls in none of `boto3`/`botocore`/`numpy`/`scipy`/`sklearn`; covers both missing-extra messages, the region-discovery fallback, the preserved module attribute, and registration tracking `ml` availability.
- Full suite: **673 passed, 3 skipped**. No existing test needed changes.
- `ruff format --check` and `ruff check` clean.
- Verified end to end against a real OpenSearch 3.5.0 cluster with basic auth from a no-extras install: server starts, tools list contains `DataDistributionTool` and `MetricChangeAnalysisTool` and omits `LogPatternAnalysisTool`.
- CI now installs with `uv sync --all-extras` so the full matrix still exercises the AWS and ML paths.

### Issues Resolved

Closes #296

### Notes for reviewers

- Happy to collapse `[aws]` and `[ml]` into a single `[full]` extra if you'd prefer one knob, or to invert the default (keep everything in `dependencies` and add a `[minimal]` install path) — this shape seemed the least surprising, but it is a product call.
- `requests-aws4auth` has no reference anywhere in `src/`; its only use is `integration_tests/conftest.py`. It is grouped under `[aws]` here as the closest fit, but it could reasonably move to the `integration` dependency group instead.
- The CHANGELOG entry links the issue; happy to repoint it at this PR number.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
