### PR TITLE
Add ApiKey header authentication

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -355,7 +355,7 @@ The guard applies only to URLs supplied by a caller. Your own `OPENSEARCH_URL` a
 
 The server supports multiple authentication methods with the following priority order:
 1. **No Authentication** (only if `OPENSEARCH_NO_AUTH=true` environment variable is set, `opensearch_no_auth: true` is passed per call, or `opensearch_no_auth: true` in multi mode config)
-2. **Bearer Token** from the request `Authorization` header (requires header auth enabled)
+2. **Bearer or ApiKey Token** from the request `Authorization` header (requires header auth enabled)
 3. **Header-Based AWS Credentials** (requires header auth enabled)
 4. **IAM Role Authentication**
 5. **Basic Authentication**
@@ -401,6 +401,10 @@ For Basic authentication:
 For Bearer authentication:
 
 - `Authorization`: HTTP Bearer authentication header (format: `Bearer <token>`)
+
+For OpenSearch API key authentication:
+
+- `Authorization`: HTTP API key authentication header (format: `ApiKey <token>`)
 
 **Note:** When `OPENSEARCH_HEADER_AUTH=true` (single mode) or `opensearch_header_auth: true` (multi mode), headers take priority over environment variables or cluster configuration values. If a header is not provided, the system falls back to the corresponding environment variable (single mode) or cluster configuration value (multi mode).
 

--- a/src/opensearch/client.py
+++ b/src/opensearch/client.py
@@ -468,7 +468,7 @@ def _initialize_client_single_mode(args: baseToolArgs = None) -> AsyncOpenSearch
             if header_username and header_password:
                 opensearch_username = header_username
                 opensearch_password = header_password
-            # Pass through Bearer token if provided in headers
+            # Pass through Bearer or ApiKey token if provided in headers
             bearer_auth_header = header_auth.get('bearer_auth_header')
 
             # A username with no password cannot authenticate. Fail rather than
@@ -664,7 +664,7 @@ def _initialize_client_multi_mode(cluster_info: ClusterInfo) -> AsyncOpenSearch:
             if header_username and header_password:
                 opensearch_username = header_username
                 opensearch_password = header_password
-            # Pass through Bearer token if provided in headers
+            # Pass through Bearer or ApiKey token if provided in headers
             bearer_auth_header = header_auth.get('bearer_auth_header')
 
             # As in single mode, an unusable Basic credential fails loudly.
