### PR TITLE
Expose tool category in _meta field of tools/list response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Upgrade `mcp[cli]` to `>=2.0.0`. Ports the server to the mcp 2.0 API: replaces removed `@server.list_tools()` / `@server.call_tool()` decorators with constructor-injected `on_list_tools` / `on_call_tool` handlers, replaces removed `request_ctx` contextvar with a local `request_context_var`, and updates renamed fields (`isError` → `is_error`, `inputSchema` → `input_schema`). Integration test client updated for the renamed `streamable_http_client` function and `httpx2`-based header/timeout configuration ([#292](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/292))
+- Mark skills category tools as read operation([#302](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/302))
 
 ### Fixed
 - Bind per-call connection credentials to the caller that supplied the URL ([#287](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/287))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Expose tool category in the `_meta` field of each `Tool` object returned by `tools/list`. Core tools report `"_meta": {"category": "core_tools"}`; tools with no known category omit `_meta`. The MCP 1.x schema for `Tool` does not restrict additional properties, so this is safe for all existing clients. ([#301](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/301))
+- Add `analytics` category as a superset of `observability` (PPLQueryTool) and `skills` (DataDistributionTool, LogPatternAnalysisTool, MetricChangeAnalysisTool). All three categories are independent — `enabled_categories=skills` enables the 3 skills tools, `enabled_categories=observability` enables PPLQueryTool, and `enabled_categories=analytics` enables all 4. ([#301](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/301))
 
 ### Changed
 - Upgrade `mcp[cli]` to `>=2.0.0`. Ports the server to the mcp 2.0 API: replaces removed `@server.list_tools()` / `@server.call_tool()` decorators with constructor-injected `on_list_tools` / `on_call_tool` handlers, replaces removed `request_ctx` contextvar with a local `request_context_var`, and updates renamed fields (`isError` → `is_error`, `inputSchema` → `input_schema`). Integration test client updated for the renamed `streamable_http_client` function and `httpx2`-based header/timeout configuration ([#292](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/292))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Expose tool category in the `_meta` field of each `Tool` object returned by `tools/list`. Core tools report `"_meta": {"category": "core_tools"}`; tools with no known category omit `_meta`. The MCP 1.x schema for `Tool` does not restrict additional properties, so this is safe for all existing clients. ([#301](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/301))
 
 ### Changed
 - Upgrade `mcp[cli]` to `>=2.0.0`. Ports the server to the mcp 2.0 API: replaces removed `@server.list_tools()` / `@server.call_tool()` decorators with constructor-injected `on_list_tools` / `on_call_tool` handlers, replaces removed `request_ctx` contextvar with a local `request_context_var`, and updates renamed fields (`isError` → `is_error`, `inputSchema` → `input_schema`). Integration test client updated for the renamed `streamable_http_client` function and `httpx2`-based header/timeout configuration ([#292](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/292))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -311,7 +311,7 @@ Key fields:
 
 ### 5. Tool category — `src/tools/tool_filter.py`
 
-Add your tool to the appropriate category list (`core_tools`, `search_relevance`, or a new category). Tools not in any enabled category are **filtered out** and invisible to clients. See the `search_relevance` category definition for how to add a new opt-in category.
+Add your tool to the appropriate category list (`core_tools`, `observability`, `skills`, `analytics`, `search_relevance`, or a new category). Tools not in any enabled category are **filtered out** and invisible to clients. See the `search_relevance` category definition for how to add a new opt-in category.
 
 Categories are enabled via YAML config or environment variable. Only `core_tools` is enabled by default.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Enable with `OPENSEARCH_ENABLED_CATEGORIES=agentic_memory`. When `memory_contain
 
 ### Observability Tools (Disabled by Default)
 
-Observability tools are grouped under the `observability` category and can be enabled using `OPENSEARCH_ENABLED_CATEGORIES=observability` or by adding `enabled_categories: [observability]` to the config file.
+Observability tools are grouped under the `observability` category and can be enabled using `OPENSEARCH_ENABLED_CATEGORIES=observability` or by adding `enabled_categories: [observability]` to the config file. Alternatively, enable the `analytics` category to get both observability and skills tools at once.
 
 - [PPLQueryTool](https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/): Executes a PPL (Piped Processing Language) query against OpenSearch. PPL provides a pipe-based syntax for querying data (`source=<index> | <command> | <command>`), supporting filtering, aggregation, sorting, deduplication, and field selection. Supports `jdbc`, `csv`, and `raw` output formats.
 
@@ -131,7 +131,7 @@ Search Relevance Workbench tools are grouped under the `search_relevance` catego
 
 ### Skills Tools (Disabled by Default)
 
-Skills tools are grouped under the `skills` category and can be enabled at once using `OPENSEARCH_ENABLED_CATEGORIES=skills` or by adding `enabled_categories: [skills]` to the config file. See the [Tool Filter](USER_GUIDE.md#tool-filter) section in the User Guide for additional information about how to filter tools.
+Skills tools are grouped under the `skills` category and can be enabled at once using `OPENSEARCH_ENABLED_CATEGORIES=skills` or by adding `enabled_categories: [skills]` to the config file. Alternatively, enable the `analytics` category to get both skills and observability tools at once. See the [Tool Filter](USER_GUIDE.md#tool-filter) section in the User Guide for additional information about how to filter tools.
 
 - [DataDistributionTool](https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/data-distribution-tool/): Analyzes data distribution patterns and field value frequencies within OpenSearch indices. Supports both single dataset analysis and comparative analysis between two time periods to identify distribution changes.
 - [LogPatternAnalysisTool](https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/log-pattern-analysis-tool/): Detects anomalous log patterns and sequences through comparative analysis between baseline and selection time ranges. Supports log sequence analysis with trace correlation, log pattern difference analysis, and log insights analysis for error detection.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -823,6 +823,22 @@ export OPENSEARCH_ENABLED_CATEGORIES="<category_name>"
 - When both config file and environment variables are provided, the config file will be prioritized
 - Tool filtering is only supported in single mode. In multi mode, tool filtering is not supported
 
+### Built-in Categories
+
+The following categories are available out of the box. Only `core_tools` (and `memory` when memory tools are registered) is enabled by default; all others must be explicitly enabled.
+
+| Category | Tools | Default |
+|----------|-------|---------|
+| `core_tools` | ListIndexTool, IndexMappingTool, SearchIndexTool, GetShardsTool, ClusterHealthTool, CountTool, ExplainTool, MsearchTool, GenericOpenSearchApiTool | Enabled |
+| `memory` | SaveMemoryTool, SearchMemoryTool, DeleteMemoryTool | Auto-enabled when registered |
+| `observability` | PPLQueryTool | Disabled |
+| `skills` | DataDistributionTool, LogPatternAnalysisTool, MetricChangeAnalysisTool | Disabled |
+| `analytics` | All `observability` + `skills` tools (superset) | Disabled |
+| `search_relevance` | Search Relevance Workbench tools | Disabled |
+| `agentic_memory` | Agentic Memory tools | Disabled |
+
+`analytics` is a convenience category that enables all observability and skills tools at once. You can also enable `observability` or `skills` individually for finer control.
+
 ## Tool Customization
 
 OpenSearch MCP server supports tool customization to modify tool display names, descriptions, and other properties. You can customize tools using either a YAML configuration file or runtime parameters.

--- a/integration_tests/framework/constants.py
+++ b/integration_tests/framework/constants.py
@@ -9,5 +9,13 @@ METRIC_TEST_INDEX = os.environ.get('IT_METRIC_TEST_INDEX', 'mcp-integration-metr
 
 # Known built-in tool categories — mirrors BUILTIN_CATEGORY_TOOLS in tool_filter.py
 BUILTIN_CATEGORIES = frozenset(
-    {'core_tools', 'memory', 'search_relevance', 'agentic_memory', 'observability', 'skills', 'analytics'}
+    {
+        'core_tools',
+        'memory',
+        'search_relevance',
+        'agentic_memory',
+        'observability',
+        'skills',
+        'analytics',
+    }
 )

--- a/integration_tests/framework/constants.py
+++ b/integration_tests/framework/constants.py
@@ -6,3 +6,8 @@ import os
 
 TEST_INDEX = os.environ.get('IT_TEST_INDEX', 'mcp-integration-test')
 METRIC_TEST_INDEX = os.environ.get('IT_METRIC_TEST_INDEX', 'mcp-integration-metric-test')
+
+# Known built-in tool categories — mirrors BUILTIN_CATEGORY_TOOLS in tool_filter.py
+BUILTIN_CATEGORIES = frozenset(
+    {'core_tools', 'memory', 'search_relevance', 'agentic_memory', 'observability', 'skills'}
+)

--- a/integration_tests/framework/constants.py
+++ b/integration_tests/framework/constants.py
@@ -9,5 +9,5 @@ METRIC_TEST_INDEX = os.environ.get('IT_METRIC_TEST_INDEX', 'mcp-integration-metr
 
 # Known built-in tool categories — mirrors BUILTIN_CATEGORY_TOOLS in tool_filter.py
 BUILTIN_CATEGORIES = frozenset(
-    {'core_tools', 'memory', 'search_relevance', 'agentic_memory', 'observability', 'skills'}
+    {'core_tools', 'memory', 'search_relevance', 'agentic_memory', 'analytics'}
 )

--- a/integration_tests/framework/constants.py
+++ b/integration_tests/framework/constants.py
@@ -9,5 +9,5 @@ METRIC_TEST_INDEX = os.environ.get('IT_METRIC_TEST_INDEX', 'mcp-integration-metr
 
 # Known built-in tool categories — mirrors BUILTIN_CATEGORY_TOOLS in tool_filter.py
 BUILTIN_CATEGORIES = frozenset(
-    {'core_tools', 'memory', 'search_relevance', 'agentic_memory', 'analytics'}
+    {'core_tools', 'memory', 'search_relevance', 'agentic_memory', 'observability', 'skills', 'analytics'}
 )

--- a/integration_tests/server_modes/test_list_tools.py
+++ b/integration_tests/server_modes/test_list_tools.py
@@ -1,0 +1,43 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from integration_tests.framework.constants import BUILTIN_CATEGORIES
+
+
+@pytest.mark.tools
+class TestListToolsMeta:
+    """Verify that tools/list returns _meta.category for each enabled tool."""
+
+    async def test_core_tools_have_category_in_meta(self, default_client):
+        """Core tools must advertise category='core_tools' in _meta."""
+        result = await default_client.list_tools()
+        tools_by_name = {t.name: t for t in result.tools}
+
+        core_tools = ('ListIndexTool', 'SearchIndexTool', 'ClusterHealthTool', 'GetShardsTool')
+        for tool_name in core_tools:
+            assert tool_name in tools_by_name, f'{tool_name} missing from tools/list'
+            tool = tools_by_name[tool_name]
+            assert tool.meta is not None, f'{tool_name} is missing _meta'
+            assert tool.meta.get('category') == 'core_tools', (
+                f'{tool_name}: expected category=core_tools, got {tool.meta}'
+            )
+
+    async def test_all_listed_tools_have_known_category_or_no_meta(self, default_client):
+        """Every tool either has a known category in _meta or has no _meta at all."""
+        result = await default_client.list_tools()
+
+        for tool in result.tools:
+            if tool.meta is None:
+                continue
+            assert 'category' in tool.meta, (
+                f'{tool.name} has _meta but is missing the category key: {tool.meta}'
+            )
+            assert tool.meta['category'] in BUILTIN_CATEGORIES, (
+                f'{tool.name} has unknown category "{tool.meta["category"]}"'
+            )
+
+    async def test_list_tools_returns_tools(self, default_client):
+        """Sanity check: tools/list returns at least the default core tools."""
+        result = await default_client.list_tools()
+        assert len(result.tools) >= 9, f'Expected at least 9 core tools, got {len(result.tools)}'

--- a/src/mcp_server_opensearch/server_instructions.py
+++ b/src/mcp_server_opensearch/server_instructions.py
@@ -92,22 +92,21 @@ def _resolve_enabled_disabled_categories() -> tuple[list[str], list[str]]:
 
 
 def are_skills_enabled() -> bool:
-    """Check whether analytics tools are enabled based on environment/config.
+    """Check whether skills tools are enabled based on environment/config.
 
-    Analytics tools are enabled when 'analytics', 'skills', or 'observability'
-    appears in the enabled categories and NOT in the disabled categories.
-    'analytics' is a superset of 'observability' (PPLQueryTool) and
-    'skills' (DataDistributionTool, LogPatternAnalysisTool,
-    MetricChangeAnalysisTool).  All three are independent categories;
-    enabling any one of them is enough to activate skill-related
-    server instructions.
+    Returns True when 'skills' or 'analytics' appears in the enabled
+    categories and NOT in the disabled categories.  'observability' alone
+    does NOT trigger this — it only enables PPLQueryTool and contains no
+    skills tools, so emitting skills-related server instructions would
+    reference tools the user hasn't enabled.
+
     Category state is resolved from the YAML config file when present,
     otherwise from the OPENSEARCH_ENABLED_CATEGORIES /
     OPENSEARCH_DISABLED_CATEGORIES environment variables — matching how
     ``process_tool_filter`` decides tool visibility.
     """
     enabled_cats, disabled_cats = _resolve_enabled_disabled_categories()
-    trigger_names = ('analytics', 'skills', 'observability')
+    trigger_names = ('analytics', 'skills')
     if any(name in disabled_cats for name in trigger_names):
         return False
     if any(name in enabled_cats for name in trigger_names):

--- a/src/mcp_server_opensearch/server_instructions.py
+++ b/src/mcp_server_opensearch/server_instructions.py
@@ -96,7 +96,11 @@ def are_skills_enabled() -> bool:
 
     Analytics tools are enabled when 'analytics', 'skills', or 'observability'
     appears in the enabled categories and NOT in the disabled categories.
-    'skills' and 'observability' are legacy aliases for 'analytics'.
+    'analytics' is a superset of 'observability' (PPLQueryTool) and
+    'skills' (DataDistributionTool, LogPatternAnalysisTool,
+    MetricChangeAnalysisTool).  All three are independent categories;
+    enabling any one of them is enough to activate skill-related
+    server instructions.
     Category state is resolved from the YAML config file when present,
     otherwise from the OPENSEARCH_ENABLED_CATEGORIES /
     OPENSEARCH_DISABLED_CATEGORIES environment variables — matching how

--- a/src/mcp_server_opensearch/server_instructions.py
+++ b/src/mcp_server_opensearch/server_instructions.py
@@ -92,18 +92,21 @@ def _resolve_enabled_disabled_categories() -> tuple[list[str], list[str]]:
 
 
 def are_skills_enabled() -> bool:
-    """Check whether skills tools are enabled based on environment/config.
+    """Check whether analytics tools are enabled based on environment/config.
 
-    Skills are enabled when 'skills' appears in the enabled categories and NOT
-    in the disabled categories. Category state is resolved from the YAML config
-    file when present, otherwise from the OPENSEARCH_ENABLED_CATEGORIES /
+    Analytics tools are enabled when 'analytics', 'skills', or 'observability'
+    appears in the enabled categories and NOT in the disabled categories.
+    'skills' and 'observability' are legacy aliases for 'analytics'.
+    Category state is resolved from the YAML config file when present,
+    otherwise from the OPENSEARCH_ENABLED_CATEGORIES /
     OPENSEARCH_DISABLED_CATEGORIES environment variables — matching how
     ``process_tool_filter`` decides tool visibility.
     """
     enabled_cats, disabled_cats = _resolve_enabled_disabled_categories()
-    if 'skills' in disabled_cats:
+    trigger_names = ('analytics', 'skills', 'observability')
+    if any(name in disabled_cats for name in trigger_names):
         return False
-    if 'skills' in enabled_cats:
+    if any(name in enabled_cats for name in trigger_names):
         return True
     return False
 

--- a/src/mcp_server_opensearch/stdio_server.py
+++ b/src/mcp_server_opensearch/stdio_server.py
@@ -59,6 +59,9 @@ async def serve(
                     name=tool_info.get('display_name', tool_name),
                     description=tool_info['description'],
                     input_schema=tool_info['input_schema'],
+                    meta={'category': tool_info['category']}
+                    if tool_info.get('category')
+                    else None,  # type: ignore[call-arg]
                 )
             )
         return ListToolsResult(tools=tools)

--- a/src/mcp_server_opensearch/streaming_server.py
+++ b/src/mcp_server_opensearch/streaming_server.py
@@ -68,6 +68,9 @@ async def create_mcp_server(
                     name=tool_info.get('display_name', tool_name),
                     description=tool_info['description'],
                     input_schema=tool_info['input_schema'],
+                    meta={'category': tool_info['category']}
+                    if tool_info.get('category')
+                    else None,  # type: ignore[call-arg]
                 )
             )
         return ListToolsResult(tools=tools)

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -251,6 +251,7 @@ SKILLS_TOOLS_REGISTRY = {
         'args_model': DataDistributionToolArgs,
         'min_version': '1.0.0',
         'http_methods': 'POST',
+        'bypass_write_filter': True,
     },
     'LogPatternAnalysisTool': {
         'display_name': 'LogPatternAnalysisTool',
@@ -267,6 +268,7 @@ SKILLS_TOOLS_REGISTRY = {
         'args_model': LogPatternAnalysisToolArgs,
         'min_version': '2.19.0',
         'http_methods': 'POST',
+        'bypass_write_filter': True,
     },
     'MetricChangeAnalysisTool': {
         'display_name': 'MetricChangeAnalysisTool',
@@ -286,5 +288,6 @@ SKILLS_TOOLS_REGISTRY = {
         'args_model': MetricChangeAnalysisToolArgs,
         'min_version': '1.0.0',
         'http_methods': 'POST',
+        'bypass_write_filter': True,
     },
 }

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -132,6 +132,22 @@ def process_categories(category_list, category_to_tools):
 
 # Single source of truth: built-in category → registry key lists.
 # Used by build_category_map and to stamp tool_info['category'] at startup.
+#
+# 'observability' and 'skills' are fine-grained categories that existed before
+# the unified 'analytics' category was introduced.  'analytics' is a superset
+# that contains every tool from both.  All three are first-class categories —
+# enabling 'skills' gives the 3 skills tools, enabling 'observability' gives
+# PPLQueryTool, and enabling 'analytics' gives all 4.
+_SKILLS_TOOLS: list[str] = [
+    'DataDistributionTool',
+    'LogPatternAnalysisTool',
+    'MetricChangeAnalysisTool',
+]
+
+_OBSERVABILITY_TOOLS: list[str] = [
+    'PPLQueryTool',
+]
+
 BUILTIN_CATEGORY_TOOLS: dict[str, list[str]] = {
     'core_tools': [
         'ListIndexTool',
@@ -179,32 +195,10 @@ BUILTIN_CATEGORY_TOOLS: dict[str, list[str]] = {
         'DeleteAgenticMemoryByQueryTool',
         'SearchAgenticMemoryTool',
     ],
-    'analytics': [
-        'PPLQueryTool',
-        'DataDistributionTool',
-        'LogPatternAnalysisTool',
-        'MetricChangeAnalysisTool',
-    ],
+    'observability': _OBSERVABILITY_TOOLS,
+    'skills': _SKILLS_TOOLS,
+    'analytics': _OBSERVABILITY_TOOLS + _SKILLS_TOOLS,
 }
-
-
-# Aliases allow legacy category names to resolve to their replacement.
-# Enabling 'observability' or 'skills' expands to 'analytics'.
-CATEGORY_ALIASES: dict[str, list[str]] = {
-    'observability': ['analytics'],
-    'skills': ['analytics'],
-}
-
-
-def expand_category_aliases(categories: list[str]) -> list[str]:
-    """Expand any alias names in a category list to their constituent categories."""
-    expanded = []
-    for cat in categories:
-        if cat in CATEGORY_ALIASES:
-            expanded.extend(CATEGORY_ALIASES[cat])
-        else:
-            expanded.append(cat)
-    return expanded
 
 
 def build_category_map(tool_registry: dict) -> dict[str, list[str]]:
@@ -333,10 +327,6 @@ def process_tool_filter(
                     f'Tools exempt from write filter via allow_write_categories: {exempt_tools}'
                 )
             apply_write_filter(tool_registry, exempt_tools=exempt_tools)
-
-        # Expand category aliases (e.g. 'observability'/'skills' -> 'analytics')
-        enabled_category_list = expand_category_aliases(enabled_category_list)
-        disabled_category_list = expand_category_aliases(disabled_category_list)
 
         # Process tools from categories and regex patterns
         enabled_tools_from_categories = process_categories(

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import re
-from .skills_tools import SKILLS_TOOLS_REGISTRY
 from .tool_params import baseToolArgs
 from .utils import (
     is_tool_compatible,
@@ -131,6 +130,80 @@ def process_categories(category_list, category_to_tools):
     return tools
 
 
+# Single source of truth: built-in category → registry key lists.
+# Used by build_category_map and to stamp tool_info['category'] at startup.
+BUILTIN_CATEGORY_TOOLS: dict[str, list[str]] = {
+    'core_tools': [
+        'ListIndexTool',
+        'IndexMappingTool',
+        'SearchIndexTool',
+        'GetShardsTool',
+        'ClusterHealthTool',
+        'CountTool',
+        'ExplainTool',
+        'MsearchTool',
+        'GenericOpenSearchApiTool',
+    ],
+    'memory': [
+        'SaveMemoryTool',
+        'SearchMemoryTool',
+        'DeleteMemoryTool',
+    ],
+    'search_relevance': [
+        'CreateSearchConfigurationTool',
+        'GetSearchConfigurationTool',
+        'DeleteSearchConfigurationTool',
+        'GetQuerySetTool',
+        'CreateQuerySetTool',
+        'SampleQuerySetTool',
+        'DeleteQuerySetTool',
+        'GetJudgmentListTool',
+        'CreateJudgmentListTool',
+        'CreateUBIJudgmentListTool',
+        'CreateLLMJudgmentListTool',
+        'DeleteJudgmentListTool',
+        'GetExperimentTool',
+        'CreateExperimentTool',
+        'DeleteExperimentTool',
+        'SearchQuerySetsTool',
+        'SearchSearchConfigurationsTool',
+        'SearchJudgmentsTool',
+        'SearchExperimentsTool',
+    ],
+    'agentic_memory': [
+        'CreateAgenticMemorySessionTool',
+        'AddAgenticMemoriesTool',
+        'GetAgenticMemoryTool',
+        'UpdateAgenticMemoryTool',
+        'DeleteAgenticMemoryByIDTool',
+        'DeleteAgenticMemoryByQueryTool',
+        'SearchAgenticMemoryTool',
+    ],
+    'observability': [
+        'PPLQueryTool',
+    ],
+    'skills': [
+        'DataDistributionTool',
+        'LogPatternAnalysisTool',
+        'MetricChangeAnalysisTool',
+    ],
+}
+
+
+def build_category_map(tool_registry: dict) -> dict[str, list[str]]:
+    """Return a category → list-of-display-names map for the given registry.
+
+    All categories come from BUILTIN_CATEGORY_TOOLS.  User-defined categories
+    (from YAML or env vars) are merged on top by the caller.
+    """
+    return {
+        category: [
+            tool_registry[k].get('display_name', k) for k in tool_keys if k in tool_registry
+        ]
+        for category, tool_keys in BUILTIN_CATEGORY_TOOLS.items()
+    }
+
+
 def process_tool_filter(
     enabled_tools: str = None,
     disabled_tools: str = None,
@@ -143,7 +216,7 @@ def process_tool_filter(
     allow_write_categories: list = None,
     filter_path: str = None,
     tool_registry: dict = None,
-) -> None:
+) -> dict:
     """Process tool filter configuration from a YAML file and environment variables.
 
     Args:
@@ -166,124 +239,19 @@ def process_tool_filter(
         }
 
         # Initialize collections
-        category_to_tools = {}
         enabled_tool_list = []
         disabled_tool_list = []
         enabled_category_list = ['core_tools']
         disabled_category_list = []
         enabled_tools_regex_list = []
         disabled_tools_regex_list = []
-        core_tools_display_name = []
 
-        # Initialize core tool names
-        core_tools = [
-            'ListIndexTool',
-            'IndexMappingTool',
-            'SearchIndexTool',
-            'GetShardsTool',
-            'ClusterHealthTool',
-            'CountTool',
-            'ExplainTool',
-            'MsearchTool',
-            'GenericOpenSearchApiTool',
-        ]
-
-        # Build core tools list using display names
-        for tool_name in core_tools:
-            if tool_name in tool_registry:
-                tool_display_name = tool_registry[tool_name].get('display_name', tool_name)
-                core_tools_display_name.append(tool_display_name)
-
-        # Add core_tools as a built-in category using display name
-        category_to_tools['core_tools'] = core_tools_display_name
-
-        # Initialize memory tool names (opt-in via MEMORY_TOOLS_ENABLED)
-        memory_tools = [
-            'SaveMemoryTool',
-            'SearchMemoryTool',
-            'DeleteMemoryTool',
-        ]
-        memory_tools_display_names = []
-        for tool_name in memory_tools:
-            if tool_name in tool_registry:
-                tool_display_name = tool_registry[tool_name].get('display_name', tool_name)
-                memory_tools_display_names.append(tool_display_name)
-        category_to_tools['memory'] = memory_tools_display_names
+        # Build built-in category map (category → list of display names)
+        category_to_tools = build_category_map(tool_registry)
 
         # Auto-enable memory category when memory tools are registered
-        if memory_tools_display_names:
+        if category_to_tools.get('memory'):
             enabled_category_list.append('memory')
-
-        # Initialize search_relevance tool names
-        search_relevance_tools = [
-            'CreateSearchConfigurationTool',
-            'GetSearchConfigurationTool',
-            'DeleteSearchConfigurationTool',
-            'GetQuerySetTool',
-            'CreateQuerySetTool',
-            'SampleQuerySetTool',
-            'DeleteQuerySetTool',
-            'GetJudgmentListTool',
-            'CreateJudgmentListTool',
-            'CreateUBIJudgmentListTool',
-            'CreateLLMJudgmentListTool',
-            'DeleteJudgmentListTool',
-            'GetExperimentTool',
-            'CreateExperimentTool',
-            'DeleteExperimentTool',
-            'SearchQuerySetsTool',
-            'SearchSearchConfigurationsTool',
-            'SearchJudgmentsTool',
-            'SearchExperimentsTool',
-        ]
-
-        # Build search_relevance tools list using display names
-        search_relevance_display_names = []
-        for tool_name in search_relevance_tools:
-            if tool_name in tool_registry:
-                tool_display_name = tool_registry[tool_name].get('display_name', tool_name)
-                search_relevance_display_names.append(tool_display_name)
-
-        # Add search_relevance as a built-in category (not enabled by default)
-        category_to_tools['search_relevance'] = search_relevance_display_names
-
-        # Initialize agentic_memory tool names
-        agentic_memory_tools = [
-            'CreateAgenticMemorySessionTool',
-            'AddAgenticMemoriesTool',
-            'GetAgenticMemoryTool',
-            'UpdateAgenticMemoryTool',
-            'DeleteAgenticMemoryByIDTool',
-            'DeleteAgenticMemoryByQueryTool',
-            'SearchAgenticMemoryTool',
-        ]
-
-        # Build agentic_memory tools list using display names
-        agentic_memory_display_names = []
-        for tool_name in agentic_memory_tools:
-            if tool_name in tool_registry:
-                tool_display_name = tool_registry[tool_name].get('display_name', tool_name)
-                agentic_memory_display_names.append(tool_display_name)
-
-        # Add agentic_memory as a built-in category (not enabled by default)
-        category_to_tools['agentic_memory'] = agentic_memory_display_names
-
-        # Initialize observability tool names
-        observability_tools = [
-            'PPLQueryTool',
-        ]
-        observability_display_names = []
-        for tool_name in observability_tools:
-            if tool_name in tool_registry:
-                tool_display_name = tool_registry[tool_name].get('display_name', tool_name)
-                observability_display_names.append(tool_display_name)
-        category_to_tools['observability'] = observability_display_names
-
-        # Add skills as a built-in category (not enabled by default)
-        skills_display_names = [
-            info.get('display_name', name) for name, info in SKILLS_TOOLS_REGISTRY.items()
-        ]
-        category_to_tools['skills'] = skills_display_names
 
         # Process YAML config file if provided
         config = load_yaml_config(filter_path)
@@ -407,9 +375,11 @@ def process_tool_filter(
         # Log results
         source = filter_path if filter_path else 'environment variables'
         logging.info(f'Applied tool filter from {source}')
+        return category_to_tools
 
     except Exception as e:
         logging.error(f'Error processing tool filter: {str(e)}')
+        return {}
 
 
 async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
@@ -451,6 +421,10 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
         filtered_registry = {
             name: info for name, info in tool_registry.items() if not info.get('memory_tool')
         }
+        category_to_tools = build_category_map(filtered_registry)
+        tool_to_category = {
+            dn.lower(): cat for cat, dns in category_to_tools.items() for dn in dns
+        }
         for name, info in filtered_registry.items():
             schema = info['input_schema']
             if 'properties' in schema:
@@ -458,6 +432,7 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
                     schema['properties'].pop(field, None)
                     if 'required' in schema and field in schema['required']:
                         schema['required'].remove(field)
+            info['category'] = tool_to_category.get(info.get('display_name', name).lower(), '')
         return filtered_registry
 
     enabled = {}
@@ -486,11 +461,12 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
         logging.warning('Both config file and environment variables are set. Using config file.')
 
     # Apply tool filtering, update the TOOL_REGISTRY
-    process_tool_filter(
+    category_to_tools = process_tool_filter(
         tool_registry=tool_registry,
         filter_path=config_file_path if config_file_path else None,
         **{k: v for k, v in env_config.items() if not config_file_path},
     )
+    tool_to_category = {dn.lower(): cat for cat, dns in category_to_tools.items() for dn in dns}
 
     for name, info in tool_registry.items():
         # Create a copy to avoid modifying the original tool info
@@ -539,6 +515,7 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
                 if 'opensearch_url' not in schema['required']:
                     schema['required'].append('opensearch_url')
         tool_info['input_schema'] = schema
+        tool_info['category'] = tool_to_category.get(tool_name.lower(), '')
 
         enabled[tool_name] = tool_info
 

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -179,15 +179,32 @@ BUILTIN_CATEGORY_TOOLS: dict[str, list[str]] = {
         'DeleteAgenticMemoryByQueryTool',
         'SearchAgenticMemoryTool',
     ],
-    'observability': [
+    'analytics': [
         'PPLQueryTool',
-    ],
-    'skills': [
         'DataDistributionTool',
         'LogPatternAnalysisTool',
         'MetricChangeAnalysisTool',
     ],
 }
+
+
+# Aliases allow legacy category names to resolve to their replacement.
+# Enabling 'observability' or 'skills' expands to 'analytics'.
+CATEGORY_ALIASES: dict[str, list[str]] = {
+    'observability': ['analytics'],
+    'skills': ['analytics'],
+}
+
+
+def expand_category_aliases(categories: list[str]) -> list[str]:
+    """Expand any alias names in a category list to their constituent categories."""
+    expanded = []
+    for cat in categories:
+        if cat in CATEGORY_ALIASES:
+            expanded.extend(CATEGORY_ALIASES[cat])
+        else:
+            expanded.append(cat)
+    return expanded
 
 
 def build_category_map(tool_registry: dict) -> dict[str, list[str]]:
@@ -316,6 +333,10 @@ def process_tool_filter(
                     f'Tools exempt from write filter via allow_write_categories: {exempt_tools}'
                 )
             apply_write_filter(tool_registry, exempt_tools=exempt_tools)
+
+        # Expand category aliases (e.g. 'observability'/'skills' -> 'analytics')
+        enabled_category_list = expand_category_aliases(enabled_category_list)
+        disabled_category_list = expand_category_aliases(disabled_category_list)
 
         # Process tools from categories and regex patterns
         enabled_tools_from_categories = process_categories(

--- a/src/tools/tool_filter.py
+++ b/src/tools/tool_filter.py
@@ -390,7 +390,9 @@ def process_tool_filter(
 
     except Exception as e:
         logging.error(f'Error processing tool filter: {str(e)}')
-        return {}
+        # Fall back to built-in category map so _meta.category stamping
+        # still works even when filter processing fails.
+        return build_category_map(tool_registry) if tool_registry else {}
 
 
 async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
@@ -430,19 +432,24 @@ async def get_tools(tool_registry: dict, config_file_path: str = '') -> dict:
     # connection setup, and are not supported in multi mode.
     if mode == 'multi':
         filtered_registry = {
-            name: info for name, info in tool_registry.items() if not info.get('memory_tool')
+            name: info.copy()
+            for name, info in tool_registry.items()
+            if not info.get('memory_tool')
         }
         category_to_tools = build_category_map(filtered_registry)
         tool_to_category = {
             dn.lower(): cat for cat, dns in category_to_tools.items() for dn in dns
         }
         for name, info in filtered_registry.items():
-            schema = info['input_schema']
+            # Deep-copy the schema so pop() doesn't mutate the original registry
+            schema = info['input_schema'].copy()
             if 'properties' in schema:
+                schema['properties'] = dict(schema['properties'])
                 for field in CONNECTION_OVERRIDE_FIELDS:
                     schema['properties'].pop(field, None)
                     if 'required' in schema and field in schema['required']:
-                        schema['required'].remove(field)
+                        schema['required'] = [r for r in schema['required'] if r != field]
+            info['input_schema'] = schema
             info['category'] = tool_to_category.get(info.get('display_name', name).lower(), '')
         return filtered_registry
 

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -86,14 +86,15 @@ class TestBuildCategoryMap:
     def test_tools_absent_from_registry_are_excluded(self):
         result = build_category_map({})
         for category, tools in result.items():
-            if category != 'analytics':
-                assert tools == [], f'Expected empty list for {category}, got {tools}'
+            assert tools == [], f'Expected empty list for {category}, got {tools}'
 
     def test_all_builtin_categories_present(self):
         result = build_category_map({})
         for category in BUILTIN_CATEGORY_TOOLS:
             assert category in result
         assert 'analytics' in result
+        assert 'observability' in result
+        assert 'skills' in result
 
     def test_custom_display_name_is_used(self):
         registry = {'ListIndexTool': {'display_name': 'MyListTool'}}
@@ -121,6 +122,32 @@ class TestBuildCategoryMap:
     def test_process_tool_filter_returns_empty_dict_on_error(self):
         result = process_tool_filter(tool_registry=None, allow_write=True)
         assert result == {}
+
+    def test_skills_category_matches_skills_tools_registry(self):
+        """_SKILLS_TOOLS must contain every key from SKILLS_TOOLS_REGISTRY.
+
+        Prevents drift when a new tool is added to skills_tools.py but
+        not to the BUILTIN_CATEGORY_TOOLS constant.
+        """
+        pytest.importorskip('numpy', reason='skills_tools requires numpy')
+        from tools.skills_tools import SKILLS_TOOLS_REGISTRY
+
+        registry_keys = set(SKILLS_TOOLS_REGISTRY.keys())
+        category_keys = set(BUILTIN_CATEGORY_TOOLS['skills'])
+        assert category_keys == registry_keys, (
+            f'BUILTIN_CATEGORY_TOOLS["skills"] is out of sync with SKILLS_TOOLS_REGISTRY. '
+            f'Missing from category: {registry_keys - category_keys}. '
+            f'Extra in category: {category_keys - registry_keys}.'
+        )
+
+    def test_analytics_is_superset_of_observability_and_skills(self):
+        """analytics must be exactly the union of observability + skills."""
+        expected = set(BUILTIN_CATEGORY_TOOLS['observability']) | set(BUILTIN_CATEGORY_TOOLS['skills'])
+        actual = set(BUILTIN_CATEGORY_TOOLS['analytics'])
+        assert actual == expected, (
+            f'analytics category is not the union of observability + skills. '
+            f'Missing: {expected - actual}. Extra: {actual - expected}.'
+        )
 
 
 class TestCategoryStamping:
@@ -614,12 +641,13 @@ class TestProcessToolFilter:
         assert 'LogPatternAnalysisTool' not in registry
 
     def test_skills_category_can_be_enabled(self):
-        """Analytics tools are exposed when the category is explicitly enabled.
-
-        Also verifies 'skills' legacy alias resolves to 'analytics'.
-        """
+        """Enabling 'skills' exposes only the 3 skills tools, not PPLQueryTool."""
         registry = {
             'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'PPLQueryTool': {
+                'display_name': 'PPLQueryTool',
+                'http_methods': 'POST',
+            },
             'DataDistributionTool': {
                 'display_name': 'DataDistributionTool',
                 'http_methods': 'POST',
@@ -638,6 +666,65 @@ class TestProcessToolFilter:
         assert 'ListIndexTool' in registry
         assert 'DataDistributionTool' in registry
         assert 'LogPatternAnalysisTool' in registry
+        assert 'PPLQueryTool' not in registry, (
+            "'skills' should only enable the 3 skills tools, not PPLQueryTool"
+        )
+
+    def test_analytics_category_enables_all_four_tools(self):
+        """Enabling 'analytics' exposes all 4 tools (superset of observability + skills)."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'PPLQueryTool': {
+                'display_name': 'PPLQueryTool',
+                'http_methods': 'POST',
+            },
+            'DataDistributionTool': {
+                'display_name': 'DataDistributionTool',
+                'http_methods': 'POST',
+            },
+            'LogPatternAnalysisTool': {
+                'display_name': 'LogPatternAnalysisTool',
+                'http_methods': 'POST',
+            },
+            'MetricChangeAnalysisTool': {
+                'display_name': 'MetricChangeAnalysisTool',
+                'http_methods': 'POST',
+            },
+        }
+        process_tool_filter(
+            tool_registry=registry,
+            enabled_categories='core_tools,analytics',
+            allow_write=True,
+        )
+
+        assert 'ListIndexTool' in registry
+        assert 'PPLQueryTool' in registry
+        assert 'DataDistributionTool' in registry
+        assert 'LogPatternAnalysisTool' in registry
+        assert 'MetricChangeAnalysisTool' in registry
+
+    def test_observability_category_enables_only_ppl(self):
+        """Enabling 'observability' exposes only PPLQueryTool."""
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'PPLQueryTool': {
+                'display_name': 'PPLQueryTool',
+                'http_methods': 'POST',
+            },
+            'DataDistributionTool': {
+                'display_name': 'DataDistributionTool',
+                'http_methods': 'POST',
+            },
+        }
+        process_tool_filter(
+            tool_registry=registry,
+            enabled_categories='core_tools,observability',
+            allow_write=True,
+        )
+
+        assert 'ListIndexTool' in registry
+        assert 'PPLQueryTool' in registry
+        assert 'DataDistributionTool' not in registry
 
     def test_data_distribution_and_log_pattern_not_in_core_tools(self):
         """DataDistributionTool and LogPatternAnalysisTool are not part of core_tools category."""

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -1,7 +1,12 @@
 import copy
 import pytest
 from semver import Version
-from tools.tool_filter import get_tools, process_tool_filter
+from tools.tool_filter import (
+    BUILTIN_CATEGORY_TOOLS,
+    build_category_map,
+    get_tools,
+    process_tool_filter,
+)
 from tools.utils import is_tool_compatible
 from unittest.mock import MagicMock, patch
 
@@ -63,6 +68,180 @@ MOCK_TOOL_REGISTRY = {
         'http_methods': 'POST',
     },
 }
+
+
+class TestBuildCategoryMap:
+    """Tests for build_category_map and BUILTIN_CATEGORY_TOOLS."""
+
+    def _registry(self, *keys):
+        return {k: {'display_name': k} for k in keys}
+
+    def test_known_core_tools_are_mapped(self):
+        registry = self._registry('ListIndexTool', 'SearchIndexTool', 'ClusterHealthTool')
+        result = build_category_map(registry)
+        assert 'ListIndexTool' in result['core_tools']
+        assert 'SearchIndexTool' in result['core_tools']
+        assert 'ClusterHealthTool' in result['core_tools']
+
+    def test_tools_absent_from_registry_are_excluded(self):
+        result = build_category_map({})
+        for category, tools in result.items():
+            if category != 'skills':
+                assert tools == [], f'Expected empty list for {category}, got {tools}'
+
+    def test_all_builtin_categories_present(self):
+        result = build_category_map({})
+        for category in BUILTIN_CATEGORY_TOOLS:
+            assert category in result
+        assert 'skills' in result
+
+    def test_custom_display_name_is_used(self):
+        registry = {'ListIndexTool': {'display_name': 'MyListTool'}}
+        result = build_category_map(registry)
+        assert 'MyListTool' in result['core_tools']
+        assert 'ListIndexTool' not in result['core_tools']
+
+    def test_search_relevance_tools_in_correct_category(self):
+        registry = self._registry('GetQuerySetTool', 'CreateExperimentTool')
+        result = build_category_map(registry)
+        assert 'GetQuerySetTool' in result['search_relevance']
+        assert 'CreateExperimentTool' in result['search_relevance']
+        assert 'GetQuerySetTool' not in result.get('core_tools', [])
+
+    def test_process_tool_filter_returns_category_map(self):
+        registry = {
+            'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
+            'ClusterHealthTool': {'display_name': 'ClusterHealthTool', 'http_methods': 'GET'},
+        }
+        result = process_tool_filter(tool_registry=registry, allow_write=True)
+        assert isinstance(result, dict)
+        assert 'core_tools' in result
+        assert 'ListIndexTool' in result['core_tools']
+
+    def test_process_tool_filter_returns_empty_dict_on_error(self):
+        result = process_tool_filter(tool_registry=None, allow_write=True)
+        assert result == {}
+
+
+class TestCategoryStamping:
+    """Tests that get_tools stamps the category field on enabled tools."""
+
+    def setup_method(self):
+        from mcp_server_opensearch.global_state import set_mode
+
+        set_mode('single')
+
+    @pytest.mark.asyncio
+    async def test_single_mode_stamps_category_on_core_tools(self):
+        registry = {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.0.0',
+                'http_methods': 'GET',
+            },
+        }
+        with (
+            patch('tools.tool_filter.get_opensearch_version', return_value=Version.parse('2.5.0')),
+            patch('tools.tool_filter.is_tool_compatible', return_value=True),
+        ):
+            result = await get_tools(registry)
+
+        assert result['ListIndexTool']['category'] == 'core_tools'
+
+    @pytest.mark.asyncio
+    async def test_single_mode_tool_not_in_any_category_gets_empty_string(self):
+        registry = {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.0.0',
+                'http_methods': 'GET',
+            },
+            'UnknownTool': {
+                'display_name': 'UnknownTool',
+                'description': 'Some tool',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'min_version': '1.0.0',
+                'http_methods': 'GET',
+            },
+        }
+        with (
+            patch('tools.tool_filter.get_opensearch_version', return_value=Version.parse('2.5.0')),
+            patch('tools.tool_filter.is_tool_compatible', return_value=True),
+            patch.dict('os.environ', {'OPENSEARCH_ENABLED_TOOLS': 'ListIndexTool,UnknownTool'}),
+        ):
+            result = await get_tools(registry)
+
+        assert result['ListIndexTool']['category'] == 'core_tools'
+        assert result['UnknownTool']['category'] == ''
+
+    @pytest.mark.asyncio
+    async def test_multi_mode_stamps_category_on_tools(self):
+        from mcp_server_opensearch.global_state import set_mode
+
+        set_mode('multi')
+
+        registry = {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'http_methods': 'GET',
+            },
+            'SearchIndexTool': {
+                'display_name': 'SearchIndexTool',
+                'description': 'Search',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'http_methods': 'GET, POST',
+            },
+        }
+        result = await get_tools(registry)
+
+        assert result['ListIndexTool']['category'] == 'core_tools'
+        assert result['SearchIndexTool']['category'] == 'core_tools'
+
+    @pytest.mark.asyncio
+    async def test_multi_mode_memory_tool_excluded_no_category_stamped(self):
+        from mcp_server_opensearch.global_state import set_mode
+
+        set_mode('multi')
+
+        registry = {
+            'ListIndexTool': {
+                'display_name': 'ListIndexTool',
+                'description': 'List indices',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'http_methods': 'GET',
+            },
+            'SaveMemoryTool': {
+                'display_name': 'SaveMemoryTool',
+                'description': 'Save memory',
+                'input_schema': {'type': 'object', 'properties': {}},
+                'function': MagicMock(),
+                'args_model': MagicMock(),
+                'http_methods': 'POST',
+                'memory_tool': True,
+            },
+        }
+        result = await get_tools(registry)
+
+        assert 'ListIndexTool' in result
+        assert 'SaveMemoryTool' not in result
 
 
 class TestIsToolCompatible:

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -86,14 +86,14 @@ class TestBuildCategoryMap:
     def test_tools_absent_from_registry_are_excluded(self):
         result = build_category_map({})
         for category, tools in result.items():
-            if category != 'skills':
+            if category != 'analytics':
                 assert tools == [], f'Expected empty list for {category}, got {tools}'
 
     def test_all_builtin_categories_present(self):
         result = build_category_map({})
         for category in BUILTIN_CATEGORY_TOOLS:
             assert category in result
-        assert 'skills' in result
+        assert 'analytics' in result
 
     def test_custom_display_name_is_used(self):
         registry = {'ListIndexTool': {'display_name': 'MyListTool'}}
@@ -445,9 +445,9 @@ class TestGetTools:
     async def test_get_tools_skills_tools_compatible_version(
         self, mock_tool_registry, mock_patches
     ):
-        """Test that skills tools are excluded by default even when version is compatible.
+        """Test that analytics tools are excluded by default even when version is compatible.
 
-        Since they belong to the 'skills' category which is not enabled by default.
+        Since they belong to the 'analytics' category which is not enabled by default.
         """
         mock_get_version, mock_is_compatible = mock_patches
 
@@ -614,7 +614,10 @@ class TestProcessToolFilter:
         assert 'LogPatternAnalysisTool' not in registry
 
     def test_skills_category_can_be_enabled(self):
-        """Skills tools are exposed when the category is explicitly enabled."""
+        """Analytics tools are exposed when the category is explicitly enabled.
+
+        Also verifies 'skills' legacy alias resolves to 'analytics'.
+        """
         registry = {
             'ListIndexTool': {'display_name': 'ListIndexTool', 'http_methods': 'GET'},
             'DataDistributionTool': {
@@ -1015,8 +1018,8 @@ class TestAllowWriteCategories:
         process_tool_filter(
             tool_registry=registry,
             allow_write=False,
-            allow_write_categories=['search_relevance', 'skills'],
-            enabled_categories='core_tools,search_relevance,skills',
+            allow_write_categories=['search_relevance', 'analytics'],
+            enabled_categories='core_tools,search_relevance,analytics',
         )
 
         assert 'ListIndexTool' in registry

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -142,7 +142,9 @@ class TestBuildCategoryMap:
 
     def test_analytics_is_superset_of_observability_and_skills(self):
         """analytics must be exactly the union of observability + skills."""
-        expected = set(BUILTIN_CATEGORY_TOOLS['observability']) | set(BUILTIN_CATEGORY_TOOLS['skills'])
+        expected = set(BUILTIN_CATEGORY_TOOLS['observability']) | set(
+            BUILTIN_CATEGORY_TOOLS['skills']
+        )
         actual = set(BUILTIN_CATEGORY_TOOLS['analytics'])
         assert actual == expected, (
             f'analytics category is not the union of observability + skills. '

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -345,8 +345,27 @@ class TestGetTools:
 
         set_mode('multi')  # Set mode to multi for this test
 
+        # Snapshot original registry to verify it is NOT mutated
+        import copy
+
+        original_snapshot = copy.deepcopy(mock_tool_registry)
+
         result = await get_tools(mock_tool_registry)
-        assert result == mock_tool_registry
+
+        # Same tool names (minus memory tools)
+        expected_names = {
+            name for name, info in mock_tool_registry.items() if not info.get('memory_tool')
+        }
+        assert set(result.keys()) == expected_names
+
+        # Original registry must not be mutated (no 'category' key added)
+        for name, info in mock_tool_registry.items():
+            assert 'category' not in info, f'Original registry mutated for {name}'
+            assert info['input_schema'] == original_snapshot[name]['input_schema'], (
+                f'Original input_schema mutated for {name}'
+            )
+
+        # Returned tools should have category stamped and schema fields intact
         assert 'param1' in result['ListIndexTool']['input_schema']['properties']
         assert 'opensearch_cluster_name' in result['SearchIndexTool']['input_schema']['properties']
 
@@ -361,8 +380,8 @@ class TestGetTools:
         mock_get_version.return_value = Version.parse('2.5.0')
 
         # Mock compatibility: only ListIndexTool should be compatible
-        mock_is_compatible.side_effect = (
-            lambda version, tool_info: tool_info['min_version'] == '1.0.0'
+        mock_is_compatible.side_effect = lambda version, tool_info: (
+            tool_info['min_version'] == '1.0.0'
         )
 
         # Call get_tools in single mode

--- a/tests/tools/test_tool_filters.py
+++ b/tests/tools/test_tool_filters.py
@@ -141,7 +141,7 @@ class TestBuildCategoryMap:
         )
 
     def test_analytics_is_superset_of_observability_and_skills(self):
-        """analytics must be exactly the union of observability + skills."""
+        """Analytics must be exactly the union of observability + skills."""
         expected = set(BUILTIN_CATEGORY_TOOLS['observability']) | set(
             BUILTIN_CATEGORY_TOOLS['skills']
         )


### PR DESCRIPTION
## Summary

Closes #300

- Extract `BUILTIN_CATEGORY_TOOLS` as a module-level constant in `tool_filter.py` — single source of truth for category → tool mappings, replacing ~100 lines of inline list-building scattered inside `process_tool_filter`
- Add `build_category_map()` helper that translates registry keys to display names
- `process_tool_filter` now returns `category_to_tools`; `get_tools` uses it to stamp `tool_info['category']` on every enabled tool in both single and multi mode
- `stdio_server` and `streaming_server` pass `meta={'category': ...}` to the `Tool` constructor so category is serialised as `_meta` on the wire; tools with no known category emit `meta=None`

**Compatibility note:** The MCP 1.x (2024-11-05) JSON schema for `Tool` does not set `additionalProperties: false`, so extra properties are valid by spec for all existing clients including raw HTTP ones.

## Test plan

- [ ] Unit tests: `TestBuildCategoryMap` — mapping correctness, empty registry, custom display names
- [ ] Unit tests: `TestCategoryStamping` — `get_tools` stamps category in single and multi mode; unknown tools get `''`
- [ ] Integration test: `integration_tests/server_modes/test_list_tools.py` — core tools carry `_meta.category = "core_tools"` against a live server; all listed tools have a known category or no `_meta`
- [ ] Manual: start server against local OpenSearch, run `tools/list` via curl and confirm `_meta.category` appears in the response