### PR TITLE
Mark skills category tools as read operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Upgrade `mcp[cli]` to `>=2.0.0`. Ports the server to the mcp 2.0 API: replaces removed `@server.list_tools()` / `@server.call_tool()` decorators with constructor-injected `on_list_tools` / `on_call_tool` handlers, replaces removed `request_ctx` contextvar with a local `request_context_var`, and updates renamed fields (`isError` → `is_error`, `inputSchema` → `input_schema`). Integration test client updated for the renamed `streamable_http_client` function and `httpx2`-based header/timeout configuration ([#292](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/292))
+- Mark skills category tools as read operation([#302](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/302))
 
 ### Fixed
 - Bind per-call connection credentials to the caller that supplied the URL ([#287](https://github.com/opensearch-project/opensearch-mcp-server-py/pull/287))

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -251,6 +251,7 @@ SKILLS_TOOLS_REGISTRY = {
         'args_model': DataDistributionToolArgs,
         'min_version': '1.0.0',
         'http_methods': 'POST',
+        'bypass_write_filter': True,
     },
     'LogPatternAnalysisTool': {
         'display_name': 'LogPatternAnalysisTool',
@@ -267,6 +268,7 @@ SKILLS_TOOLS_REGISTRY = {
         'args_model': LogPatternAnalysisToolArgs,
         'min_version': '2.19.0',
         'http_methods': 'POST',
+        'bypass_write_filter': True,
     },
     'MetricChangeAnalysisTool': {
         'display_name': 'MetricChangeAnalysisTool',
@@ -286,5 +288,6 @@ SKILLS_TOOLS_REGISTRY = {
         'args_model': MetricChangeAnalysisToolArgs,
         'min_version': '1.0.0',
         'http_methods': 'POST',
+        'bypass_write_filter': True,
     },
 }


### PR DESCRIPTION
### Description
Mark skills category tools as read operation. What they are doing is query data and do analysis, no write to cluster.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).