@@ -749,7 +749,7 @@ def _create_opensearch_client(
         aws_secret_access_key: AWS secret access key from headers (optional)
         aws_session_token: AWS session token from headers (optional)
         max_response_size: Maximum response size in bytes (None means no limit)
-        bearer_auth_header: Authorization Bearer header value (optional)
+        bearer_auth_header: Authorization Bearer or ApiKey header value (optional)
         opensearch_ca_cert_path: Path to the CA certificate bundle for verifying TLS
         opensearch_client_cert_path: Path to the client certificate for mTLS
         opensearch_client_key_path: Path to the client private key for mTLS
@@ -865,9 +865,9 @@ def _create_opensearch_client(
                 _log_connection_event('no_auth', datasource_type, opensearch_url, str(e))
                 raise AuthenticationError(f'Failed to connect without authentication: {e}')
 
-        # 2. Header-based Authorization (Bearer token)
+        # 2. Header-based Authorization (Bearer or ApiKey token)
         if bearer_auth_header:
-            logger.info('[HEADER AUTH] Using Authorization Bearer header')
+            logger.info('[HEADER AUTH] Using token from Authorization header')
             try:
                 client_kwargs['headers'] = {'Authorization': bearer_auth_header}
                 return AsyncOpenSearch(**client_kwargs)
@@ -876,7 +876,7 @@ def _create_opensearch_client(
                     'header_auth_bearer', datasource_type, opensearch_url, str(e)
                 )
                 raise AuthenticationError(
-                    f'Failed to authenticate with Authorization Bearer header: {e}'
+                    f'Failed to authenticate with token from Authorization header: {e}'
                 )
 
         # 3. Header-based AWS credentials authentication (highest priority when provided)
@@ -1159,7 +1159,7 @@ def _get_auth_from_headers() -> Dict[str, Optional[str]]:
         - aws_service_name: AWS service name (es or aoss)
         - opensearch_username: Username from Basic auth (Authorization header)
         - opensearch_password: Password from Basic auth (Authorization header)
-        - bearer_auth_header: Authorization Bearer header value (if provided)
+        - bearer_auth_header: Authorization Bearer or ApiKey header value (if provided)
         All values are None if headers are not available or not set.
     """
     result: Dict[str, Optional[str]] = {
@@ -1195,6 +1195,10 @@ def _get_auth_from_headers() -> Dict[str, Optional[str]]:
                     token = auth_header[7:].strip()
                     if token:
                         result['bearer_auth_header'] = f'Bearer {token}'
+                elif auth_header_lower.startswith('apikey '):
+                    token = auth_header[7:].strip()
+                    if token:
+                        result['bearer_auth_header'] = f'ApiKey {token}'
                 elif auth_header_lower.startswith('basic '):
                     import base64
 

--- a/tests/opensearch/test_client.py
+++ b/tests/opensearch/test_client.py
@@ -818,8 +818,8 @@ class TestHeaderBasedBasicAuth:
         assert call_kwargs['http_auth'] == ('env-user', 'env-password')
 
 
-class TestHeaderBasedBearerAuth:
-    """Tests for Bearer authentication via Authorization header."""
+class TestHeaderBasedTokenAuth:
+    """Tests for token authentication via Authorization header."""
 
     def setup_method(self):
         """Setup before each test method."""
@@ -869,6 +869,30 @@ class TestHeaderBasedBearerAuth:
         assert client == mock_client
         call_kwargs = mock_opensearch.call_args[1]
         assert call_kwargs['headers'] == {'Authorization': f'Bearer {bearer_token}'}
+        assert 'http_auth' not in call_kwargs
+
+    @patch('opensearch.client.request_context_var')
+    @patch('opensearch.client.AsyncOpenSearch')
+    def test_api_key_auth_from_authorization_header(self, mock_opensearch, mock_request_ctx):
+        """Test ApiKey auth passthrough from Authorization header."""
+        from starlette.requests import Request
+
+        os.environ['OPENSEARCH_URL'] = 'https://test-opensearch-domain.com'
+        os.environ['OPENSEARCH_HEADER_AUTH'] = 'true'
+
+        api_key = 'test-api-key'
+        mock_request = Mock(spec=Request)
+        mock_request.headers = {'authorization': f'apikey {api_key}'}
+        mock_request_ctx.get.return_value = mock_request
+
+        mock_client = Mock()
+        mock_opensearch.return_value = mock_client
+
+        client = initialize_client(baseToolArgs(opensearch_cluster_name=''))
+
+        assert client == mock_client
+        call_kwargs = mock_opensearch.call_args[1]
+        assert call_kwargs['headers'] == {'Authorization': f'ApiKey {api_key}'}
         assert 'http_auth' not in call_kwargs
 
     @patch('opensearch.client.request_context_var')


### PR DESCRIPTION
Closes #304.

### Summary

- recognize `Authorization: ApiKey <token>` when header authentication is enabled
- forward the API key using the canonical `ApiKey` scheme
- keep authorization scheme matching case-insensitive
- document ApiKey authentication and add unit coverage

### Testing

- `uv run pytest -q` — 663 passed, 3 skipped
- `uv run ruff format --check src/opensearch/client.py tests/opensearch/test_client.py`
- `uv run ruff check src/opensearch/client.py tests/opensearch/test_client.py`

Signed-off-by: Andrei Lalaev <deathalt@ya.ru>